### PR TITLE
use a BlockBuilder in Authorizer

### DIFF
--- a/biscuit-auth/src/datalog/mod.rs
+++ b/biscuit-auth/src/datalog/mod.rs
@@ -155,7 +155,7 @@ impl Rule {
         &self,
         facts: &FactSet,
         origin: usize,
-        scope: &Origin,
+        scope: &TrustedOrigins,
         symbols: &SymbolTable,
     ) -> bool {
         let fact_it = facts.iterator(scope);
@@ -560,7 +560,7 @@ impl World {
         self.facts.insert(origin, fact);
     }
 
-    pub fn add_rule(&mut self, origin: usize, scope: &Origin, rule: Rule) {
+    pub fn add_rule(&mut self, origin: usize, scope: &TrustedOrigins, rule: Rule) {
         self.rules.insert(origin, scope, rule);
     }
 
@@ -640,7 +640,7 @@ impl World {
         &self,
         rule: Rule,
         origin: usize,
-        scope: &Origin,
+        scope: &TrustedOrigins,
         symbols: &SymbolTable,
     ) -> FactSet {
         let mut new_facts = FactSet::default();
@@ -654,7 +654,7 @@ impl World {
         &self,
         rule: Rule,
         origin: usize,
-        scope: &Origin,
+        scope: &TrustedOrigins,
         symbols: &SymbolTable,
     ) -> bool {
         rule.find_match(&self.facts, origin, scope, symbols)
@@ -702,12 +702,12 @@ impl FactSet {
 
     pub fn iterator<'a>(
         &'a self,
-        block_ids: &'a Origin,
+        block_ids: &'a TrustedOrigins,
     ) -> impl Iterator<Item = (&Origin, &Fact)> + Clone {
         self.inner
             .iter()
             .filter_map(move |(ids, facts)| {
-                if block_ids.is_superset(ids) {
+                if block_ids.contains(ids) {
                     Some(facts.iter().map(move |fact| (ids, fact)))
                 } else {
                     None
@@ -757,11 +757,11 @@ impl IntoIterator for FactSet {
 
 #[derive(Clone, Debug, Default)]
 pub struct RuleSet {
-    pub inner: HashMap<Origin, Vec<(usize, Rule)>>,
+    pub inner: HashMap<TrustedOrigins, Vec<(usize, Rule)>>,
 }
 
 impl RuleSet {
-    pub fn insert(&mut self, origin: usize, scope: &Origin, rule: Rule) {
+    pub fn insert(&mut self, origin: usize, scope: &TrustedOrigins, rule: Rule) {
         match self.inner.get_mut(scope) {
             None => {
                 self.inner.insert(scope.clone(), vec![(origin, rule)]);
@@ -772,7 +772,7 @@ impl RuleSet {
         }
     }
 
-    pub fn iter_all<'a>(&'a self) -> impl Iterator<Item = (&Origin, &Rule)> + Clone {
+    pub fn iter_all<'a>(&'a self) -> impl Iterator<Item = (&TrustedOrigins, &Rule)> + Clone {
         self.inner
             .iter()
             .map(move |(ids, rules)| rules.iter().map(move |(_, rule)| (ids, rule)))

--- a/biscuit-auth/src/datalog/mod.rs
+++ b/biscuit-auth/src/datalog/mod.rs
@@ -239,44 +239,6 @@ impl Rule {
                     ))
         }
     }
-
-    pub(crate) fn origins(
-        &self,
-        current_block: usize,
-        public_key_to_block_id: Option<&HashMap<usize, Vec<usize>>>,
-    ) -> Origin {
-        let mut origins = Origin::default();
-        // the authorizer is always trusted
-        origins.insert(usize::MAX);
-        // the current block is always trusted
-        origins.insert(current_block);
-
-        // if there is no scope, the block scopes are used instead,
-        // so there is no need to default to trusting the authority here
-
-        for scope in &self.scopes {
-            match scope {
-                Scope::Authority => {
-                    // todo this won't be redundant once authority is separated
-                    // from authorizer
-                    origins.insert(0);
-                }
-                Scope::Previous => {
-                    if current_block != usize::MAX {
-                        origins.extend(0..current_block + 1)
-                    }
-                }
-                Scope::PublicKey(key_id) => {
-                    if let Some(map) = public_key_to_block_id {
-                        if let Some(block_ids) = map.get(&(*key_id as usize)) {
-                            origins.extend(block_ids.iter())
-                        }
-                    }
-                }
-            }
-        }
-        origins
-    }
 }
 
 /// recursive iterator for rule application

--- a/biscuit-auth/src/datalog/origin.rs
+++ b/biscuit-auth/src/datalog/origin.rs
@@ -1,6 +1,9 @@
 use std::collections::BTreeSet;
+use std::collections::HashMap;
 use std::hash::Hash;
 use std::iter::FromIterator;
+
+use crate::token::Scope;
 
 #[derive(Clone, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Origin {
@@ -48,5 +51,68 @@ impl FromIterator<usize> for Origin {
         Self {
             inner: iter.into_iter().collect(),
         }
+    }
+}
+
+/// This represents the sets of origins trusted by a rule
+#[derive(Clone, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct TrustedOrigins(Origin);
+
+impl TrustedOrigins {
+    pub fn default() -> TrustedOrigins {
+        let mut origins = Origin::default();
+        origins.insert(usize::MAX);
+        origins.insert(0);
+        TrustedOrigins(origins)
+    }
+    pub fn from_scopes(
+        rule_scopes: &[Scope],
+        default_origins: &TrustedOrigins,
+        current_block: usize,
+        public_key_to_block_id: &HashMap<usize, Vec<usize>>,
+    ) -> TrustedOrigins {
+        if rule_scopes.is_empty() {
+            return default_origins.clone();
+        }
+
+        let mut origins = Origin::default();
+        origins.insert(usize::MAX);
+        origins.insert(current_block);
+
+        for scope in rule_scopes {
+            match scope {
+                Scope::Authority => {
+                    origins.insert(0);
+                }
+                Scope::Previous => {
+                    if current_block != usize::MAX {
+                        origins.extend(0..current_block + 1)
+                    }
+                }
+                Scope::PublicKey(key_id) => {
+                    if let Some(block_ids) = public_key_to_block_id.get(&(*key_id as usize)) {
+                        origins.extend(block_ids.iter())
+                    }
+                }
+            }
+        }
+
+        TrustedOrigins(origins)
+    }
+
+    pub fn contains(&self, fact_origin: &Origin) -> bool {
+        self.0.is_superset(&fact_origin)
+    }
+}
+
+impl FromIterator<usize> for TrustedOrigins {
+    fn from_iter<T: IntoIterator<Item = usize>>(iter: T) -> Self {
+        Self(iter.into_iter().collect())
+    }
+}
+
+impl<'a> FromIterator<&'a usize> for TrustedOrigins {
+    fn from_iter<T: IntoIterator<Item = &'a usize>>(iter: T) -> Self {
+        Self(iter.into_iter().cloned().collect())
     }
 }

--- a/biscuit-auth/src/token/authorizer.rs
+++ b/biscuit-auth/src/token/authorizer.rs
@@ -1,15 +1,17 @@
 //! Authorizer structure and associated functions
 use super::builder::{
-    constrained_rule, date, fact, pred, rule, string, var, Binary, Check, Expression, Fact, Op,
-    Policy, PolicyKind, Rule, Term,
+    constrained_rule, date, fact, pred, rule, string, var, Binary, BlockBuilder, Check, Expression,
+    Fact, Op, Policy, PolicyKind, Rule, Scope, Term,
 };
 use super::builder_ext::{AuthorizerExt, BuilderExt};
 use super::{Biscuit, Block};
 use crate::builder::Convert;
 use crate::crypto::PublicKey;
-use crate::datalog::{self, FactSet, Origin, RuleSet, RunLimits};
+use crate::datalog::{self, Origin, RunLimits};
 use crate::error;
 use crate::time::Instant;
+use crate::token;
+use crate::token::scope_to_origins;
 use biscuit_parser::parser::parse_source;
 use prost::Message;
 use std::collections::{BTreeMap, HashSet};
@@ -25,9 +27,9 @@ use std::{
 /// can be created from [Biscuit::authorizer] or [Authorizer::new]
 #[derive(Clone)]
 pub struct Authorizer<'t> {
+    authorizer_block_builder: BlockBuilder,
     world: datalog::World,
     pub(crate) symbols: datalog::SymbolTable,
-    checks: Vec<Check>,
     token_checks: Vec<Vec<datalog::Check>>,
     policies: Vec<Policy>,
     token: Option<&'t Biscuit>,
@@ -55,11 +57,12 @@ impl<'t> Authorizer<'t> {
     pub fn new() -> Result<Self, error::Logic> {
         let world = datalog::World::new();
         let symbols = super::default_symbol_table();
+        let authorizer_block_builder = BlockBuilder::new();
 
         Ok(Authorizer {
+            authorizer_block_builder,
             world,
             symbols,
-            checks: vec![],
             token_checks: vec![],
             policies: vec![],
             token: None,
@@ -77,49 +80,37 @@ impl<'t> Authorizer<'t> {
         let AuthorizerPolicies {
             version: _,
             symbols,
-            mut facts,
-            mut rules,
-            mut checks,
+            facts,
+            rules,
+            checks,
             policies,
         } = crate::format::convert::proto_authorizer_to_authorizer(&data)?;
 
-        let mut origin = Origin::default();
-        origin.insert(usize::MAX);
-        let mut f = FactSet::default();
-        let mut r = RuleSet::default();
+        let mut authorizer = Self::new()?;
 
-        for fact in facts.drain(..) {
-            f.insert(&origin, fact);
+        for fact in facts {
+            authorizer
+                .authorizer_block_builder
+                .add_fact(Fact::convert_from(&fact, &symbols)?)?;
         }
 
-        let mut default_scope = Origin::default();
-        default_scope.insert(0);
-        default_scope.insert(usize::MAX);
-        for rule in rules.drain(..) {
-            let rule_scope = if rule.scopes.is_empty() {
-                default_scope.clone()
-            } else {
-                rule.origins(usize::MAX, None)
-            };
-            r.insert(usize::MAX, &rule_scope, rule);
+        for rule in rules {
+            authorizer
+                .authorizer_block_builder
+                .add_rule(Rule::convert_from(&rule, &symbols)?)?;
         }
 
-        let world = datalog::World { facts: f, rules: r };
-        let checks = checks
-            .drain(..)
-            .map(|c| Check::convert_from(&c, &symbols))
-            .collect::<Result<Vec<_>, error::Format>>()?;
+        for check in checks {
+            authorizer
+                .authorizer_block_builder
+                .add_check(Check::convert_from(&check, &symbols)?)?;
+        }
 
-        Ok(Authorizer {
-            world,
-            symbols,
-            checks,
-            token_checks: vec![],
-            policies,
-            token: None,
-            blocks: vec![],
-            public_key_to_block_id: HashMap::new(),
-        })
+        for policy in policies {
+            authorizer.policies.push(policy);
+        }
+
+        Ok(authorizer)
     }
 
     /// add a token to an empty authorizer
@@ -143,7 +134,6 @@ impl<'t> Authorizer<'t> {
         let mut blocks = Vec::new();
 
         let authority = token.block(0)?;
-        let block_scope = authority.origins(0, Some(&self.public_key_to_block_id));
 
         let mut authority_origin = Origin::default();
         authority_origin.insert(0);
@@ -161,12 +151,13 @@ impl<'t> Authorizer<'t> {
             }
 
             let rule = rule.translate(&token.symbols, &mut self.symbols)?;
-            if rule.scopes.is_empty() {
-                self.world.rules.insert(0, &block_scope, rule);
-            } else {
-                let rule_scope = rule.origins(0, Some(&self.public_key_to_block_id));
-                self.world.rules.insert(0, &rule_scope, rule);
-            }
+            let scope = scope_to_origins(
+                &rule.scopes,
+                &authority.scopes,
+                0,
+                Some(&self.public_key_to_block_id),
+            );
+            self.world.rules.insert(0, &scope, rule);
         }
 
         blocks.push(authority);
@@ -180,10 +171,9 @@ impl<'t> Authorizer<'t> {
                 &block.symbols
             };
 
-            let block_scope = block.origins(i, Some(&self.public_key_to_block_id));
-
             let mut block_origin = Origin::default();
             block_origin.insert(i);
+
             for fact in block.facts.iter().cloned() {
                 let fact = Fact::convert_from(&fact, &block_symbols)?.convert(&mut self.symbols);
                 self.world.facts.insert(&block_origin, fact);
@@ -197,13 +187,14 @@ impl<'t> Authorizer<'t> {
                 }
                 let rule = rule.translate(&block_symbols, &mut self.symbols)?;
 
-                if rule.scopes.is_empty() {
-                    self.world.rules.insert(i, &block_scope, rule);
-                } else {
-                    let rule_scope = rule.origins(i, Some(&self.public_key_to_block_id));
+                let scope = scope_to_origins(
+                    &rule.scopes,
+                    &block.scopes,
+                    i,
+                    Some(&self.public_key_to_block_id),
+                );
 
-                    self.world.rules.insert(i, &rule_scope, rule);
-                }
+                self.world.rules.insert(i, &scope, rule);
             }
 
             blocks.push(block);
@@ -222,6 +213,7 @@ impl<'t> Authorizer<'t> {
     pub fn save(&self) -> Result<Vec<u8>, error::Token> {
         let mut symbols = self.symbols.clone();
         let mut checks: Vec<datalog::Check> = self
+            .authorizer_block_builder
             .checks
             .iter()
             .map(|c| c.convert(&mut symbols))
@@ -254,42 +246,29 @@ impl<'t> Authorizer<'t> {
             */
     }
 
-    /// add a fact to the authorizer
+    pub fn append(&mut self, other: BlockBuilder) {
+        self.authorizer_block_builder.append(other)
+    }
+
     pub fn add_fact<F: TryInto<Fact>>(&mut self, fact: F) -> Result<(), error::Token>
     where
         error::Token: From<<F as TryInto<Fact>>::Error>,
     {
-        let fact = fact.try_into()?;
-        fact.validate()?;
-
-        let mut origin = Origin::default();
-        origin.insert(usize::MAX);
-
-        self.world
-            .facts
-            .insert(&origin, fact.convert(&mut self.symbols));
-        Ok(())
+        self.authorizer_block_builder.add_fact(fact)
     }
 
-    /// add a rule to the authorizer
-    pub fn add_rule<R: TryInto<Rule>>(&mut self, rule: R) -> Result<(), error::Token>
+    pub fn add_rule<Ru: TryInto<Rule>>(&mut self, rule: Ru) -> Result<(), error::Token>
     where
-        error::Token: From<<R as TryInto<Rule>>::Error>,
+        error::Token: From<<Ru as TryInto<Rule>>::Error>,
     {
-        let rule = rule.try_into()?;
-        rule.validate_parameters()?;
+        self.authorizer_block_builder.add_rule(rule)
+    }
 
-        let rule = rule.convert(&mut self.symbols);
-        let mut rule_scope = rule.origins(usize::MAX, Some(&self.public_key_to_block_id));
-
-        // rules with no scope annotations default to `trusting authority`
-        // todo default to an authorizer-level scope annotation when supported
-        if rule.scopes.is_empty() {
-            rule_scope.insert(0);
-        }
-
-        self.world.rules.insert(usize::MAX, &rule_scope, rule);
-        Ok(())
+    pub fn add_check<C: TryInto<Check>>(&mut self, check: C) -> Result<(), error::Token>
+    where
+        error::Token: From<<C as TryInto<Check>>::Error>,
+    {
+        self.authorizer_block_builder.add_check(check)
     }
 
     /// adds some datalog code to the authorizer
@@ -320,19 +299,15 @@ impl<'t> Authorizer<'t> {
         params: HashMap<String, Term>,
         scope_params: HashMap<String, PublicKey>,
     ) -> Result<(), error::Token> {
-        let input = source.as_ref();
+        let source = source.as_ref();
 
-        let source_result = parse_source(input).map_err(|e| {
+        let source_result = parse_source(&source).map_err(|e| {
             let e2: biscuit_parser::error::LanguageError = e.into();
             e2
         })?;
 
-        let mut origin = Origin::default();
-        origin.insert(usize::MAX);
-
         for (_, fact) in source_result.facts.into_iter() {
             let mut fact: Fact = fact.into();
-
             for (name, value) in &params {
                 let res = match fact.set(&name, value) {
                     Ok(_) => Ok(()),
@@ -346,10 +321,7 @@ impl<'t> Authorizer<'t> {
                 res?;
             }
             fact.validate()?;
-
-            self.world
-                .facts
-                .insert(&origin, fact.convert(&mut self.symbols));
+            self.authorizer_block_builder.facts.push(fact);
         }
 
         for (_, rule) in source_result.rules.into_iter() {
@@ -379,10 +351,7 @@ impl<'t> Authorizer<'t> {
                 res?;
             }
             rule.validate_parameters()?;
-            let rule = rule.convert(&mut self.symbols);
-            let rule_scope = rule.origins(usize::MAX, Some(&self.public_key_to_block_id));
-
-            self.world.rules.insert(usize::MAX, &rule_scope, rule);
+            self.authorizer_block_builder.rules.push(rule);
         }
 
         for (_, check) in source_result.checks.into_iter() {
@@ -412,9 +381,8 @@ impl<'t> Authorizer<'t> {
                 res?;
             }
             check.validate_parameters()?;
-            self.checks.push(check);
+            self.authorizer_block_builder.checks.push(check);
         }
-
         for (_, policy) in source_result.policies.into_iter() {
             let mut policy: Policy = policy.into();
             for (name, value) in &params {
@@ -448,6 +416,10 @@ impl<'t> Authorizer<'t> {
         Ok(())
     }
 
+    pub fn add_scope(&mut self, scope: Scope) {
+        self.authorizer_block_builder.add_scope(scope);
+    }
+
     /// run a query over the authorizer's Datalog engine to gather data
     ///
     /// ```rust
@@ -465,6 +437,7 @@ impl<'t> Authorizer<'t> {
     /// # assert_eq!(res[0].0, "John Doe");
     /// # assert_eq!(res[0].1, 42);
     /// ```
+    // TODO rename as `query_token`
     pub fn query<R: TryInto<Rule>, T: TryFrom<Fact, Error = E>, E: Into<error::Token>>(
         &mut self,
         rule: R,
@@ -490,19 +463,22 @@ impl<'t> Authorizer<'t> {
     {
         let rule = rule.try_into()?.convert(&mut self.symbols);
 
-        let mut origin = rule.origins(usize::MAX, Some(&self.public_key_to_block_id));
-
-        // by default, the query trusts the authority, in addition to the authorizer itself
-        if rule.scopes.is_empty() {
-            origin.insert(0);
-        }
+        let scope = scope_to_origins(
+            &rule.scopes,
+            &[], // for queries, we don't want to default on the authorizer trust
+            // queries are there to explore the final state of the world,
+            // whereas authorizer contents are there to authorize or not
+            // a token
+            usize::MAX,
+            Some(&self.public_key_to_block_id),
+        );
 
         self.world
             .run_with_limits(&self.symbols, limits.into())
             .map_err(error::Token::RunLimit)?;
         let res = self
             .world
-            .query_rule(rule, usize::MAX, &origin, &self.symbols);
+            .query_rule(rule, usize::MAX, &scope, &self.symbols);
 
         res //.drain(..)
             .inner
@@ -584,7 +560,15 @@ impl<'t> Authorizer<'t> {
         let origin = if rule.scopes.is_empty() {
             all_origins
         } else {
-            rule.origins(usize::MAX, Some(&self.public_key_to_block_id))
+            scope_to_origins(
+                &rule.scopes,
+                &[], // for queries, we don't want to default on the authorizer trust
+                // queries are there to explore the final state of the world,
+                // whereas authorizer contents are there to authorize or not
+                // a token
+                usize::MAX,
+                Some(&self.public_key_to_block_id),
+            )
         };
 
         let res = self
@@ -602,25 +586,10 @@ impl<'t> Authorizer<'t> {
             .collect::<Result<Vec<T>, _>>()
     }
 
-    /// add a check to the authorizer
-    pub fn add_check<C: TryInto<Check>>(&mut self, check: C) -> Result<(), error::Token>
-    where
-        error::Token: From<<C as TryInto<Check>>::Error>,
-    {
-        let check = check.try_into()?;
-        check.validate_parameters()?;
-        self.checks.push(check);
-        Ok(())
-    }
-
     /// adds a fact with the current time
     pub fn set_time(&mut self) {
         let fact = fact("time", &[date(&SystemTime::now())]);
-        let mut origin = Origin::default();
-        origin.insert(0);
-        self.world
-            .facts
-            .insert(&origin, fact.convert(&mut self.symbols));
+        self.authorizer_block_builder.add_fact(fact).unwrap();
     }
 
     /// add a policy to the authorizer
@@ -634,6 +603,7 @@ impl<'t> Authorizer<'t> {
         Ok(())
     }
 
+    /// todo remove, it's covered in BuilderExt
     /// adds a `allow if true` policy
     pub fn allow(&mut self) -> Result<(), error::Token> {
         self.add_policy("allow if true")
@@ -657,6 +627,7 @@ impl<'t> Authorizer<'t> {
     /// on error, this can return a list of all the failed checks or deny policy
     ///
     /// this method can specify custom runtime limits
+    /// todo consume the input to prevent further direct use
     pub fn authorize_with_limits(
         &mut self,
         limits: AuthorizerLimits,
@@ -666,33 +637,64 @@ impl<'t> Authorizer<'t> {
         let mut errors = vec![];
         let mut policy_result: Option<Result<usize, usize>> = None;
 
-        //FIXME: the authorizer should be generated with run limits
-        // that are "consumed" after each use
-        // Note: the authority facts and rules were already inserted
-        // in add_token
+        let mut authorizer_origin = Origin::default();
+        authorizer_origin.insert(usize::MAX);
+
+        let authorizer_scopes: Vec<token::Scope> = self
+            .authorizer_block_builder
+            .scopes
+            .clone()
+            .iter()
+            .map(|s| s.convert(&mut self.symbols).clone())
+            .collect();
+
+        for fact in &self.authorizer_block_builder.facts {
+            self.world
+                .facts
+                .insert(&authorizer_origin, fact.convert(&mut self.symbols));
+        }
+
+        for rule in &self.authorizer_block_builder.rules {
+            let rule = rule.convert(&mut self.symbols);
+
+            let scope = scope_to_origins(
+                &rule.scopes,
+                &authorizer_scopes,
+                usize::MAX,
+                Some(&self.public_key_to_block_id),
+            );
+
+            self.world.rules.insert(usize::MAX, &scope, rule);
+        }
+
         self.world
             .run_with_limits(&self.symbols, RunLimits::default())
             .map_err(error::Token::RunLimit)?;
         //self.world.rules.clear();
 
-        // by default we trust authority and the authorizer
-        let mut origin = Origin::default();
-        origin.extend([0, usize::MAX]);
+        let authorizer_scopes: Vec<token::Scope> = self
+            .authorizer_block_builder
+            .scopes
+            .clone()
+            .iter()
+            .map(|s| s.convert(&mut self.symbols).clone())
+            .collect();
 
-        for (i, check) in self.checks.iter().enumerate() {
+        for (i, check) in self.authorizer_block_builder.checks.iter().enumerate() {
             let c = check.convert(&mut self.symbols);
             let mut successful = false;
 
             for query in check.queries.iter() {
                 let query = query.convert(&mut self.symbols);
-                let origin = if query.scopes.is_empty() {
-                    origin.clone()
-                } else {
-                    query.origins(usize::MAX, Some(&self.public_key_to_block_id))
-                };
+                let scope = scope_to_origins(
+                    &query.scopes,
+                    &authorizer_scopes,
+                    usize::MAX,
+                    Some(&self.public_key_to_block_id),
+                );
                 let res = self
                     .world
-                    .query_match(query, usize::MAX, &origin, &self.symbols);
+                    .query_match(query, usize::MAX, &scope, &self.symbols);
 
                 let now = Instant::now();
                 if now >= time_limit {
@@ -716,8 +718,6 @@ impl<'t> Authorizer<'t> {
         }
 
         if let Some(token) = self.token.as_ref() {
-            let origin = self.blocks[0].origins(0, Some(&self.public_key_to_block_id));
-
             for (j, check) in self.blocks[0].checks.iter().enumerate() {
                 let mut successful = false;
 
@@ -725,14 +725,15 @@ impl<'t> Authorizer<'t> {
                 let check = c.convert(&mut self.symbols);
 
                 for query in check.queries.iter() {
-                    let origin = if query.scopes.is_empty() {
-                        origin.clone()
-                    } else {
-                        query.origins(0, Some(&self.public_key_to_block_id))
-                    };
+                    let scope = scope_to_origins(
+                        &query.scopes,
+                        &self.blocks[0].scopes,
+                        0,
+                        Some(&self.public_key_to_block_id),
+                    );
                     let res = self
                         .world
-                        .query_match(query.clone(), 0, &origin, &self.symbols);
+                        .query_match(query.clone(), 0, &scope, &self.symbols);
 
                     let now = Instant::now();
                     if now >= time_limit {
@@ -758,11 +759,13 @@ impl<'t> Authorizer<'t> {
         'policies_test: for (i, policy) in self.policies.iter().enumerate() {
             for query in policy.queries.iter() {
                 let query = query.convert(&mut self.symbols);
-                let scope = if query.scopes.is_empty() {
-                    origin.clone()
-                } else {
-                    query.origins(usize::MAX, Some(&self.public_key_to_block_id))
-                };
+                let scope = scope_to_origins(
+                    &query.scopes,
+                    &authorizer_scopes,
+                    usize::MAX,
+                    Some(&self.public_key_to_block_id),
+                );
+
                 let res = self
                     .world
                     .query_match(query, usize::MAX, &scope, &self.symbols);
@@ -791,8 +794,6 @@ impl<'t> Authorizer<'t> {
                     &block.symbols
                 };
 
-                let origin = block.origins(i + 1, Some(&self.public_key_to_block_id));
-
                 self.world
                     .run_with_limits(&self.symbols, RunLimits::default())
                     .map_err(error::Token::RunLimit)?;
@@ -803,15 +804,16 @@ impl<'t> Authorizer<'t> {
                     let check = c.convert(&mut self.symbols);
 
                     for query in check.queries.iter() {
-                        let origin = if query.scopes.is_empty() {
-                            origin.clone()
-                        } else {
-                            query.origins(i + 1, Some(&self.public_key_to_block_id))
-                        };
+                        let scope = scope_to_origins(
+                            &query.scopes,
+                            &block.scopes,
+                            i + 1,
+                            Some(&self.public_key_to_block_id),
+                        );
 
                         let res =
                             self.world
-                                .query_match(query.clone(), i + 1, &origin, &self.symbols);
+                                .query_match(query.clone(), i + 1, &scope, &self.symbols);
 
                         let now = Instant::now();
                         if now >= time_limit {
@@ -886,7 +888,7 @@ impl<'t> Authorizer<'t> {
             .collect();
 
         let mut checks = Vec::new();
-        for (index, check) in self.checks.iter().enumerate() {
+        for (index, check) in self.authorizer_block_builder.checks.iter().enumerate() {
             checks.push(format!("Authorizer[{}]: {}", index, check));
         }
 
@@ -914,7 +916,7 @@ impl<'t> Authorizer<'t> {
 
     /// returns all of the data loaded in the authorizer
     pub fn dump(&self) -> (Vec<Fact>, Vec<Rule>, Vec<Check>, Vec<Policy>) {
-        let mut checks = self.checks.clone();
+        let mut checks = self.authorizer_block_builder.checks.clone();
         checks.extend(
             self.token_checks
                 .iter()
@@ -922,21 +924,25 @@ impl<'t> Authorizer<'t> {
                 .map(|c| Check::convert_from(c, &self.symbols).unwrap()),
         );
 
-        (
-            self.world
-                .facts
-                .iter_all()
-                .map(|f| Fact::convert_from(f.1, &self.symbols))
-                .collect::<Result<Vec<_>, error::Format>>()
-                .unwrap(),
-            self.world
-                .rules
-                .iter_all()
-                .map(|r| Rule::convert_from(r.1, &self.symbols).unwrap())
-                .collect(),
-            checks,
-            self.policies.clone(),
-        )
+        let mut facts = self
+            .world
+            .facts
+            .iter_all()
+            .map(|f| Fact::convert_from(f.1, &self.symbols))
+            .collect::<Result<Vec<_>, error::Format>>()
+            .unwrap();
+        facts.extend(self.authorizer_block_builder.facts.clone());
+
+        let mut rules = self
+            .world
+            .rules
+            .iter_all()
+            .map(|r| Rule::convert_from(r.1, &self.symbols))
+            .collect::<Result<Vec<_>, error::Format>>()
+            .unwrap();
+        rules.extend(self.authorizer_block_builder.rules.clone());
+
+        (facts, rules, checks, self.policies.clone())
     }
 
     pub fn dump_code(&self) -> String {
@@ -1006,37 +1012,31 @@ impl std::convert::From<AuthorizerLimits> for crate::datalog::RunLimits {
 impl BuilderExt for Authorizer<'_> {
     fn add_resource(&mut self, name: &str) {
         let f = fact("resource", &[string(name)]);
-        let mut origin = Origin::default();
-        origin.insert(0);
-        self.world
-            .facts
-            .insert(&origin, f.convert(&mut self.symbols));
+        self.add_fact(f).unwrap();
     }
     fn check_resource(&mut self, name: &str) {
-        self.checks.push(Check {
+        self.add_check(Check {
             queries: vec![rule(
                 "resource_check",
                 &[string("resource_check")],
                 &[pred("resource", &[string(name)])],
             )],
-        });
+        })
+        .unwrap();
     }
     fn add_operation(&mut self, name: &str) {
         let f = fact("operation", &[string(name)]);
-        let mut origin = Origin::default();
-        origin.insert(0);
-        self.world
-            .facts
-            .insert(&origin, f.convert(&mut self.symbols));
+        self.add_fact(f).unwrap();
     }
     fn check_operation(&mut self, name: &str) {
-        self.checks.push(Check {
+        self.add_check(Check {
             queries: vec![rule(
                 "operation_check",
                 &[string("operation_check")],
                 &[pred("operation", &[string(name)])],
             )],
-        });
+        })
+        .unwrap();
     }
     fn check_resource_prefix(&mut self, prefix: &str) {
         let check = constrained_rule(
@@ -1052,9 +1052,10 @@ impl BuilderExt for Authorizer<'_> {
             }],
         );
 
-        self.checks.push(Check {
+        self.add_check(Check {
             queries: vec![check],
-        });
+        })
+        .unwrap();
     }
 
     fn check_resource_suffix(&mut self, suffix: &str) {
@@ -1071,9 +1072,10 @@ impl BuilderExt for Authorizer<'_> {
             }],
         );
 
-        self.checks.push(Check {
+        self.add_check(Check {
             queries: vec![check],
-        });
+        })
+        .unwrap();
     }
 
     fn check_expiration_date(&mut self, exp: SystemTime) {
@@ -1090,9 +1092,10 @@ impl BuilderExt for Authorizer<'_> {
             }],
         );
 
-        self.checks.push(Check {
+        self.add_check(Check {
             queries: vec![check],
-        });
+        })
+        .unwrap();
     }
 }
 
@@ -1302,8 +1305,6 @@ mod tests {
 
         // this rule trusts both the third-party block and the authority, and can access facts
         // from both
-        // todo authorizer rules currently don't see mappings to block public keys, so this
-        // won't match, even though it should
         authorizer
             .add_rule(
                 format!("possible(true) <- right($right), group(\"admin\") trusting authority, ed25519/{external_pub}")
@@ -1325,12 +1326,7 @@ mod tests {
         authorizer.add_fact("authorizer(true)").unwrap();
         authorizer
             .add_check(
-                // todo the rule above should match, but doesn't because of public key mapping
-                // issues. Directly checking the facts work, because the check has access to
-                // a complete mapping. Use the commented out version once the mapping issue
-                // is solved
-                //format!("check if possible(true) trusting authority, ed25519/{external_pub}")
-                format!("check if right(\"read\"), group(\"admin\") trusting authority, ed25519/{external_pub}")
+                format!("check if possible(true) trusting authority, ed25519/{external_pub}")
                     .as_str(),
             )
             .unwrap();
@@ -1356,7 +1352,7 @@ mod tests {
             authorizer.query("right($right) <- right($right)").unwrap();
         assert_eq!(authority_facts.len(), 1);
 
-        // todo: authority facts should not be visible if
+        // authority facts are not visible if
         // there is an explicit rule scope annotation that does
         // not cover previous or authority
         let authority_facts_untrusted: Vec<Fact> = authorizer

--- a/biscuit-auth/src/token/block.rs
+++ b/biscuit-auth/src/token/block.rs
@@ -1,8 +1,6 @@
-use std::collections::HashMap;
-
 use crate::{
     crypto::PublicKey,
-    datalog::{Check, Fact, Origin, Rule, SymbolTable, Term},
+    datalog::{Check, Fact, Rule, SymbolTable, Term},
 };
 
 use super::{public_keys::PublicKeys, Scope};
@@ -67,43 +65,5 @@ impl Block {
         }
 
         res
-    }
-
-    pub(crate) fn origins(
-        &self,
-        current_block: usize,
-        public_key_to_block_id: Option<&HashMap<usize, Vec<usize>>>,
-    ) -> Origin {
-        let mut origins = Origin::default();
-        // we always trust the authorizer
-        origins.insert(usize::MAX);
-        // we always trust the current block
-        origins.insert(current_block);
-
-        // in the default case, we trust the authority block
-        if self.scopes.is_empty() {
-            origins.insert(0);
-        } else {
-            for scope in &self.scopes {
-                match scope {
-                    Scope::Authority => {
-                        origins.insert(0);
-                    }
-                    Scope::Previous => {
-                        if current_block != usize::MAX {
-                            origins.extend(0..current_block + 1)
-                        }
-                    }
-                    Scope::PublicKey(key_id) => {
-                        if let Some(map) = public_key_to_block_id {
-                            if let Some(block_ids) = map.get(&(*key_id as usize)) {
-                                origins.extend(block_ids.iter())
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        origins
     }
 }

--- a/biscuit-auth/src/token/mod.rs
+++ b/biscuit-auth/src/token/mod.rs
@@ -13,7 +13,6 @@ use prost::Message;
 use rand_core::{CryptoRng, RngCore};
 
 use crate::crypto::{self};
-use crate::datalog::Origin;
 use crate::format::convert::proto_block_to_token_block;
 use crate::format::schema::{self, ThirdPartyBlockContents};
 use authorizer::Authorizer;
@@ -637,49 +636,6 @@ pub enum Scope {
     Previous,
     // index of the public key in the token's list
     PublicKey(u64),
-}
-
-pub(crate) fn scope_to_origins(
-    rule_scopes: &[Scope],
-    block_scopes: &[Scope],
-    current_block: usize,
-    public_key_to_block_id: Option<&HashMap<usize, Vec<usize>>>,
-) -> Origin {
-    let scopes = if rule_scopes.is_empty() {
-        if block_scopes.is_empty() {
-            &[Scope::Authority]
-        } else {
-            block_scopes
-        }
-    } else {
-        rule_scopes
-    };
-
-    let mut origins = Origin::default();
-    origins.insert(usize::MAX);
-    origins.insert(current_block);
-
-    for scope in scopes {
-        match scope {
-            Scope::Authority => {
-                origins.insert(0);
-            }
-            Scope::Previous => {
-                if current_block != usize::MAX {
-                    origins.extend(0..current_block + 1)
-                }
-            }
-            Scope::PublicKey(key_id) => {
-                if let Some(map) = public_key_to_block_id {
-                    if let Some(block_ids) = map.get(&(*key_id as usize)) {
-                        origins.extend(block_ids.iter())
-                    }
-                }
-            }
-        }
-    }
-
-    origins
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Instead of adding authorizer checks, rules & facts directly to the datalog world, we
keep them in a BlockBuilder, and add them to the world only when running `authorize`.

This brings ~two~ three important benefits:

- this removes duplication between authorizer and BlockBuilder by letting Authorizer
  delegate to BlockBuilder (`add_xxx`)
- this solves an issue where rules added in the authorizer before the token would not
  have access to the public_key_to_block_id mapping and would fail to generate facts
  for rules trusting third-party blocks
- this allows an authorizer to carry a default scope, like blocks do

A related refactoring has been included: instead of having `Block.origins()` and
`Rule.origins()` with duplicate logic, everything happens inside a single
`TrustedOrigins::from_scope` function that handles both the defaulting behaviour for scopes, and then the conversion
to trusted origins. Furthermore, a `TrustedOrigins` newtype has been introduced, to separate the origin of a fact,
from the origins trusted by a rule. This makes many previous bugs type errors.

Do note:

1. `add_code` in `BlockBuilder` does not handle block-leve scopes, and `add_code` in `Authorizer` doesn't eithe
2. `parse_source` refuses parsing a block-level scope annotation anyway
3. `query` called before `authorize` will only return token facts (only those declared directly, not those generated by rules).

1 & 2 will be covered in a dedicated PR (along with parameter substitution in macros)

3 will require further discussion around making `Authorizer` more type-safe, by making its lifecycle more obvious (currently a lot depends on when some methods are called)