### PR TITLE
Extend the example and add (hidden) assertions for query, fix world not being populated from token when querying.

### DIFF
--- a/src/token/authorizer.rs
+++ b/src/token/authorizer.rs
@@ -229,8 +229,20 @@ impl<'t> Authorizer<'t> {
 
     /// run a query over the authorizer's Datalog engine to gather data
     ///
-    /// ```rust,compile_fail
+    /// ```rust
+    /// # use biscuit_auth::KeyPair;
+    /// # use biscuit_auth::Biscuit;
+    /// let keypair = KeyPair::new();
+    /// let mut builder = Biscuit::builder(&keypair);
+    /// builder.add_authority_fact("user(\"John Doe\", 42)");
+    ///
+    /// let biscuit = builder.build().unwrap();
+    ///
+    /// let mut authorizer = biscuit.authorizer().unwrap();
     /// let res: Vec<(String, i64)> = authorizer.query("data($name, $id) <- user($name, $id)").unwrap();
+    /// # assert_eq!(res.len(), 1);
+    /// # assert_eq!(res[0].0, "John Doe");
+    /// # assert_eq!(res[0].1, 42);
     /// ```
     pub fn query<R: TryInto<Rule>, T: TryFrom<Fact, Error = E>, E: Into<error::Token>>(
         &mut self,


### PR DESCRIPTION
Expand the example in the docs for querying an authorizer for a biscuit.