### PR TITLE
split `error::Token::Sealed` in two errors

### DIFF
--- a/src/capi.rs
+++ b/src/capi.rs
@@ -66,7 +66,7 @@ pub enum ErrorKind {
     FormatBlockSerializationError,
     FormatVersion,
     SymbolTableOverlap,
-    Sealed,
+    AppendOnSealed,
     LogicInvalidBlockRule,
     LogicUnauthorized,
     LogicAuthorizerNotEmpty,
@@ -80,6 +80,7 @@ pub enum ErrorKind {
     FormatInvalidSignatureSize,
     FormatInvalidKey,
     FormatSignatureInvalidSignatureGeneration,
+    AlreadySealed,
 }
 
 #[no_mangle]
@@ -122,7 +123,8 @@ pub extern "C" fn error_kind() -> ErrorKind {
                     }
                     Token::Format(Format::InvalidKey(_)) => ErrorKind::FormatInvalidKey,
                     Token::SymbolTableOverlap => ErrorKind::SymbolTableOverlap,
-                    Token::Sealed => ErrorKind::Sealed,
+                    Token::AppendOnSealed => ErrorKind::AppendOnSealed,
+                    Token::AlreadySealed => ErrorKind::AlreadySealed,
                     Token::Language(_) => ErrorKind::LanguageError,
                     Token::FailedLogic(Logic::InvalidBlockRule(_, _)) => {
                         ErrorKind::LogicInvalidBlockRule

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -206,7 +206,10 @@ impl Token {
         next_key: &KeyPair,
         message: &[u8],
     ) -> Result<Self, error::Token> {
-        let keypair = self.next.keypair()?;
+        let keypair = match self.next.keypair() {
+            Err(error::Token::AlreadySealed) => Err(error::Token::AppendOnSealed),
+            other => other,
+        }?;
 
         let signature = sign(&keypair, next_key, message)?;
 
@@ -270,7 +273,7 @@ impl Token {
 impl TokenNext {
     pub fn keypair(&self) -> Result<KeyPair, error::Token> {
         match &self {
-            TokenNext::Seal(_) => Err(error::Token::Sealed),
+            TokenNext::Seal(_) => Err(error::Token::AlreadySealed),
             TokenNext::Secret(private) => Ok(KeyPair::from(private.clone())),
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,7 +15,9 @@ pub enum Token {
     #[error("multiple blocks declare the same symbols")]
     SymbolTableOverlap,
     #[error("tried to append a block to a sealed token")]
-    Sealed,
+    AppendOnSealed,
+    #[error("tried to seal an already sealed token")]
+    AlreadySealed,
     #[error("authorization failed")]
     FailedLogic(Logic),
     #[error("error generating Datalog")]

--- a/src/token/mod.rs
+++ b/src/token/mod.rs
@@ -337,7 +337,7 @@ impl Biscuit {
         block_builder: BlockBuilder,
     ) -> Result<Self, error::Token> {
         if self.container.is_none() {
-            return Err(error::Token::Sealed);
+            return Err(error::Token::AppendOnSealed);
         }
 
         let block = block_builder.build(self.symbols.clone());
@@ -351,7 +351,7 @@ impl Biscuit {
         let mut symbols = self.symbols.clone();
 
         let container = match self.container.as_ref() {
-            None => return Err(error::Token::Sealed),
+            None => return Err(error::Token::AppendOnSealed),
             Some(c) => c.append(keypair, &block)?,
         };
 


### PR DESCRIPTION
This can happen in two cases:

- trying to append a block to a sealed token (consistent with the error description)
- trying to sealed an already sealed token

When in the second case, the current error description is misleading. Moreover, we might
want treat the two errors differently (ie we should always fail when we can't append a
block, but we might want to ignore the error if we're trying to seal an already sealed
token).

The way `error::Token` is structured makes things a bit awkward (`append` has to catch
and adapt the error returned by `TokenNext.keypair()`).