### PR TITLE
set block version to 4 for recent features

### DIFF
--- a/biscuit-auth/src/token/mod.rs
+++ b/biscuit-auth/src/token/mod.rs
@@ -30,7 +30,7 @@ pub use third_party::*;
 /// minimum supported version of the serialization format
 pub const MIN_SCHEMA_VERSION: u32 = 3;
 /// maximum supported version of the serialization format
-pub const MAX_SCHEMA_VERSION: u32 = 3;
+pub const MAX_SCHEMA_VERSION: u32 = 4;
 
 /// some symbols are predefined and available in every implementation, to avoid
 /// transmitting them with every token

--- a/biscuit-auth/src/token/third_party.rs
+++ b/biscuit-auth/src/token/third_party.rs
@@ -118,7 +118,8 @@ impl Request {
     pub fn create_response(self, private_key: PrivateKey) -> Result<Vec<u8>, error::Token> {
         let mut symbols = SymbolTable::new();
         symbols.public_keys = self.public_keys.clone();
-        let block = self.builder.build(symbols);
+        let mut block = self.builder.build(symbols);
+        block.version = super::MAX_SCHEMA_VERSION;
 
         let mut v = Vec::new();
         token_block_to_proto_block(&block)


### PR DESCRIPTION
blocks that use scopes and 3d party blocks should have their version set to 4, but we can keep version 3 if it does not use those features