### PR TITLE
Fix deprecated `ed25519_dalek::Signature::new` calls.

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -131,6 +131,10 @@ pub enum Format {
     InvalidSignatureSize(usize),
     #[error("invalid key")]
     InvalidKey(String),
+    #[error("could not deserialize signature")]
+    SignatureDeserializationError(String),
+    #[error("could not deserialize the signature's block")]
+    BlockSignatureDeserializationError(String),
 }
 
 /// Signature errors

--- a/src/error.rs
+++ b/src/error.rs
@@ -133,7 +133,7 @@ pub enum Format {
     InvalidKey(String),
     #[error("could not deserialize signature")]
     SignatureDeserializationError(String),
-    #[error("could not deserialize the signature's block")]
+    #[error("could not deserialize the block signature")]
     BlockSignatureDeserializationError(String),
 }
 


### PR DESCRIPTION
In the next release of `ed25519_dalek` signature's[ parsing could fail.](https://github.com/RustCrypto/signatures/pull/401)
I've created  specific format errors but I can revert to `?` syntax instead