### PR TITLE
Better macro errors

### DIFF
--- a/biscuit-auth-datalog-macros/Cargo.toml
+++ b/biscuit-auth-datalog-macros/Cargo.toml
@@ -10,3 +10,4 @@ proc-macro = true
 biscuit-auth = { path = "../biscuit-auth", features = ["datalog-macro"], version = "2.1.0" }
 quote = "1.0.14"
 syn = { version = "1.0.85", features = ["full", "extra-traits"] }
+proc-macro-error = "1.0"

--- a/biscuit-auth-datalog-macros/src/lib.rs
+++ b/biscuit-auth-datalog-macros/src/lib.rs
@@ -177,7 +177,7 @@ impl BlockBuilderWithParams {
                 parameters: parameters.clone(),
             })
         } else {
-            let unknown_parameters: Vec<String> = macro_parameters
+            let unused_parameters: Vec<String> = macro_parameters
                 .difference(&datalog_parameters)
                 .map(|k| k.to_string())
                 .collect();
@@ -185,18 +185,10 @@ impl BlockBuilderWithParams {
                 .difference(&macro_parameters)
                 .map(|k| k.to_string())
                 .collect();
-
-            if !missing_parameters.is_empty() {
-                Err(error::Token::Language(error::LanguageError::Builder {
-                    invalid_parameters: missing_parameters,
-                }))
-            } else {
-                Err(error::Token::Language(
-                    error::LanguageError::UnknownParameter(
-                        unknown_parameters[0].clone().to_string(),
-                    ),
-                ))
-            }
+            Err(error::Token::Language(error::LanguageError::Parameters {
+                missing_parameters,
+                unused_parameters,
+            }))
         }
     }
 }

--- a/biscuit-auth-datalog-macros/tests/simple_test.rs
+++ b/biscuit-auth-datalog-macros/tests/simple_test.rs
@@ -11,7 +11,6 @@ fn block_macro() {
             check if {my_key}.starts_with("my");
             "#,
         my_key = "my_value",
-        other_key = false,
     );
     assert_eq!(
         b.to_string(),
@@ -24,7 +23,7 @@ check if "my_value".starts_with("my");
 
 #[test]
 fn block_macro_trailing_comma() {
-    let b = block!(r#"fact("test");"#, my_key = "my_value",);
+    let b = block!(r#"fact({my_key});"#, my_key = "test",);
     assert_eq!(
         b.to_string(),
         r#"fact("test");

--- a/biscuit-auth/src/error.rs
+++ b/biscuit-auth/src/error.rs
@@ -20,7 +20,7 @@ pub enum Token {
     AlreadySealed,
     #[error("authorization failed")]
     FailedLogic(Logic),
-    #[error("error generating Datalog")]
+    #[error("error generating Datalog: {0}")]
     Language(LanguageError),
     #[error("Reached Datalog execution limits")]
     RunLimit(RunLimit),
@@ -224,7 +224,7 @@ pub enum RunLimit {
 pub enum LanguageError {
     #[error("datalog parsing error")]
     ParseError(ParseErrors),
-    #[error("datalog parameters must all be bound, provided values must all be used. {missing_parameters:?} {unused_parameters:?}")]
+    #[error("datalog parameters must all be bound, provided values must all be used.\nMissing parameters: {missing_parameters:?}\nUnused parameters: {unused_parameters:?}")]
     Parameters {
         missing_parameters: Vec<String>,
         unused_parameters: Vec<String>,

--- a/biscuit-auth/src/error.rs
+++ b/biscuit-auth/src/error.rs
@@ -224,7 +224,12 @@ pub enum RunLimit {
 pub enum LanguageError {
     #[error("datalog parsing error")]
     ParseError(ParseErrors),
-    #[error("facts must not contain unbound parameters")]
+    #[error("datalog parameters must all be bound, provided values must all be used. {missing_parameters:?} {unused_parameters:?}")]
+    Parameters {
+        missing_parameters: Vec<String>,
+        unused_parameters: Vec<String>,
+    },
+    #[error("datalog fragments must not contain unbound parameters")]
     Builder { invalid_parameters: Vec<String> },
     #[error("cannot set value for an unknown parameter")]
     UnknownParameter(String),


### PR DESCRIPTION
# Before

## invalid datalog

```
error: proc macro panicked
  --> biscuit-auth-datalog-macros/examples/example.rs:40:21
   |
40 |           .authorize(&authorizer!(
   |  _____________________^
41 | |             r#"yolo
42 | |             time({now});
43 | |             operation({operation});
...  |
53 | |             user_id = "1234",
54 | |         ))
   | |_________^
   |
   = help: message: called `Result::unwrap()` on an `Err` value: Language(ParseError(ParseErrors { errors: [ParseError { input: "yolo\n            time({now})", message: None }] }))
```

## missing parameter

```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Language(Builder { invalid_parameters: ["now"] })', biscuit-auth-datalog-macros/examples/example.rs:40:21
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

# After

## invalid datalog

## parameter errors

```
error: error generating Datalog: datalog parameters must all be bound, provided values must all be used.
       Missing parameters: ["my_key"]
       Unused parameters: ["d_my_key"]
  --> biscuit-auth-datalog-macros/tests/simple_test.rs:8:13
   |
8  |       let b = block!(
   |  _____________^
9  | |         r#"fact("test", hex:aabbcc, [true], {my_key});
10 | |             rule($0, true) <- fact($0, $1, $2, {my_key});
11 | |             check if {my_key}.starts_with("my");
12 | |             "#,
13 | |         d_my_key = "my_value",
14 | |     );
   | |_____^
   |
   = note: this error originates in the macro `block`
 (in Nightly builds, run with -Z macro-backtrace for more info)
```