### PR TITLE
3rd-party: add support for scope parameter substitution

### DIFF
--- a/biscuit-auth-datalog-macros/src/lib.rs
+++ b/biscuit-auth-datalog-macros/src/lib.rs
@@ -203,21 +203,21 @@ impl ToTokens for BlockBuilderWithParams {
         let facts_quote = self.builder.facts.iter().map(|f| {
             quote! {
                 let mut fact = #f;
-                #(fact.set_lenient(#param_names, #param_values).unwrap();)*
+                #(fact.set_macro_param(#param_names, #param_values).unwrap();)*
                 builder.add_fact(fact).unwrap();
             }
         });
         let rules_quote = self.builder.rules.iter().map(|r| {
             quote! {
                 let mut rule = #r;
-                #(rule.set_lenient(#param_names, #param_values).unwrap();)*
+                #(rule.set_macro_param(#param_names, #param_values).unwrap();)*
                 builder.add_rule(rule).unwrap();
             }
         });
         let checks_quote = self.builder.checks.iter().map(|c| {
             quote! {
                 let mut check = #c;
-                #(check.set_lenient(#param_names, #param_values).unwrap();)*
+                #(check.set_macro_param(#param_names, #param_values).unwrap();)*
                 builder.add_check(check).unwrap();
             }
         });
@@ -282,28 +282,28 @@ impl ToTokens for AuthorizerWithParams {
         let facts_quote = self.facts.iter().map(|f| {
             quote! {
                 let mut fact = #f;
-                #(fact.set_lenient(#param_names, #param_values).unwrap();)*
+                #(fact.set_macro_param(#param_names, #param_values).unwrap();)*
                 builder.add_fact(fact).unwrap();
             }
         });
         let rules_quote = self.rules.iter().map(|r| {
             quote! {
                 let mut rule = #r;
-                #(rule.set_lenient(#param_names, #param_values).unwrap();)*
+                #(rule.set_macro_param(#param_names, #param_values).unwrap();)*
                 builder.add_rule(rule).unwrap();
             }
         });
         let checks_quote = self.checks.iter().map(|c| {
             quote! {
                 let mut check = #c;
-                #(check.set_lenient(#param_names, #param_values).unwrap();)*
+                #(check.set_macro_param(#param_names, #param_values).unwrap();)*
                 builder.add_check(check).unwrap();
             }
         });
         let policies_quote = self.policies.iter().map(|p| {
             quote! {
                 let mut policy = #p;
-                #(policy.set_lenient(#param_names, #param_values).unwrap();)*
+                #(policy.set_macro_param(#param_names, #param_values).unwrap();)*
                 builder.add_policy(policy).unwrap();
             }
         });
@@ -468,21 +468,21 @@ impl ToTokens for BiscuitWithParams {
         let facts_quote = self.facts.iter().map(|f| {
             quote! {
                 let mut fact = #f;
-                #(fact.set_lenient(#param_names, #param_values).unwrap();)*
+                #(fact.set_macro_param(#param_names, #param_values).unwrap();)*
                 builder.add_fact(fact).unwrap();
             }
         });
         let rules_quote = self.rules.iter().map(|r| {
             quote! {
                 let mut rule = #r;
-                #(rule.set_lenient(#param_names, #param_values).unwrap();)*
+                #(rule.set_macro_param(#param_names, #param_values).unwrap();)*
                 builder.add_rule(rule).unwrap();
             }
         });
         let checks_quote = self.checks.iter().map(|c| {
             quote! {
                 let mut check = #c;
-                #(check.set_lenient(#param_names, #param_values).unwrap();)*
+                #(check.set_macro_param(#param_names, #param_values).unwrap();)*
                 builder.add_check(check).unwrap();
             }
         });

--- a/biscuit-auth/src/parser.rs
+++ b/biscuit-auth/src/parser.rs
@@ -404,6 +404,9 @@ fn scope(i: &str) -> IResult<&str, Scope, Error> {
             //FIXME: handle the unwrap()
             Scope::PublicKey(PublicKey::from_bytes(&bytes).unwrap())
         }),
+        map(delimited(char('{'), name, char('}')), |n| {
+            Scope::Parameter(n.to_string())
+        }),
     ))(i)
 }
 

--- a/biscuit-auth/src/token/mod.rs
+++ b/biscuit-auth/src/token/mod.rs
@@ -370,43 +370,7 @@ impl Biscuit {
     }
 
     pub fn third_party_request(&self) -> Result<Request, error::Token> {
-        if self.container.proof.is_sealed() {
-            return Err(error::Token::AppendOnSealed);
-        }
-
-        let mut public_keys = PublicKeys::new();
-
-        for pk in &schema::Block::decode(&self.container.authority.data[..])
-            .map_err(|e| {
-                error::Format::DeserializationError(format!("deserialization error: {:?}", e))
-            })?
-            .public_keys
-        {
-            public_keys.insert(&PublicKey::from_proto(&pk)?);
-        }
-        for block in &self.container.blocks {
-            for pk in &schema::Block::decode(&block.data[..])
-                .map_err(|e| {
-                    error::Format::DeserializationError(format!("deserialization error: {:?}", e))
-                })?
-                .public_keys
-            {
-                public_keys.insert(&PublicKey::from_proto(&pk)?);
-            }
-        }
-
-        let previous_key = self
-            .container
-            .blocks
-            .last()
-            .unwrap_or(&&self.container.authority)
-            .next_key;
-
-        Ok(Request {
-            previous_key,
-            public_keys,
-            builder: BlockBuilder::new(),
-        })
+        Request::from_container(&self.container)
     }
 
     pub fn append_third_party(


### PR DESCRIPTION
Public keys can now be provided for scopes through parameter
substitution.  The `add_code_with_params` functions now take an
extra parameters hashmap that can hold public keys. Similarly, all
the builder structs carry an extra `scope_parameters` hashmap for
provided parameters.

Macros substitution work a bit differently: term and scope params are
not separated: they can be interleaved, and a dedicated trait projects
them to an enum (term or scope).  This way, the parameter substitution
code knows whether to add them as terms or scope elements.  The initial
plan was to add a blanket Into<Term> => ToAnyParam implementation but
that was not possible because of potential overlapping instances. So
the solution is to complement each Into<Term> impl with a ToAnyParam
impl.

Note that block-level parameter subsitution is not supported yet,
simply because `add_code` functions don't handle it at all either.