### PR TITLE
Fix default symbol table

### DIFF
--- a/src/token/mod.rs
+++ b/src/token/mod.rs
@@ -27,7 +27,7 @@ pub fn default_symbol_table() -> SymbolTable {
     syms.insert("resource");
     syms.insert("operation");
     syms.insert("right");
-    syms.insert("current_time");
+    syms.insert("time");
     syms.insert("revocation_id");
 
     syms


### PR DESCRIPTION
The default symbol table defined in the spec lists `time`, not `current_time`. This is not a big issue for tokens created, attenuated and verified by the same implementation, but it can cause issue for cross implementation use.

The Haskell impl follows the spec, I'm not sure about go and java.