### PR TITLE
3rd-party: properly display third-party blocks

### DIFF
--- a/biscuit-auth/src/token/mod.rs
+++ b/biscuit-auth/src/token/mod.rs
@@ -234,8 +234,14 @@ impl Biscuit {
 
     /// prints the content of a block as Datalog source code
     pub fn print_block_source(&self, index: usize) -> Result<String, error::Token> {
-        self.block(index)
-            .map(|block| block.print_source(&self.symbols))
+        self.block(index).map(|block| {
+            let symbols = if block.external_key.is_some() {
+                &block.symbols
+            } else {
+                &self.symbols
+            };
+            block.print_source(symbols)
+        })
     }
 
     /// creates a new token, using a provided CSPRNG

--- a/biscuit-auth/src/token/unverified.rs
+++ b/biscuit-auth/src/token/unverified.rs
@@ -213,8 +213,13 @@ impl UnverifiedBiscuit {
     /// prints the content of a block as Datalog source code
     pub fn print_block_source(&self, index: usize) -> Result<String, error::Token> {
         let block = self.authorizer_block(index)?;
+        let symbols = if block.external_key.is_some() {
+            &block.symbols
+        } else {
+            &self.symbols
+        };
 
-        Ok(block.print_source(&self.symbols))
+        Ok(block.print_source(symbols))
     }
 
     /// creates a sealed version of the token


### PR DESCRIPTION
Third-party blocks use their own symbol table,
not the one from the token.