### PR TITLE
builder exts: make the ttl check more compact

### DIFF
--- a/biscuit-auth/src/token/authorizer.rs
+++ b/biscuit-auth/src/token/authorizer.rs
@@ -1039,11 +1039,11 @@ impl BuilderExt for Authorizer<'_> {
     fn check_expiration_date(&mut self, exp: SystemTime) {
         let check = constrained_rule(
             "expiration",
-            &[var("date")],
-            &[pred("time", &[var("date")])],
+            &[var("time")],
+            &[pred("time", &[var("time")])],
             &[Expression {
                 ops: vec![
-                    Op::Value(var("date")),
+                    Op::Value(var("time")),
                     Op::Value(date(&exp)),
                     Op::Binary(Binary::LessOrEqual),
                 ],

--- a/biscuit-auth/src/token/builder.rs
+++ b/biscuit-auth/src/token/builder.rs
@@ -2195,11 +2195,11 @@ impl BuilderExt for BlockBuilder {
     fn check_expiration_date(&mut self, exp: SystemTime) {
         let check = constrained_rule(
             "expiration",
-            &[var("date")],
-            &[pred("time", &[var("date")])],
+            &[var("time")],
+            &[pred("time", &[var("time")])],
             &[Expression {
                 ops: vec![
-                    Op::Value(var("date")),
+                    Op::Value(var("time")),
                     Op::Value(date(&exp)),
                     Op::Binary(Binary::LessOrEqual),
                 ],


### PR DESCRIPTION
reusing the `time` name avoids allocating a new string in the symbol table,
since it's already part of the default symbol table