### PR TITLE
3rd party improvements for CLI

### DIFF
--- a/biscuit-auth/src/token/mod.rs
+++ b/biscuit-auth/src/token/mod.rs
@@ -177,8 +177,8 @@ impl Biscuit {
 
     /// returns a list of revocation identifiers for each block, in order
     ///
-    /// if a token is generated with the same keys and the same content,
-    /// those identifiers will stay the same
+    /// revocation identifiers are unique: tokens generated separately with
+    /// the same contents will have different revocation ids
     pub fn revocation_identifiers(&self) -> Vec<Vec<u8>> {
         let mut res = Vec::new();
 

--- a/biscuit-auth/src/token/mod.rs
+++ b/biscuit-auth/src/token/mod.rs
@@ -191,6 +191,26 @@ impl Biscuit {
         res
     }
 
+    /// returns a list of external key for each block, in order
+    ///
+    /// Blocks carrying an external public key are _third-party blocks_
+    /// and their contents can be trusted as coming from the holder of
+    /// the corresponding private key
+    pub fn external_public_keys(&self) -> Vec<Option<Vec<u8>>> {
+        let mut res = vec![None];
+
+        for block in self.container.blocks.iter() {
+            res.push(
+                block
+                    .external_signature
+                    .as_ref()
+                    .map(|sig| sig.public_key.to_bytes().to_vec()),
+            );
+        }
+
+        res
+    }
+
     /// pretty printer for this token
     pub fn print(&self) -> String {
         let authority = self

--- a/biscuit-auth/src/token/third_party.rs
+++ b/biscuit-auth/src/token/third_party.rs
@@ -82,6 +82,11 @@ impl Request {
             )))
         })
     }
+
+    pub fn serialize_base64(&self) -> Result<Vec<u8>, error::Token> {
+        Ok(base64::encode_config(self.serialize()?, base64::URL_SAFE).into_bytes())
+    }
+
     pub fn deserialize(slice: &[u8]) -> Result<Self, error::Token> {
         let data = schema::ThirdPartyBlockRequest::decode(slice).map_err(|e| {
             error::Format::DeserializationError(format!("deserialization error: {:?}", e))
@@ -100,6 +105,14 @@ impl Request {
             public_keys,
             builder: BlockBuilder::new(),
         })
+    }
+
+    pub fn deserialize_base64<T>(slice: T) -> Result<Self, error::Token>
+    where
+        T: AsRef<[u8]>,
+    {
+        let decoded = base64::decode_config(slice, base64::URL_SAFE)?;
+        Self::deserialize(&decoded)
     }
 
     pub fn create_response(self, private_key: PrivateKey) -> Result<Vec<u8>, error::Token> {
@@ -142,6 +155,13 @@ impl Request {
                 e
             )))
         })
+    }
+
+    pub fn create_response_base64(self, private_key: PrivateKey) -> Result<Vec<u8>, error::Token> {
+        Ok(
+            base64::encode_config(self.create_response(private_key)?, base64::URL_SAFE)
+                .into_bytes(),
+        )
     }
 }
 

--- a/biscuit-auth/src/token/unverified.rs
+++ b/biscuit-auth/src/token/unverified.rs
@@ -191,6 +191,26 @@ impl UnverifiedBiscuit {
         res
     }
 
+    /// returns a list of external key for each block, in order
+    ///
+    /// Blocks carrying an external public key are _third-party blocks_
+    /// and their contents can be trusted as coming from the holder of
+    /// the corresponding private key
+    pub fn external_public_keys(&self) -> Vec<Option<Vec<u8>>> {
+        let mut res = vec![None];
+
+        for block in self.container.blocks.iter() {
+            res.push(
+                block
+                    .external_signature
+                    .as_ref()
+                    .map(|sig| sig.public_key.to_bytes().to_vec()),
+            );
+        }
+
+        res
+    }
+
     /// returns the number of blocks (at least 1)
     pub fn block_count(&self) -> usize {
         1 + self.container.blocks.len()

--- a/biscuit-auth/src/token/unverified.rs
+++ b/biscuit-auth/src/token/unverified.rs
@@ -179,8 +179,8 @@ impl UnverifiedBiscuit {
 
     /// returns a list of revocation identifiers for each block, in order
     ///
-    /// if a token is generated with the same keys and the same content,
-    /// those identifiers will stay the same
+    /// revocation identifiers are unique: tokens generated separately with
+    /// the same contents will have different revocation ids
     pub fn revocation_identifiers(&self) -> Vec<Vec<u8>> {
         let mut res = vec![self.container.authority.signature.to_bytes().to_vec()];
 


### PR DESCRIPTION
- helpers for base64-encoded requests & third-party blocks
- don't require a public key on `UnverifiedBiscuit.append_third_party`
- expose external keys

