### PR TITLE
remove symbol leftovers

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,9 +158,7 @@ Here are examples of checks that can be implemented with that language:
 
 Like Datalog, this language is based around facts and rules, but with some slight modifications:
 
-- an authority fact starts with the #authority symbol. It can only be added in the authority block (or generated from rules in the authority rules). It provides the basic authorization data, like which rights exist
-- an ambient fact starts with the #ambient symbol. It can only be provided by the verifier. It gives information on the current request, like which resource is accessed or the current time
-- Blocks can provide facts but they cannot be authority or ambient facts. They contain rules that use facts from the current block, or from the authority and ambient contexts. If all rules in a block succeed, the block is validated.
+- Blocks can provide facts but they are not visible from other blocks. They contain rules that use facts from the current block, or from the authority and ambient contexts. If all rules in a block succeed, the block is validated.
 
 A check rule requires the presence of one or more facts, and can have additional expressions on these facts. It is possible to create rules like these ones:
 

--- a/examples/testcases.rs
+++ b/examples/testcases.rs
@@ -331,13 +331,13 @@ fn basic_token<T: Rng + CryptoRng>(
     let mut builder = Biscuit::builder(&root);
 
     builder
-        .add_authority_fact(fact("right", &[string("file1"), s("read")]))
+        .add_authority_fact(fact("right", &[string("file1"), string("read")]))
         .unwrap();
     builder
-        .add_authority_fact(fact("right", &[string("file2"), s("read")]))
+        .add_authority_fact(fact("right", &[string("file2"), string("read")]))
         .unwrap();
     builder
-        .add_authority_fact(fact("right", &[string("file1"), s("write")]))
+        .add_authority_fact(fact("right", &[string("file1"), string("write")]))
         .unwrap();
 
     let biscuit1 = builder.build_with_rng(rng).unwrap();
@@ -350,8 +350,8 @@ fn basic_token<T: Rng + CryptoRng>(
             &[var("0")],
             &[
                 pred("resource", &[var("0")]),
-                pred("operation", &[s("read")]),
-                pred("right", &[var("0"), s("read")]),
+                pred("operation", &[string("read")]),
+                pred("right", &[var("0"), string("read")]),
             ],
         ))
         .unwrap();
@@ -409,7 +409,7 @@ fn different_root_key<T: Rng + CryptoRng>(
     let mut builder = Biscuit::builder(&root2);
 
     builder
-        .add_authority_fact(fact("right", &[string("file1"), s("read")]))
+        .add_authority_fact(fact("right", &[string("file1"), string("read")]))
         .unwrap();
 
     let biscuit1 = builder.build_with_rng(rng).unwrap();
@@ -422,8 +422,8 @@ fn different_root_key<T: Rng + CryptoRng>(
             &[var("0")],
             &[
                 pred("resource", &[var("0")]),
-                pred("operation", &[s("read")]),
-                pred("right", &[var("0"), s("read")]),
+                pred("operation", &[string("read")]),
+                pred("right", &[var("0"), string("read")]),
             ],
         ))
         .unwrap();
@@ -475,13 +475,13 @@ fn invalid_signature_format<T: Rng + CryptoRng>(
     let mut builder = Biscuit::builder(&root);
 
     builder
-        .add_authority_fact(fact("right", &[string("file1"), s("read")]))
+        .add_authority_fact(fact("right", &[string("file1"), string("read")]))
         .unwrap();
     builder
-        .add_authority_fact(fact("right", &[string("file2"), s("read")]))
+        .add_authority_fact(fact("right", &[string("file2"), string("read")]))
         .unwrap();
     builder
-        .add_authority_fact(fact("right", &[string("file1"), s("write")]))
+        .add_authority_fact(fact("right", &[string("file1"), string("write")]))
         .unwrap();
 
     let biscuit1 = builder.build_with_rng(rng).unwrap();
@@ -494,8 +494,8 @@ fn invalid_signature_format<T: Rng + CryptoRng>(
             &[var("0")],
             &[
                 pred("resource", &[var("0")]),
-                pred("operation", &[s("read")]),
-                pred("right", &[var("0"), s("read")]),
+                pred("operation", &[string("read")]),
+                pred("right", &[var("0"), string("read")]),
             ],
         ))
         .unwrap();
@@ -550,13 +550,13 @@ fn random_block<T: Rng + CryptoRng>(
     let mut builder = Biscuit::builder(&root);
 
     builder
-        .add_authority_fact(fact("right", &[string("file1"), s("read")]))
+        .add_authority_fact(fact("right", &[string("file1"), string("read")]))
         .unwrap();
     builder
-        .add_authority_fact(fact("right", &[string("file2"), s("read")]))
+        .add_authority_fact(fact("right", &[string("file2"), string("read")]))
         .unwrap();
     builder
-        .add_authority_fact(fact("right", &[string("file1"), s("write")]))
+        .add_authority_fact(fact("right", &[string("file1"), string("write")]))
         .unwrap();
 
     let biscuit1 = builder.build_with_rng(rng).unwrap();
@@ -569,8 +569,8 @@ fn random_block<T: Rng + CryptoRng>(
             &[var("0")],
             &[
                 pred("resource", &[var("0")]),
-                pred("operation", &[s("read")]),
-                pred("right", &[var("0"), s("read")]),
+                pred("operation", &[string("read")]),
+                pred("right", &[var("0"), string("read")]),
             ],
         ))
         .unwrap();
@@ -628,13 +628,13 @@ fn invalid_signature<T: Rng + CryptoRng>(
     let mut builder = Biscuit::builder(&root);
 
     builder
-        .add_authority_fact(fact("right", &[string("file1"), s("read")]))
+        .add_authority_fact(fact("right", &[string("file1"), string("read")]))
         .unwrap();
     builder
-        .add_authority_fact(fact("right", &[string("file2"), s("read")]))
+        .add_authority_fact(fact("right", &[string("file2"), string("read")]))
         .unwrap();
     builder
-        .add_authority_fact(fact("right", &[string("file1"), s("write")]))
+        .add_authority_fact(fact("right", &[string("file1"), string("write")]))
         .unwrap();
 
     let biscuit1 = builder.build_with_rng(rng).unwrap();
@@ -647,8 +647,8 @@ fn invalid_signature<T: Rng + CryptoRng>(
             &[var("0")],
             &[
                 pred("resource", &[var("0")]),
-                pred("operation", &[s("read")]),
-                pred("right", &[var("0"), s("read")]),
+                pred("operation", &[string("read")]),
+                pred("right", &[var("0"), string("read")]),
             ],
         ))
         .unwrap();
@@ -705,13 +705,13 @@ fn reordered_blocks<T: Rng + CryptoRng>(
     let mut builder = Biscuit::builder(&root);
 
     builder
-        .add_authority_fact(fact("right", &[string("file1"), s("read")]))
+        .add_authority_fact(fact("right", &[string("file1"), string("read")]))
         .unwrap();
     builder
-        .add_authority_fact(fact("right", &[string("file2"), s("read")]))
+        .add_authority_fact(fact("right", &[string("file2"), string("read")]))
         .unwrap();
     builder
-        .add_authority_fact(fact("right", &[string("file1"), s("write")]))
+        .add_authority_fact(fact("right", &[string("file1"), string("write")]))
         .unwrap();
 
     let biscuit1 = builder.build_with_rng(rng).unwrap();
@@ -724,8 +724,8 @@ fn reordered_blocks<T: Rng + CryptoRng>(
             &[var("0")],
             &[
                 pred("resource", &[var("0")]),
-                pred("operation", &[s("read")]),
-                pred("right", &[var("0"), s("read")]),
+                pred("operation", &[string("read")]),
+                pred("right", &[var("0"), string("read")]),
             ],
         ))
         .unwrap();
@@ -808,7 +808,7 @@ fn scoped_rules<T: Rng + CryptoRng>(
     block2
         .add_rule(rule(
             "right",
-            &[var("0"), s("read")],
+            &[var("0"), string("read")],
             &[
                 pred("resource", &[var("0")]),
                 pred("user_id", &[var("1")]),
@@ -822,8 +822,8 @@ fn scoped_rules<T: Rng + CryptoRng>(
             &[var("0")],
             &[
                 pred("resource", &[var("0")]),
-                pred("operation", &[s("read")]),
-                pred("right", &[var("0"), s("read")]),
+                pred("operation", &[string("read")]),
+                pred("right", &[var("0"), string("read")]),
             ],
         ))
         .unwrap();
@@ -861,7 +861,7 @@ fn scoped_rules<T: Rng + CryptoRng>(
             &data[..],
             vec![
                 fact("resource", &[string("file2")]),
-                fact("operation", &[s("read")]),
+                fact("operation", &[string("read")]),
             ],
             vec![],
             vec![],
@@ -889,7 +889,7 @@ fn scoped_checks<T: Rng + CryptoRng>(
     let mut builder = Biscuit::builder(&root);
 
     builder
-        .add_authority_fact(fact("right", &[string("file1"), s("read")]))
+        .add_authority_fact(fact("right", &[string("file1"), string("read")]))
         .unwrap();
 
     let biscuit1 = builder.build_with_rng(rng).unwrap();
@@ -902,8 +902,8 @@ fn scoped_checks<T: Rng + CryptoRng>(
             &[var("0")],
             &[
                 pred("resource", &[var("0")]),
-                pred("operation", &[s("read")]),
-                pred("right", &[var("0"), s("read")]),
+                pred("operation", &[string("read")]),
+                pred("right", &[var("0"), string("read")]),
             ],
         ))
         .unwrap();
@@ -914,7 +914,7 @@ fn scoped_checks<T: Rng + CryptoRng>(
     let mut block3 = biscuit2.create_block();
 
     block3
-        .add_fact(fact("right", &[string("file2"), s("read")]))
+        .add_fact(fact("right", &[string("file2"), string("read")]))
         .unwrap();
 
     let keypair3 = KeyPair::new_with_rng(rng);
@@ -941,7 +941,7 @@ fn scoped_checks<T: Rng + CryptoRng>(
             &data[..],
             vec![
                 fact("resource", &[string("file2")]),
-                fact("operation", &[s("read")]),
+                fact("operation", &[string("read")]),
             ],
             vec![],
             vec![],
@@ -1009,7 +1009,7 @@ fn expired_token<T: Rng + CryptoRng>(
             &data[..],
             vec![
                 fact("resource", &[string("file1")]),
-                fact("operation", &[s("read")]),
+                fact("operation", &[string("read")]),
                 fact(
                     "time",
                     &[date(
@@ -1045,7 +1045,7 @@ fn authorizer_scope<T: Rng + CryptoRng>(
     let mut builder = Biscuit::builder(&root);
 
     builder
-        .add_authority_fact(fact("right", &[string("file1"), s("read")]))
+        .add_authority_fact(fact("right", &[string("file1"), string("read")]))
         .unwrap();
 
     let biscuit1 = builder.build_with_rng(rng).unwrap();
@@ -1053,7 +1053,7 @@ fn authorizer_scope<T: Rng + CryptoRng>(
     let mut block2 = biscuit1.create_block();
 
     block2
-        .add_fact(fact("right", &[string("file2"), s("read")]))
+        .add_fact(fact("right", &[string("file2"), string("read")]))
         .unwrap();
 
     let keypair2 = KeyPair::new_with_rng(rng);
@@ -1080,7 +1080,7 @@ fn authorizer_scope<T: Rng + CryptoRng>(
             &data[..],
             vec![
                 fact("resource", &[string("file2")]),
-                fact("operation", &[s("read")]),
+                fact("operation", &[string("read")]),
             ],
             vec![],
             vec![vec![rule(
@@ -1115,7 +1115,7 @@ fn authorizer_authority_checks<T: Rng + CryptoRng>(
     let mut builder = Biscuit::builder(&root);
 
     builder
-        .add_authority_fact(fact("right", &[string("file1"), s("read")]))
+        .add_authority_fact(fact("right", &[string("file1"), string("read")]))
         .unwrap();
 
     let biscuit1 = builder.build_with_rng(rng).unwrap();
@@ -1140,7 +1140,7 @@ fn authorizer_authority_checks<T: Rng + CryptoRng>(
             &data[..],
             vec![
                 fact("resource", &[string("file2")]),
-                fact("operation", &[s("read")]),
+                fact("operation", &[string("read")]),
             ],
             vec![],
             vec![vec![rule(
@@ -1205,7 +1205,7 @@ fn authority_checks<T: Rng + CryptoRng>(
             &data[..],
             vec![
                 fact("resource", &[string("file1")]),
-                fact("operation", &[s("read")]),
+                fact("operation", &[string("read")]),
             ],
             vec![],
             vec![],
@@ -1219,7 +1219,7 @@ fn authority_checks<T: Rng + CryptoRng>(
             &data[..],
             vec![
                 fact("resource", &[string("file2")]),
-                fact("operation", &[s("read")]),
+                fact("operation", &[string("read")]),
             ],
             vec![],
             vec![],
@@ -1246,10 +1246,10 @@ fn block_rules<T: Rng + CryptoRng>(
 
     let mut builder = Biscuit::builder(&root);
     builder
-        .add_authority_fact(fact("right", &[string("file1"), s("read")]))
+        .add_authority_fact(fact("right", &[string("file1"), string("read")]))
         .unwrap();
     builder
-        .add_authority_fact(fact("right", &[string("file2"), s("read")]))
+        .add_authority_fact(fact("right", &[string("file2"), string("read")]))
         .unwrap();
 
     let biscuit1 = builder.build_with_rng(rng).unwrap();
@@ -1542,8 +1542,8 @@ fn check_head_name<T: Rng + CryptoRng>(
     builder
         .add_authority_check(rule(
             "check1",
-            &[s("test")],
-            &[pred("resource", &[s("hello")])],
+            &[string("test")],
+            &[pred("resource", &[string("hello")])],
         ))
         .unwrap();
 
@@ -1552,7 +1552,7 @@ fn check_head_name<T: Rng + CryptoRng>(
     //println!("biscuit1 (authority): {}", biscuit1.print());
 
     let mut block2 = biscuit1.create_block();
-    block2.add_fact(fact("check1", &[s("test")])).unwrap();
+    block2.add_fact(fact("check1", &[string("test")])).unwrap();
 
     let keypair2 = KeyPair::new_with_rng(rng);
     let biscuit2 = biscuit1.append_with_keypair(&keypair2, block2).unwrap();
@@ -1738,8 +1738,8 @@ fn unbound_variables_in_rule<T: Rng + CryptoRng>(
     builder
         .add_authority_check(rule(
             "check1",
-            &[s("test")],
-            &[pred("operation", &[s("read")])],
+            &[string("test")],
+            &[pred("operation", &[string("read")])],
         ))
         .unwrap();
 
@@ -1750,7 +1750,7 @@ fn unbound_variables_in_rule<T: Rng + CryptoRng>(
     block2
         .add_rule(rule(
             "operation",
-            &[var("unbound"), s("read")],
+            &[var("unbound"), string("read")],
             &[pred("operation", &[var("any1"), var("any2")])],
         ))
         .unwrap();
@@ -1776,7 +1776,7 @@ fn unbound_variables_in_rule<T: Rng + CryptoRng>(
         validate_token(
             root,
             &data[..],
-            vec![fact("operation", &[s("write")])],
+            vec![fact("operation", &[string("write")])],
             vec![],
             vec![],
         ),
@@ -1804,8 +1804,8 @@ fn generating_ambient_from_variables<T: Rng + CryptoRng>(
     builder
         .add_authority_check(rule(
             "check1",
-            &[s("test")],
-            &[pred("operation", &[s("read")])],
+            &[string("test")],
+            &[pred("operation", &[string("read")])],
         ))
         .unwrap();
 
@@ -1816,7 +1816,7 @@ fn generating_ambient_from_variables<T: Rng + CryptoRng>(
     block2
         .add_rule(rule(
             "operation",
-            &[s("read")],
+            &[string("read")],
             &[pred("operation", &[var("any")])],
         ))
         .unwrap();
@@ -1846,7 +1846,7 @@ fn generating_ambient_from_variables<T: Rng + CryptoRng>(
         validate_token(
             root,
             &data[..],
-            vec![fact("operation", &[s("write")])],
+            vec![fact("operation", &[string("write")])],
             vec![],
             vec![],
         ),
@@ -1872,13 +1872,13 @@ fn sealed_token<T: Rng + CryptoRng>(
     let mut builder = Biscuit::builder(&root);
 
     builder
-        .add_authority_fact(fact("right", &[string("file1"), s("read")]))
+        .add_authority_fact(fact("right", &[string("file1"), string("read")]))
         .unwrap();
     builder
-        .add_authority_fact(fact("right", &[string("file2"), s("read")]))
+        .add_authority_fact(fact("right", &[string("file2"), string("read")]))
         .unwrap();
     builder
-        .add_authority_fact(fact("right", &[string("file1"), s("write")]))
+        .add_authority_fact(fact("right", &[string("file1"), string("write")]))
         .unwrap();
 
     let biscuit1 = builder.build_with_rng(rng).unwrap();
@@ -1891,8 +1891,8 @@ fn sealed_token<T: Rng + CryptoRng>(
             &[var("0")],
             &[
                 pred("resource", &[var("0")]),
-                pred("operation", &[s("read")]),
-                pred("right", &[var("0"), s("read")]),
+                pred("operation", &[string("read")]),
+                pred("right", &[var("0"), string("read")]),
             ],
         ))
         .unwrap();

--- a/src/datalog/mod.rs
+++ b/src/datalog/mod.rs
@@ -1186,7 +1186,7 @@ mod tests {
 
         assert!(res.is_empty());
 
-        // operation($unbound, #read) should not have been generated
+        // operation($unbound, "read") should not have been generated
         // in case it is generated though, verify that rule application
         // will not match it
         w.add_fact(fact(operation, &[&unbound, &read]));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,10 +42,10 @@
 //!     let mut builder = Biscuit::builder(&root);
 //!
 //!     // let's define some access rights
-//!     builder.add_authority_fact("right(\"/a/file1.txt\", #read)")?;
-//!     builder.add_authority_fact("right(\"/a/file1.txt\", #write)")?;
-//!     builder.add_authority_fact("right(\"/a/file2.txt\", #read)")?;
-//!     builder.add_authority_fact("right(\"/b/file3.txt\", #write)")?;
+//!     builder.add_authority_fact("right(\"/a/file1.txt\", \"read\")")?;
+//!     builder.add_authority_fact("right(\"/a/file1.txt\", \"write\")")?;
+//!     builder.add_authority_fact("right(\"/a/file2.txt\", \"read\")")?;
+//!     builder.add_authority_fact("right(\"/b/file3.txt\", \"write\")")?;
 //!
 //!     // we can now create the token
 //!     let biscuit = builder.build()?;
@@ -67,7 +67,7 @@
 //!
 //!     // checks are implemented as logic rules. If the rule produces something,
 //!     // the check is successful
-//!     builder.add_check("check if resource(\"/a/file1.txt\"), operation(#read)")?;
+//!     builder.add_check("check if resource(\"/a/file1.txt\"), operation(\"read\")")?;
 //!
 //!     // we can now create a new token
 //!     let biscuit = deser.append(builder)?;
@@ -93,7 +93,7 @@
 //!   v1.add_fact("resource(\"/a/file1.txt\")")?;
 //!   v1.add_fact("operation(\"read\")")?;
 //!   // we will check that the token has the corresponding right
-//!   v1.add_check("check if right(\"/a/file1.txt\", #read)")?;
+//!   v1.add_check("check if right(\"/a/file1.txt\", \"read\")")?;
 //!
 //!   // we choose if we want to allow or deny access
 //!   // we can define a serie of allow/deny policies in the same
@@ -106,7 +106,7 @@
 //!   let mut v2 = biscuit2.authorizer()?;
 //!   v2.add_fact("resource(\"/a/file1.txt\")")?;
 //!   v2.add_fact("operation(\"write\")")?;
-//!   v2.add_check("check if right(\"/a/file1.txt\", #write)")?;
+//!   v2.add_check("check if right(\"/a/file1.txt\", \"write\")")?;
 //!
 //!   // the second authorizer requested a read operation
 //!   assert!(v2.authorize().is_err());
@@ -114,7 +114,7 @@
 //!   let mut v3 = biscuit2.authorizer()?;
 //!   v3.add_fact("resource(\"/a/file2.txt\")")?;
 //!   v3.add_fact("operation(\"read\")")?;
-//!   v3.add_check("check if right(\"/a/file2.txt\", #read)")?;
+//!   v3.add_check("check if right(\"/a/file2.txt\", \"read\")")?;
 //!
 //!   // the third authorizer requests /a/file2.txt
 //!   assert!(v3.authorize().is_err());

--- a/src/token/builder.rs
+++ b/src/token/builder.rs
@@ -150,11 +150,11 @@ impl BlockBuilder {
     pub(crate) fn check_right(&mut self, right: &str) {
         let check = rule(
             "check_right",
-            &[s(right)],
+            &[string(right)],
             &[
                 pred("resource", &[var("resource_name")]),
-                pred("operation", &[s(right)]),
-                pred("right", &[var("resource_name"), s(right)]),
+                pred("operation", &[string(right)]),
+                pred("right", &[var("resource_name"), string(right)]),
             ],
         );
 
@@ -165,7 +165,7 @@ impl BlockBuilder {
     pub fn check_resource(&mut self, resource: &str) {
         let check = rule(
             "resource_check",
-            &[s("resource_check")],
+            &[string("resource_check")],
             &[pred("resource", &[string(resource)])],
         );
 
@@ -176,8 +176,8 @@ impl BlockBuilder {
     pub fn check_operation(&mut self, operation: &str) {
         let check = rule(
             "operation_check",
-            &[s("operation_check")],
-            &[pred("operation", &[s(operation)])],
+            &[string("operation_check")],
+            &[pred("operation", &[string(operation)])],
         );
 
         let _ = self.add_check(check);
@@ -326,7 +326,7 @@ impl<'a> BiscuitBuilder<'a> {
 
     #[cfg(test)]
     pub(crate) fn add_right(&mut self, resource: &str, right: &str) {
-        let _ = self.add_authority_fact(fact("right", &[string(resource), s(right)]));
+        let _ = self.add_authority_fact(fact("right", &[string(resource), string(right)]));
     }
 
     pub fn set_context(&mut self, context: String) {
@@ -1138,11 +1138,6 @@ pub fn int(i: i64) -> Term {
 
 /// creates a string
 pub fn string(s: &str) -> Term {
-    Term::Str(s.to_string())
-}
-
-/// creates a string
-pub fn s(s: &str) -> Term {
     Term::Str(s.to_string())
 }
 

--- a/src/token/mod.rs
+++ b/src/token/mod.rs
@@ -42,7 +42,7 @@ pub fn default_symbol_table() -> SymbolTable {
 ///   // like access rights
 ///   // data from the authority block cannot be created in any other block
 ///   let mut builder = Biscuit::builder(&root);
-///   builder.add_authority_fact(fact("right", &[string("/a/file1.txt"), s("read")]));
+///   builder.add_authority_fact(fact("right", &[string("/a/file1.txt"), string("read")]));
 ///
 ///   // facts and rules can also be parsed from a string
 ///   builder.add_authority_fact("right(\"/a/file1.txt\", \"read\")").expect("parse error");
@@ -483,7 +483,7 @@ impl Block {
 
 #[cfg(test)]
 mod tests {
-    use super::builder::{check, fact, pred, rule, s, var};
+    use super::builder::{check, fact, pred, rule, string, var};
     use super::*;
     use crate::crypto::KeyPair;
     use crate::error::*;
@@ -531,8 +531,8 @@ mod tests {
                 &[var(0)],
                 &[
                     pred("resource", &[var(0)]),
-                    pred("operation", &[s("read")]),
-                    pred("right", &[var(0), s("read")]),
+                    pred("operation", &[string("read")]),
+                    pred("right", &[var(0), string("read")]),
                 ],
             ));
 
@@ -560,8 +560,8 @@ mod tests {
                     &[var("resource")],
                     &[
                         pred("resource", &[var("resource")]),
-                        pred("operation", &[s("read")]),
-                        pred("right", &[var("resource"), s("read")]),
+                        pred("operation", &[string("read")]),
+                        pred("right", &[var("resource"), string("read")]),
                     ],
                 ))
                 .unwrap();
@@ -588,8 +588,8 @@ mod tests {
             block3
                 .add_check(rule(
                     "check2",
-                    &[s("file1")],
-                    &[pred("resource", &[s("file1")])],
+                    &[string("file1")],
+                    &[pred("resource", &[string("file1")])],
                 ))
                 .unwrap();
 
@@ -611,8 +611,8 @@ mod tests {
             let mut authorizer = final_token.authorizer().unwrap();
 
             let mut facts = vec![
-                fact("resource", &[s("file1")]),
-                fact("operation", &[s("read")]),
+                fact("resource", &[string("file1")]),
+                fact("operation", &[string("read")]),
             ];
 
             for fact in facts.drain(..) {
@@ -631,8 +631,8 @@ mod tests {
             let mut authorizer = final_token.authorizer().unwrap();
 
             let mut facts = vec![
-                fact("resource", &[s("file2")]),
-                fact("operation", &[s("write")]),
+                fact("resource", &[string("file2")]),
+                fact("operation", &[string("write")]),
             ];
 
             for fact in facts.drain(..) {
@@ -848,13 +848,13 @@ mod tests {
         let mut builder = Biscuit::builder(&root);
 
         builder
-            .add_authority_fact(fact("right", &[string("file1"), s("read")]))
+            .add_authority_fact(fact("right", &[string("file1"), string("read")]))
             .unwrap();
         builder
-            .add_authority_fact(fact("right", &[string("file2"), s("read")]))
+            .add_authority_fact(fact("right", &[string("file2"), string("read")]))
             .unwrap();
         builder
-            .add_authority_fact(fact("right", &[string("file1"), s("write")]))
+            .add_authority_fact(fact("right", &[string("file1"), string("write")]))
             .unwrap();
 
         let biscuit1 = builder.build_with_rng(&mut rng).unwrap();
@@ -864,8 +864,8 @@ mod tests {
 
         v.add_check(rule(
             "right",
-            &[s("right")],
-            &[pred("right", &[string("file2"), s("write")])],
+            &[string("right")],
+            &[pred("right", &[string("file2"), string("write")])],
         ))
         .unwrap();
 
@@ -964,7 +964,7 @@ mod tests {
         let mut builder = Biscuit::builder(&root);
 
         builder
-            .add_authority_check(check(&[pred("resource", &[s("hello")])]))
+            .add_authority_check(check(&[pred("resource", &[string("hello")])]))
             .unwrap();
 
         let biscuit1 = builder.build_with_rng(&mut rng).unwrap();
@@ -973,7 +973,7 @@ mod tests {
 
         // new check: can only have read access1
         let mut block2 = biscuit1.create_block();
-        block2.add_fact(fact("check1", &[s("test")])).unwrap();
+        block2.add_fact(fact("check1", &[string("test")])).unwrap();
 
         let keypair2 = KeyPair::new_with_rng(&mut rng);
         let biscuit2 = biscuit1.append_with_keypair(&keypair2, block2).unwrap();
@@ -1038,7 +1038,7 @@ mod tests {
         );
 
         let mut block2 = biscuit1.create_block();
-        block2.add_fact(fact("name", &[s("test")])).unwrap();
+        block2.add_fact(fact("name", &[string("test")])).unwrap();
 
         let keypair2 = KeyPair::new_with_rng(&mut rng);
         let biscuit2 = biscuit1

--- a/tests/rights.rs
+++ b/tests/rights.rs
@@ -12,11 +12,17 @@ fn main() {
 
     let mut builder = Biscuit::builder(&root);
 
-    builder.add_authority_fact(fact("right", &[s("authority"), string("file1"), s("read")]));
-    builder.add_authority_fact(fact("right", &[s("authority"), string("file2"), s("read")]));
     builder.add_authority_fact(fact(
         "right",
-        &[s("authority"), string("file1"), s("write")],
+        &[string("authority"), string("file1"), string("read")],
+    ));
+    builder.add_authority_fact(fact(
+        "right",
+        &[string("authority"), string("file2"), string("read")],
+    ));
+    builder.add_authority_fact(fact(
+        "right",
+        &[string("authority"), string("file1"), string("write")],
     ));
 
     let biscuit1 = builder.build_with_rng(&mut rng).unwrap();
@@ -29,10 +35,10 @@ fn main() {
 
     v.add_check(rule(
         "right",
-        &[s("right")],
+        &[string("right")],
         &[pred(
             "right",
-            &[s("authority"), string("file2"), s("write")],
+            &[string("authority"), string("file2"), string("write")],
         )],
     ));
 


### PR DESCRIPTION
Symbol syntax was still accepted by the parser and used in tests.

I've removed support for symbols from the parser and updated all tests and examples.

The only remaining use of a symbol is in the description of test case #19, which is supposed to check restrictions for privileged symbols. Since they are not there anymore, idk what the test actually checks. Maybe it could just be dropped?