### PR TITLE
Add macros for compile-time datalog parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,2 @@
 [workspace]
-members = ["biscuit-auth/"]
+members = ["biscuit-auth/", "biscuit-auth-datalog-macros/"]

--- a/biscuit-auth-datalog-macros/.gitignore
+++ b/biscuit-auth-datalog-macros/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/biscuit-auth-datalog-macros/Cargo.toml
+++ b/biscuit-auth-datalog-macros/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "biscuit-quote"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+biscuit-auth = { path = "../biscuit-auth", features = ["datalog-macro"], version = "2.1.0" }
+quote = "1.0.14"
+syn = { version = "1.0.85", features = ["full", "extra-traits"] }

--- a/biscuit-auth-datalog-macros/shell.nix
+++ b/biscuit-auth-datalog-macros/shell.nix
@@ -1,0 +1,10 @@
+{ pkgs ? import <nixpkgs> {}}: with pkgs;
+
+mkShell {
+  buildInputs = [
+    openssl
+    rustup
+    pkg-config
+    zlib
+  ];
+}

--- a/biscuit-auth-datalog-macros/src/lib.rs
+++ b/biscuit-auth-datalog-macros/src/lib.rs
@@ -1,5 +1,9 @@
 extern crate proc_macro;
-use biscuit_auth::{builder::BlockBuilder, error, parser::parse_block_source};
+use biscuit_auth::{
+    builder::{BlockBuilder, Check, Fact, Policy, Rule},
+    error,
+    parser::{parse_block_source, parse_source},
+};
 use proc_macro::TokenStream;
 use quote::{quote, ToTokens};
 use std::collections::HashMap;
@@ -140,4 +144,126 @@ impl ToTokens for BlockBuilderWithParams {
             builder
         });
     }
+}
+
+#[derive(Clone, Debug)]
+struct AuthorizerWithParams {
+    pub parameters: HashMap<String, Expr>,
+    pub facts: Vec<Fact>,
+    pub rules: Vec<Rule>,
+    pub checks: Vec<Check>,
+    pub policies: Vec<Policy>,
+}
+
+impl AuthorizerWithParams {
+    pub fn from_code<T: AsRef<str>>(
+        source: T,
+        parameters: &HashMap<String, Expr>,
+    ) -> std::result::Result<Self, error::Token> {
+        let input = source.as_ref();
+        let source_result = parse_source(input)?;
+        let mut facts = Vec::new();
+        let mut rules = Vec::new();
+        let mut checks = Vec::new();
+        let mut policies = Vec::new();
+
+        for (_, fact) in source_result.facts.into_iter() {
+            facts.push(fact);
+        }
+        for (_, rule) in source_result.rules.into_iter() {
+            rules.push(rule);
+        }
+        for (_, check) in source_result.checks.into_iter() {
+            checks.push(check);
+        }
+        for (_, policy) in source_result.policies.into_iter() {
+            policies.push(policy);
+        }
+
+        Ok(AuthorizerWithParams {
+            facts,
+            rules,
+            checks,
+            policies,
+            parameters: parameters.clone(),
+        })
+    }
+}
+
+impl ToTokens for AuthorizerWithParams {
+    fn to_tokens(&self, tokens: &mut quote::__private::TokenStream) {
+        let param_names: Vec<String> = self.parameters.clone().into_keys().collect();
+        let param_values: Vec<Expr> = self.parameters.clone().into_values().collect();
+        let facts_quote = self.facts.iter().map(|f| {
+            quote! {
+                let mut fact = #f;
+                #(fact.set_lenient(#param_names, #param_values).unwrap();)*
+                builder.add_fact(fact).unwrap();
+            }
+        });
+        let rules_quote = self.rules.iter().map(|r| {
+            quote! {
+                let mut rule = #r;
+                #(rule.set_lenient(#param_names, #param_values).unwrap();)*
+                builder.add_rule(rule).unwrap();
+            }
+        });
+        let checks_quote = self.checks.iter().map(|c| {
+            quote! {
+                let mut check = #c;
+                #(check.set_lenient(#param_names, #param_values).unwrap();)*
+                builder.add_check(check).unwrap();
+            }
+        });
+        let policies_quote = self.policies.iter().map(|p| {
+            quote! {
+                let mut policy = #p;
+                #(policy.set_lenient(#param_names, #param_values).unwrap();)*
+                builder.add_policy(policy).unwrap();
+            }
+        });
+        tokens.extend(quote! {
+            let mut builder = ::biscuit_auth::Authorizer::new().unwrap();
+            #(#facts_quote)*
+            #(#rules_quote)*
+            #(#checks_quote)*
+            #(#policies_quote)*
+            builder
+        });
+    }
+}
+
+/// create an `Authorizer` from a datalog string and optional parameters.
+/// The datalog string is parsed at compile time and replaced by manual
+/// block building.
+///
+/// ```rust
+/// extern crate biscuit_quote;
+/// use biscuit_quote::{authorizer};
+/// use std::time::SystemTime;
+///
+/// let b = authorizer!(
+///   r#"
+///     time({now});
+///     allow if true;
+///   "#,
+///   now = SystemTime::now(),
+/// );
+/// ```
+#[proc_macro]
+pub fn authorizer(input: TokenStream) -> TokenStream {
+    let ParsedQuery {
+        datalog,
+        parameters,
+    } = syn::parse(input).unwrap();
+
+    let builder = AuthorizerWithParams::from_code(&datalog, &parameters).unwrap();
+
+    let gen = quote! {
+        {
+          #builder
+        }
+    };
+
+    gen.into()
 }

--- a/biscuit-auth-datalog-macros/src/lib.rs
+++ b/biscuit-auth-datalog-macros/src/lib.rs
@@ -1,0 +1,143 @@
+extern crate proc_macro;
+use biscuit_auth::{builder::BlockBuilder, error, parser::parse_block_source};
+use proc_macro::TokenStream;
+use quote::{quote, ToTokens};
+use std::collections::HashMap;
+use syn::{
+    parse::{Parse, ParseStream, Result},
+    Expr, Ident, LitStr, Token,
+};
+
+/// create a `BlockBuilder` from a datalog string and optional parameters.
+/// The datalog string is parsed at compile time and replaced by manual
+/// block building.
+///
+/// ```rust
+/// extern crate biscuit_auth;
+/// extern crate biscuit_quote;
+/// use biscuit_auth::Biscuit;
+/// use biscuit_quote::{block};
+///
+/// let b = block!(
+///   r#"
+///     user({user_id});
+///     check if user($id);
+///   "#,
+///   user_id = "1234"
+/// );
+/// ```
+#[proc_macro]
+pub fn block(input: TokenStream) -> TokenStream {
+    let ParsedQuery {
+        datalog,
+        parameters,
+    } = syn::parse(input).unwrap();
+
+    let builder = BlockBuilderWithParams::from_code(&datalog, &parameters).unwrap();
+
+    let gen = quote! {
+        {
+          #builder
+        }
+    };
+
+    gen.into()
+}
+
+struct ParsedQuery {
+    datalog: String,
+    parameters: HashMap<String, Expr>,
+}
+
+impl Parse for ParsedQuery {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let datalog = input.parse::<LitStr>()?.value();
+
+        let mut parameters = HashMap::new();
+
+        while input.peek(Token![,]) {
+            let _: Token![,] = input.parse()?;
+            if input.is_empty() {
+                break;
+            }
+
+            let key: Ident = input.parse()?;
+            let _: Token![=] = input.parse()?;
+            let value: Expr = input.parse()?;
+
+            parameters.insert(key.to_string(), value);
+        }
+
+        Ok(ParsedQuery {
+            datalog,
+            parameters,
+        })
+    }
+}
+
+#[derive(Clone, Debug)]
+struct BlockBuilderWithParams {
+    pub builder: BlockBuilder,
+    pub parameters: HashMap<String, Expr>,
+}
+
+impl BlockBuilderWithParams {
+    pub fn from_code<T: AsRef<str>>(
+        source: T,
+        parameters: &HashMap<String, Expr>,
+    ) -> std::result::Result<Self, error::Token> {
+        let input = source.as_ref();
+        let mut builder = BlockBuilder::new();
+        let source_result = parse_block_source(input)?;
+
+        for (_, fact) in source_result.facts.into_iter() {
+            builder.facts.push(fact);
+        }
+        for (_, rule) in source_result.rules.into_iter() {
+            builder.rules.push(rule);
+        }
+        for (_, check) in source_result.checks.into_iter() {
+            builder.checks.push(check);
+        }
+
+        Ok(BlockBuilderWithParams {
+            builder,
+            parameters: parameters.clone(),
+        })
+    }
+}
+
+impl ToTokens for BlockBuilderWithParams {
+    fn to_tokens(&self, tokens: &mut quote::__private::TokenStream) {
+        let param_names: Vec<String> = self.parameters.clone().into_keys().collect();
+        let param_values: Vec<Expr> = self.parameters.clone().into_values().collect();
+        let facts_quote = self.builder.facts.iter().map(|f| {
+            quote! {
+                let mut fact = #f;
+                #(fact.set(#param_names, #param_values).unwrap();)*
+                builder.add_fact(fact).unwrap();
+            }
+        });
+        let rules_quote = self.builder.rules.iter().map(|r| {
+            quote! {
+                let mut rule = #r;
+                #(rule.set(#param_names, #param_values).unwrap();)*
+                builder.add_rule(rule).unwrap();
+            }
+        });
+        let checks_quote = self.builder.checks.iter().map(|c| {
+            quote! {
+                let mut check = #c;
+                #(check.set(#param_names, #param_values).unwrap();)*
+                builder.add_check(check).unwrap();
+            }
+        });
+        tokens.extend(quote! {
+            let mut builder = ::biscuit_auth::builder::BlockBuilder::new();
+            #(#facts_quote)*
+            #(#rules_quote)*
+            #(#checks_quote)*
+            builder
+        });
+    }
+}

--- a/biscuit-auth-datalog-macros/src/lib.rs
+++ b/biscuit-auth-datalog-macros/src/lib.rs
@@ -114,21 +114,21 @@ impl ToTokens for BlockBuilderWithParams {
         let facts_quote = self.builder.facts.iter().map(|f| {
             quote! {
                 let mut fact = #f;
-                #(fact.set(#param_names, #param_values).unwrap();)*
+                #(fact.set_lenient(#param_names, #param_values).unwrap();)*
                 builder.add_fact(fact).unwrap();
             }
         });
         let rules_quote = self.builder.rules.iter().map(|r| {
             quote! {
                 let mut rule = #r;
-                #(rule.set(#param_names, #param_values).unwrap();)*
+                #(rule.set_lenient(#param_names, #param_values).unwrap();)*
                 builder.add_rule(rule).unwrap();
             }
         });
         let checks_quote = self.builder.checks.iter().map(|c| {
             quote! {
                 let mut check = #c;
-                #(check.set(#param_names, #param_values).unwrap();)*
+                #(check.set_lenient(#param_names, #param_values).unwrap();)*
                 builder.add_check(check).unwrap();
             }
         });

--- a/biscuit-auth-datalog-macros/src/lib.rs
+++ b/biscuit-auth-datalog-macros/src/lib.rs
@@ -23,7 +23,7 @@
 //!   expiration = SystemTime::now() + Duration::from_secs(86_400),
 //! )).expect("Failed to append block");
 //!
-//! let mut authorizer = authorizer!(
+//! biscuit.authorize(&authorizer!(
 //!   r#"
 //!      time({now});
 //!      operation({operation});
@@ -39,10 +39,7 @@
 //!   operation = "read",
 //!   resource = "file1",
 //!   user_id = "1234",
-//! );
-//! authorizer.add_token(&biscuit)
-//!  .expect("Failed to load token in authorizer");
-//! authorizer.authorize();
+//! )).expect("Failed to authorize biscuit");
 //! ```
 
 extern crate proc_macro;

--- a/biscuit-auth-datalog-macros/tests/simple_test.rs
+++ b/biscuit-auth-datalog-macros/tests/simple_test.rs
@@ -1,44 +1,31 @@
-extern crate biscuit_auth;
 extern crate biscuit_quote;
-use biscuit_auth::{Biscuit, KeyPair};
 use biscuit_quote::block;
 
 #[test]
 fn it_works() {
-    let root = KeyPair::new();
-    let mut biscuit_builder = Biscuit::builder(&root);
-
-    biscuit_builder
-        .add_authority_fact("right(\"/a/file1.txt\", \"read\")")
-        .unwrap();
-    let biscuit = biscuit_builder.build().unwrap();
-
-    let new = biscuit
-        .append(block!(
-            r#"fact("test", hex:aabbcc, [true], {my_key});
+    let b = block!(
+        r#"fact("test", hex:aabbcc, [true], {my_key});
             rule($0, true) <- fact($0, $1, $2, {my_key});
             check if {my_key}.starts_with("my");
             "#,
-            my_key = "my_value",
-            other_key = false,
-        ))
-        .unwrap();
-    println!("biscuit: {}", new.print());
-    panic!("no");
-}
-
-/*
-#[test]
-fn it_works_with_2_parameters() {
-    let toto = block!(r#"fact("test");"#, my_key = "my_value", my_key2 = 42);
-    dbg!(toto);
-    panic!("no");
+        my_key = "my_value",
+        other_key = false,
+    );
+    assert_eq!(
+        b.to_string(),
+        r#"fact("test", hex:aabbcc, [ true], "my_value");
+rule($0, true) <- fact($0, $1, $2, "my_value");
+check if "my_value".starts_with("my");
+"#,
+    );
 }
 
 #[test]
 fn it_works_trailing_comma() {
-    let toto = block!(r#"fact("test");"#, my_key = "my_value",);
-    dbg!(toto);
-    panic!("no");
+    let b = block!(r#"fact("test");"#, my_key = "my_value",);
+    assert_eq!(
+        b.to_string(),
+        r#"fact("test");
+"#,
+    );
 }
-*/

--- a/biscuit-auth-datalog-macros/tests/simple_test.rs
+++ b/biscuit-auth-datalog-macros/tests/simple_test.rs
@@ -1,5 +1,7 @@
+extern crate biscuit_auth;
 extern crate biscuit_quote;
-use biscuit_quote::{authorizer, block};
+use biscuit_auth::KeyPair;
+use biscuit_quote::{authorizer, biscuit, block};
 
 #[test]
 fn block_macro() {
@@ -54,6 +56,38 @@ allow if false;
 #[test]
 fn authorizer_macro_trailing_comma() {
     let b = authorizer!(r#"fact("test");"#, my_key = "my_value",);
+    assert_eq!(
+        b.dump_code(),
+        r#"fact("test");
+"#,
+    );
+}
+
+#[test]
+fn biscuit_macro() {
+    let root = KeyPair::new();
+    let b = biscuit!(
+        &root,
+        r#"fact("test", hex:aabbcc, [ true], {my_key});
+        rule($0, true) <- fact($0, $1, $2, {my_key});
+        check if {my_key}.starts_with("my");
+        "#,
+        my_key = "my_value",
+        other_key = false,
+    );
+    assert_eq!(
+        b.dump_code(),
+        r#"fact("test", hex:aabbcc, [ true], "my_value");
+rule($0, true) <- fact($0, $1, $2, "my_value");
+check if "my_value".starts_with("my");
+"#,
+    );
+}
+
+#[test]
+fn biscuit_macro_trailing_comma() {
+    let root = KeyPair::new();
+    let b = biscuit!(&root, r#"fact("test");"#, my_key = "my_value",);
     assert_eq!(
         b.dump_code(),
         r#"fact("test");

--- a/biscuit-auth-datalog-macros/tests/simple_test.rs
+++ b/biscuit-auth-datalog-macros/tests/simple_test.rs
@@ -33,17 +33,30 @@ fn block_macro_trailing_comma() {
 #[test]
 fn authorizer_macro() {
     let b = authorizer!(
-        r#"
-          deny if true;
-            "#,
+        r#"fact("test", hex:aabbcc, [ true], {my_key});
+        rule($0, true) <- fact($0, $1, $2, {my_key});
+        check if {my_key}.starts_with("my");
+        allow if {other_key};
+        "#,
         my_key = "my_value",
         other_key = false,
     );
-    panic!("todo");
+    assert_eq!(
+        b.dump_code(),
+        r#"fact("test", hex:aabbcc, [ true], "my_value");
+rule($0, true) <- fact($0, $1, $2, "my_value");
+check if "my_value".starts_with("my");
+allow if false;
+"#,
+    );
 }
 
 #[test]
 fn authorizer_macro_trailing_comma() {
     let b = authorizer!(r#"fact("test");"#, my_key = "my_value",);
-    panic!("todo");
+    assert_eq!(
+        b.dump_code(),
+        r#"fact("test");
+"#,
+    );
 }

--- a/biscuit-auth-datalog-macros/tests/simple_test.rs
+++ b/biscuit-auth-datalog-macros/tests/simple_test.rs
@@ -1,8 +1,8 @@
 extern crate biscuit_quote;
-use biscuit_quote::block;
+use biscuit_quote::{authorizer, block};
 
 #[test]
-fn it_works() {
+fn block_macro() {
     let b = block!(
         r#"fact("test", hex:aabbcc, [true], {my_key});
             rule($0, true) <- fact($0, $1, $2, {my_key});
@@ -21,11 +21,29 @@ check if "my_value".starts_with("my");
 }
 
 #[test]
-fn it_works_trailing_comma() {
+fn block_macro_trailing_comma() {
     let b = block!(r#"fact("test");"#, my_key = "my_value",);
     assert_eq!(
         b.to_string(),
         r#"fact("test");
 "#,
     );
+}
+
+#[test]
+fn authorizer_macro() {
+    let b = authorizer!(
+        r#"
+          deny if true;
+            "#,
+        my_key = "my_value",
+        other_key = false,
+    );
+    panic!("todo");
+}
+
+#[test]
+fn authorizer_macro_trailing_comma() {
+    let b = authorizer!(r#"fact("test");"#, my_key = "my_value",);
+    panic!("todo");
 }

--- a/biscuit-auth-datalog-macros/tests/simple_test.rs
+++ b/biscuit-auth-datalog-macros/tests/simple_test.rs
@@ -1,0 +1,43 @@
+extern crate biscuit_auth;
+extern crate biscuit_quote;
+use biscuit_auth::{Biscuit, KeyPair};
+use biscuit_quote::block;
+
+#[test]
+fn it_works() {
+    let root = KeyPair::new();
+    let mut biscuit_builder = Biscuit::builder(&root);
+
+    biscuit_builder
+        .add_authority_fact("right(\"/a/file1.txt\", \"read\")")
+        .unwrap();
+    let biscuit = biscuit_builder.build().unwrap();
+
+    let new = biscuit
+        .append(block!(
+            r#"fact("test", hex:aabbcc, [true], {my_key});
+            rule($0, true) <- fact($0, $1, $2, {my_key});
+            check if {my_key}.starts_with("my");
+            "#,
+            my_key = "my_value"
+        ))
+        .unwrap();
+    println!("biscuit: {}", new.print());
+    panic!("no");
+}
+
+/*
+#[test]
+fn it_works_with_2_parameters() {
+    let toto = block!(r#"fact("test");"#, my_key = "my_value", my_key2 = 42);
+    dbg!(toto);
+    panic!("no");
+}
+
+#[test]
+fn it_works_trailing_comma() {
+    let toto = block!(r#"fact("test");"#, my_key = "my_value",);
+    dbg!(toto);
+    panic!("no");
+}
+*/

--- a/biscuit-auth-datalog-macros/tests/simple_test.rs
+++ b/biscuit-auth-datalog-macros/tests/simple_test.rs
@@ -19,7 +19,8 @@ fn it_works() {
             rule($0, true) <- fact($0, $1, $2, {my_key});
             check if {my_key}.starts_with("my");
             "#,
-            my_key = "my_value"
+            my_key = "my_value",
+            other_key = false,
         ))
         .unwrap();
     println!("biscuit: {}", new.print());

--- a/biscuit-auth/Cargo.toml
+++ b/biscuit-auth/Cargo.toml
@@ -11,13 +11,15 @@ homepage = "https://github.com/biscuit-auth/biscuit"
 repository = "https://github.com/biscuit-auth/biscuit-rust"
 
 [features]
-default = ["regex-full"]
+default = ["regex-full", "datalog-macro"]
 regex-full = [ "regex/perf", "regex/unicode"]
 # used by cargo-c to signal the compilation of C bindings
 capi = ["inline-c"]
 wasm = ["wasm-bindgen", "getrandom/wasm-bindgen"]
 # used by biscuit-wasm to serialize errors to JSON
 serde-error = ["serde"]
+# used by biscuit-auth-quote to parse datalog at compile-time
+datalog-macro = ["quote"]
 
 [dependencies]
 rand_core = "^0.5"
@@ -37,6 +39,7 @@ ed25519-dalek = "1.0.1"
 serde = { version = "1.0.132", optional = true, features = ["derive"] }
 getrandom = { version = "0.1.16" }
 time = {version = "0.3.7", features = ["formatting", "parsing"]}
+quote = { version = "1.0.14", optional = true }
 
 [dev-dependencies]
 rand = "0.7"

--- a/biscuit-auth/src/datalog/expression.rs
+++ b/biscuit-auth/src/datalog/expression.rs
@@ -3,6 +3,9 @@ use super::{SymbolTable, TemporarySymbolTable};
 use regex::Regex;
 use std::collections::HashMap;
 
+#[cfg(feature = "datalog-macro")]
+use quote::{quote, ToTokens};
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct Expression {
     pub ops: Vec<Op>,
@@ -45,6 +48,17 @@ impl Unary {
             Unary::Parens => format!("({})", value),
             Unary::Length => format!("{}.length()", value),
         }
+    }
+}
+
+#[cfg(feature = "datalog-macro")]
+impl ToTokens for Unary {
+    fn to_tokens(&self, tokens: &mut quote::__private::TokenStream) {
+        tokens.extend(match self {
+            Unary::Negate => quote! {::biscuit_auth::datalog::Unary::Negate },
+            Unary::Parens => quote! {::biscuit_auth::datalog::Unary::Parens },
+            Unary::Length => quote! {::biscuit_auth::datalog::Unary::Length },
+        });
     }
 }
 
@@ -206,6 +220,31 @@ impl Binary {
             Binary::Intersection => format!("{}.intersection({})", left, right),
             Binary::Union => format!("{}.union({})", left, right),
         }
+    }
+}
+
+#[cfg(feature = "datalog-macro")]
+impl ToTokens for Binary {
+    fn to_tokens(&self, tokens: &mut quote::__private::TokenStream) {
+        tokens.extend(match self {
+            Binary::LessThan => quote! { ::biscuit_auth::datalog::Binary::LessThan  },
+            Binary::GreaterThan => quote! { ::biscuit_auth::datalog::Binary::GreaterThan  },
+            Binary::LessOrEqual => quote! { ::biscuit_auth::datalog::Binary::LessOrEqual  },
+            Binary::GreaterOrEqual => quote! { ::biscuit_auth::datalog::Binary::GreaterOrEqual  },
+            Binary::Equal => quote! { ::biscuit_auth::datalog::Binary::Equal  },
+            Binary::Contains => quote! { ::biscuit_auth::datalog::Binary::Contains  },
+            Binary::Prefix => quote! { ::biscuit_auth::datalog::Binary::Prefix  },
+            Binary::Suffix => quote! { ::biscuit_auth::datalog::Binary::Suffix  },
+            Binary::Regex => quote! { ::biscuit_auth::datalog::Binary::Regex  },
+            Binary::Add => quote! { ::biscuit_auth::datalog::Binary::Add  },
+            Binary::Sub => quote! { ::biscuit_auth::datalog::Binary::Sub  },
+            Binary::Mul => quote! { ::biscuit_auth::datalog::Binary::Mul  },
+            Binary::Div => quote! { ::biscuit_auth::datalog::Binary::Div  },
+            Binary::And => quote! { ::biscuit_auth::datalog::Binary::And  },
+            Binary::Or => quote! { ::biscuit_auth::datalog::Binary::Or  },
+            Binary::Intersection => quote! { ::biscuit_auth::datalog::Binary::Intersection  },
+            Binary::Union => quote! { ::biscuit_auth::datalog::Binary::Union  },
+        });
     }
 }
 

--- a/biscuit-auth/src/token/authorizer.rs
+++ b/biscuit-auth/src/token/authorizer.rs
@@ -705,6 +705,24 @@ impl<'t> Authorizer<'t> {
             self.policies.clone(),
         )
     }
+
+    pub fn dump_code(&self) -> String {
+        let (facts, rules, checks, policies) = self.dump();
+        let mut f = String::new();
+        for fact in facts {
+            f.push_str(&format!("{};\n", &fact));
+        }
+        for rule in rules {
+            f.push_str(&format!("{};\n", &rule));
+        }
+        for check in checks {
+            f.push_str(&format!("{};\n", &check));
+        }
+        for policy in policies {
+            f.push_str(&format!("{};\n", &policy));
+        }
+        f
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/biscuit-auth/src/token/builder.rs
+++ b/biscuit-auth/src/token/builder.rs
@@ -460,7 +460,7 @@ impl Term {
             Term::Set(s) => datalog::Term::Set(s.iter().map(|i| i.convert(symbols)).collect()),
             // The error is caught in the `add_xxx` functions, so this should
             // not happen™
-            Term::Parameter(_s) => panic!("Remaining parameter"),
+            Term::Parameter(s) => panic!("Remaining parameter {}", &s),
         }
     }
 
@@ -1101,26 +1101,28 @@ impl Rule {
 }
 
 fn display_rule_body(r: &Rule, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    if !r.body.is_empty() {
-        write!(f, "{}", r.body[0])?;
+    let mut rule = r.clone();
+    rule.apply_parameters();
+    if !rule.body.is_empty() {
+        write!(f, "{}", rule.body[0])?;
 
-        if r.body.len() > 1 {
-            for i in 1..r.body.len() {
-                write!(f, ", {}", r.body[i])?;
+        if rule.body.len() > 1 {
+            for i in 1..rule.body.len() {
+                write!(f, ", {}", rule.body[i])?;
             }
         }
     }
 
-    if !r.expressions.is_empty() {
-        if !r.body.is_empty() {
+    if !rule.expressions.is_empty() {
+        if !rule.body.is_empty() {
             write!(f, ", ")?;
         }
 
-        write!(f, "{}", r.expressions[0])?;
+        write!(f, "{}", rule.expressions[0])?;
 
-        if r.expressions.len() > 1 {
-            for i in 1..r.expressions.len() {
-                write!(f, ", {}", r.expressions[i])?;
+        if rule.expressions.len() > 1 {
+            for i in 1..rule.expressions.len() {
+                write!(f, ", {}", rule.expressions[i])?;
             }
         }
     }
@@ -1253,12 +1255,16 @@ impl fmt::Display for Check {
         write!(f, "check if ")?;
 
         if !self.queries.is_empty() {
-            display_rule_body(&self.queries[0], f)?;
+            let mut q0 = self.queries[0].clone();
+            q0.apply_parameters();
+            display_rule_body(&q0, f)?;
 
             if self.queries.len() > 1 {
                 for i in 1..self.queries.len() {
                     write!(f, " or ")?;
-                    display_rule_body(&self.queries[i], f)?;
+                    let mut qn = self.queries[i].clone();
+                    qn.apply_parameters();
+                    display_rule_body(&qn, f)?;
                 }
             }
         }

--- a/biscuit-auth/src/token/builder.rs
+++ b/biscuit-auth/src/token/builder.rs
@@ -718,6 +718,24 @@ impl Fact {
         }
     }
 
+    /// replace a parameter with the term argument, without raising an error
+    /// if the parameter is not present in the fact description
+    pub fn set_lenient<T: Into<Term>>(&mut self, name: &str, term: T) -> Result<(), error::Token> {
+        if let Some(parameters) = self.parameters.as_mut() {
+            match parameters.get_mut(name) {
+                None => Ok(()),
+                Some(v) => {
+                    *v = Some(term.into());
+                    Ok(())
+                }
+            }
+        } else {
+            Err(error::Token::Language(
+                error::LanguageError::UnknownParameter(name.to_string()),
+            ))
+        }
+    }
+
     fn apply_parameters(&mut self) {
         if let Some(parameters) = self.parameters.clone() {
             self.predicate.terms = self
@@ -1015,6 +1033,24 @@ impl Rule {
         }
     }
 
+    /// replace a parameter with the term argument, without raising an error if the
+    /// parameter is not present in the rule
+    pub fn set_lenient<T: Into<Term>>(&mut self, name: &str, term: T) -> Result<(), error::Token> {
+        if let Some(parameters) = self.parameters.as_mut() {
+            match parameters.get_mut(name) {
+                None => Ok(()),
+                Some(v) => {
+                    *v = Some(term.into());
+                    Ok(())
+                }
+            }
+        } else {
+            Err(error::Token::Language(
+                error::LanguageError::UnknownParameter(name.to_string()),
+            ))
+        }
+    }
+
     fn apply_parameters(&mut self) {
         if let Some(parameters) = self.parameters.clone() {
             self.head.terms = self
@@ -1165,6 +1201,16 @@ impl Check {
                 error::LanguageError::UnknownParameter(name.to_string()),
             ))
         }
+    }
+
+    /// replace a parameter with the term argument, without raising an error if the
+    /// parameter is not present in the check
+    pub fn set_lenient<T: Into<Term>>(&mut self, name: &str, term: T) -> Result<(), error::Token> {
+        let term = term.into();
+        for query in &mut self.queries {
+            query.set_lenient(name, term.clone())?;
+        }
+        Ok(())
     }
 
     pub fn validate_parameters(&self) -> Result<(), error::Token> {

--- a/biscuit-auth/src/token/builder.rs
+++ b/biscuit-auth/src/token/builder.rs
@@ -406,6 +406,39 @@ impl<'a> BiscuitBuilder<'a> {
         self.context = Some(context);
     }
 
+    /// returns all of the datalog loaded in the biscuit builder
+    pub fn dump(&self) -> (Vec<Fact>, Vec<Rule>, Vec<Check>) {
+        (
+            self.facts
+                .iter()
+                .map(|f| Fact::convert_from(f, &self.symbols))
+                .collect(),
+            self.rules
+                .iter()
+                .map(|r| Rule::convert_from(r, &self.symbols))
+                .collect(),
+            self.checks
+                .iter()
+                .map(|c| Check::convert_from(c, &self.symbols))
+                .collect(),
+        )
+    }
+
+    pub fn dump_code(&self) -> String {
+        let (facts, rules, checks) = self.dump();
+        let mut f = String::new();
+        for fact in facts {
+            f.push_str(&format!("{};\n", &fact));
+        }
+        for rule in rules {
+            f.push_str(&format!("{};\n", &rule));
+        }
+        for check in checks {
+            f.push_str(&format!("{};\n", &check));
+        }
+        f
+    }
+
     pub fn build(self) -> Result<Biscuit, error::Token> {
         self.build_with_rng(&mut rand::rngs::OsRng)
     }

--- a/biscuit-auth/src/token/mod.rs
+++ b/biscuit-auth/src/token/mod.rs
@@ -140,6 +140,13 @@ impl Biscuit {
         Authorizer::from_token(self)
     }
 
+    /// runs authorization with the provided authorizer
+    pub fn authorize<'t>(&self, authorizer: &Authorizer) -> Result<usize, error::Token> {
+        let mut a = authorizer.clone();
+        a.add_token(self)?;
+        a.authorize()
+    }
+
     /// creates a new block builder
     pub fn create_block(&self) -> BlockBuilder {
         BlockBuilder::new()


### PR DESCRIPTION
The gist is to allow this kind of code:

```rust
 extern crate biscuit_auth;
 extern crate biscuit_quote;
 use biscuit_auth::KeyPair;
 use biscuit_quote::{authorizer, biscuit, block};
 use std::time::{Duration, SystemTime};

 let root = KeyPair::new();

 let biscuit = biscuit!(
   &root,
   r#"
   user({user_id});
   right({user_id}, "file1", "read");
   "#,
   user_id = "1234",
 ).build().expect("Failed to create biscuit");

 biscuit.append(block!(
   r#"
     check if time($time), $time < {expiration};
   "#,
   expiration = SystemTime::now() + Duration::from_secs(86_400),
 )).expect("Failed to append block");

 biscuit.authorize(&authorizer!(
   r#"
      time({now});
      operation({operation});
      resource({resource});

      is_allowed($user_id) <- right($user_id, $resource, $operation),
                              resource($resource),
                              operation($operation);

      allow if is_allowed({user_id});
   "#,
   now = SystemTime::now(),
   operation = "read",
   resource = "file1",
   user_id = "1234",
 )).expect("Failed to authorize biscuit");
```

# Remaining improvements

The happy path is good, but the error handling is rather bad for now. 

- macro errors could be better formatted
- parameter substitution errors should be collected instead of crashing at the first one

I'm not super familiar with reëxports in rust, but if we could have a single crate that exports the macros and `biscuit-rust`, that would be better in terms of ux (a bit like what clap now does, instead of requiring people to depend on two separate crates)