### PR TITLE
Add #[must_use] and use collect() for building Vecs

### DIFF
--- a/biscuit-auth/examples/testcases.rs
+++ b/biscuit-auth/examples/testcases.rs
@@ -245,11 +245,11 @@ fn validate_token(
         }
     };
 
-    let mut revocation_ids = vec![];
-
-    for bytes in token.revocation_identifiers() {
-        revocation_ids.push(hex::encode(&bytes));
-    }
+    let revocation_ids = token
+        .revocation_identifiers()
+        .into_iter()
+        .map(|rev_id| hex::encode(&rev_id))
+        .collect::<Vec<_>>();
 
     let mut authorizer = match token.authorizer() {
         Ok(v) => v,

--- a/biscuit-auth/src/crypto/mod.rs
+++ b/biscuit-auth/src/crypto/mod.rs
@@ -22,6 +22,7 @@ pub struct KeyPair {
 }
 
 impl KeyPair {
+    #[must_use]
     pub fn new() -> Self {
         Self::new_with_rng(&mut rand::rngs::OsRng)
     }
@@ -32,6 +33,7 @@ impl KeyPair {
         KeyPair { kp }
     }
 
+    #[must_use]
     pub fn from(key: &PrivateKey) -> Self {
         let secret = SecretKey::from_bytes(&key.0.to_bytes()).unwrap();
 
@@ -42,11 +44,13 @@ impl KeyPair {
         }
     }
 
+    #[must_use]
     pub fn private(&self) -> PrivateKey {
         let secret = SecretKey::from_bytes(&self.kp.secret.to_bytes()).unwrap();
         PrivateKey(secret)
     }
 
+    #[must_use]
     pub fn public(&self) -> PublicKey {
         PublicKey(self.kp.public)
     }
@@ -70,11 +74,13 @@ pub struct PrivateKey(pub(crate) ed25519_dalek::SecretKey);
 
 impl PrivateKey {
     /// serializes to a byte array
+    #[must_use]
     pub fn to_bytes(&self) -> [u8; 32] {
         self.0.to_bytes()
     }
 
     /// serializes to an hex-encoded string
+    #[must_use]
     pub fn to_bytes_hex(&self) -> String {
         hex::encode(self.to_bytes())
     }
@@ -97,6 +103,7 @@ impl PrivateKey {
     }
 
     /// returns the matching public key
+    #[must_use]
     pub fn public(&self) -> PublicKey {
         PublicKey((&self.0).into())
     }
@@ -120,11 +127,13 @@ pub struct PublicKey(pub(crate) ed25519_dalek::PublicKey);
 
 impl PublicKey {
     /// serializes to a byte array
+    #[must_use]
     pub fn to_bytes(&self) -> [u8; 32] {
         self.0.to_bytes()
     }
 
     /// serializes to an hex-encoded string
+    #[must_use]
     pub fn to_bytes_hex(&self) -> String {
         hex::encode(self.to_bytes())
     }
@@ -154,6 +163,7 @@ impl PublicKey {
         PublicKey::from_bytes(&key.key)
     }
 
+    #[must_use]
     pub fn to_proto(&self) -> schema::PublicKey {
         schema::PublicKey {
             algorithm: schema::public_key::Algorithm::Ed25519 as i32,
@@ -161,6 +171,7 @@ impl PublicKey {
         }
     }
 
+    #[must_use]
     pub fn print(&self) -> String {
         format!("ed25519/{}", hex::encode(&self.to_bytes()))
     }

--- a/biscuit-auth/src/datalog/expression.rs
+++ b/biscuit-auth/src/datalog/expression.rs
@@ -40,6 +40,7 @@ impl Unary {
         }
     }
 
+    #[must_use]
     pub fn print(&self, value: String, _symbols: &SymbolTable) -> String {
         match self {
             Unary::Negate => format!("!{}", value),
@@ -188,6 +189,7 @@ impl Binary {
         }
     }
 
+    #[must_use]
     pub fn print(&self, left: String, right: String, _symbols: &SymbolTable) -> String {
         match self {
             Binary::LessThan => format!("{} < {}", left, right),
@@ -262,6 +264,7 @@ impl Expression {
         }
     }
 
+    #[must_use]
     pub fn print(&self, symbols: &SymbolTable) -> Option<String> {
         let mut stack: Vec<String> = Vec::new();
 

--- a/biscuit-auth/src/datalog/mod.rs
+++ b/biscuit-auth/src/datalog/mod.rs
@@ -53,6 +53,7 @@ pub struct Predicate {
 }
 
 impl Predicate {
+    #[must_use]
     pub fn new(name: SymbolIndex, terms: &[Term]) -> Predicate {
         Predicate {
             name,
@@ -73,6 +74,7 @@ pub struct Fact {
 }
 
 impl Fact {
+    #[must_use]
     pub fn new(name: SymbolIndex, terms: &[Term]) -> Fact {
         Fact {
             predicate: Predicate::new(name, terms),
@@ -151,6 +153,7 @@ impl Rule {
         })
     }
 
+    #[must_use]
     pub fn find_match(
         &self,
         facts: &FactSet,
@@ -430,6 +433,7 @@ pub struct MatchedVariables {
 }
 
 impl MatchedVariables {
+    #[must_use]
     pub fn new(import: HashSet<u32>) -> Self {
         MatchedVariables {
             variables: import.iter().map(|key| (*key, None)).collect(),
@@ -447,10 +451,12 @@ impl MatchedVariables {
         }
     }
 
+    #[must_use]
     pub fn is_complete(&self) -> bool {
         self.variables.values().all(|v| v.is_some())
     }
 
+    #[must_use]
     pub fn complete(&self) -> Option<HashMap<u32, Term>> {
         let mut result = HashMap::new();
         for (k, v) in self.variables.iter() {
@@ -506,6 +512,7 @@ pub fn expressed_rule<I: AsRef<Term>, P: AsRef<Predicate>, C: AsRef<Expression>>
     }
 }
 
+#[must_use]
 pub fn int(i: i64) -> Term {
     Term::Integer(i)
 }
@@ -514,6 +521,7 @@ pub fn int(i: i64) -> Term {
     Term::Str(s.to_string())
 }*/
 
+#[must_use]
 pub fn date(t: &SystemTime) -> Term {
     let dur = t.duration_since(UNIX_EPOCH).unwrap();
     Term::Date(dur.as_secs())
@@ -524,6 +532,7 @@ pub fn var(syms: &mut SymbolTable, name: &str) -> Term {
     Term::Variable(id as u32)
 }
 
+#[must_use]
 pub fn match_preds(rule_pred: &Predicate, fact_pred: &Predicate) -> bool {
     rule_pred.name == fact_pred.name
         && rule_pred.terms.len() == fact_pred.terms.len()
@@ -552,6 +561,7 @@ pub struct World {
 }
 
 impl World {
+    #[must_use]
     pub fn new() -> Self {
         World::default()
     }
@@ -635,6 +645,7 @@ impl World {
             .collect::<Vec<_>>()
     }*/
 
+    #[must_use]
     pub fn query_rule(
         &self,
         rule: Rule,
@@ -649,6 +660,7 @@ impl World {
         new_facts
     }
 
+    #[must_use]
     pub fn query_match(
         &self,
         rule: Rule,
@@ -695,10 +707,12 @@ impl FactSet {
         }
     }
 
+    #[must_use]
     pub fn len(&self) -> usize {
         self.inner.values().fold(0, |acc, set| acc + set.len())
     }
 
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.inner.values().all(|set| set.is_empty())
     }

--- a/biscuit-auth/src/datalog/origin.rs
+++ b/biscuit-auth/src/datalog/origin.rs
@@ -15,12 +15,14 @@ impl Origin {
         self.inner.insert(i);
     }
 
+    #[must_use]
     pub fn union(&self, other: &Self) -> Self {
         Origin {
             inner: self.inner.union(&other.inner).cloned().collect(),
         }
     }
 
+    #[must_use]
     pub fn is_superset(&self, other: &Self) -> bool {
         self.inner.is_superset(&other.inner)
     }
@@ -59,12 +61,14 @@ impl FromIterator<usize> for Origin {
 pub struct TrustedOrigins(Origin);
 
 impl TrustedOrigins {
+    #[must_use]
     pub fn default() -> TrustedOrigins {
         let mut origins = Origin::default();
         origins.insert(usize::MAX);
         origins.insert(0);
         TrustedOrigins(origins)
     }
+    #[must_use]
     pub fn from_scopes(
         rule_scopes: &[Scope],
         default_origins: &TrustedOrigins,
@@ -100,6 +104,7 @@ impl TrustedOrigins {
         TrustedOrigins(origins)
     }
 
+    #[must_use]
     pub fn contains(&self, fact_origin: &Origin) -> bool {
         self.0.is_superset(fact_origin)
     }

--- a/biscuit-auth/src/datalog/symbol.rs
+++ b/biscuit-auth/src/datalog/symbol.rs
@@ -48,6 +48,7 @@ const DEFAULT_SYMBOLS: [&str; 28] = [
 const OFFSET: usize = 1024;
 
 impl SymbolTable {
+    #[must_use]
     pub fn new() -> Self {
         SymbolTable {
             symbols: vec![],
@@ -97,6 +98,7 @@ impl SymbolTable {
         Term::Str(term)
     }
 
+    #[must_use]
     pub fn get(&self, s: &str) -> Option<SymbolIndex> {
         if let Some(index) = DEFAULT_SYMBOLS.iter().position(|sym| *sym == s) {
             return Some(index as u64);
@@ -108,10 +110,12 @@ impl SymbolTable {
             .map(|i| (OFFSET + i) as SymbolIndex)
     }
 
+    #[must_use]
     pub fn strings(&self) -> Vec<String> {
         self.symbols.clone()
     }
 
+    #[must_use]
     pub fn current_offset(&self) -> usize {
         self.symbols.len()
     }
@@ -122,6 +126,7 @@ impl SymbolTable {
         table
     }
 
+    #[must_use]
     pub fn is_disjoint(&self, other: &SymbolTable) -> bool {
         let h1 = self.symbols.iter().collect::<HashSet<_>>();
         let h2 = other.symbols.iter().collect::<HashSet<_>>();
@@ -129,6 +134,7 @@ impl SymbolTable {
         h1.is_disjoint(&h2)
     }
 
+    #[must_use]
     pub fn get_symbol(&self, i: SymbolIndex) -> Option<&str> {
         if i >= OFFSET as u64 {
             self.symbols
@@ -146,12 +152,14 @@ impl SymbolTable {
     }
 
     // infallible symbol printing method
+    #[must_use]
     pub fn print_symbol_default(&self, i: SymbolIndex) -> String {
         self.get_symbol(i)
             .map(|s| s.to_string())
             .unwrap_or_else(|| format!("<{}?>", i))
     }
 
+    #[must_use]
     pub fn print_world(&self, w: &World) -> String {
         let facts = w
             .facts
@@ -170,6 +178,7 @@ impl SymbolTable {
         format!("World {{\n  facts: {:#?}\n  rules: {:#?}\n}}", facts, rules)
     }
 
+    #[must_use]
     pub fn print_term(&self, term: &Term) -> String {
         match term {
             Term::Variable(i) => format!("${}", self.print_symbol_default(*i as u64)),
@@ -196,10 +205,12 @@ impl SymbolTable {
             }
         }
     }
+    #[must_use]
     pub fn print_fact(&self, f: &Fact) -> String {
         self.print_predicate(&f.predicate)
     }
 
+    #[must_use]
     pub fn print_predicate(&self, p: &Predicate) -> String {
         let strings = p
             .terms
@@ -213,11 +224,13 @@ impl SymbolTable {
         )
     }
 
+    #[must_use]
     pub fn print_expression(&self, e: &super::expression::Expression) -> String {
         e.print(self)
             .unwrap_or_else(|| format!("<invalid expression: {:?}>", e.ops))
     }
 
+    #[must_use]
     pub fn print_rule_body(&self, r: &Rule) -> String {
         let preds: Vec<_> = r.body.iter().map(|p| self.print_predicate(p)).collect();
 
@@ -258,12 +271,14 @@ impl SymbolTable {
         format!("{}{}{}", preds.join(", "), e, scopes)
     }
 
+    #[must_use]
     pub fn print_rule(&self, r: &Rule) -> String {
         let res = self.print_predicate(&r.head);
 
         format!("{} <- {}", res, self.print_rule_body(r))
     }
 
+    #[must_use]
     pub fn print_check(&self, c: &Check) -> String {
         let queries = c
             .queries
@@ -289,6 +304,7 @@ pub struct TemporarySymbolTable<'a> {
 }
 
 impl<'a> TemporarySymbolTable<'a> {
+    #[must_use]
     pub fn new(base: &'a SymbolTable) -> Self {
         let offset = OFFSET + base.current_offset();
 
@@ -299,6 +315,7 @@ impl<'a> TemporarySymbolTable<'a> {
         }
     }
 
+    #[must_use]
     pub fn get_symbol(&self, i: SymbolIndex) -> Option<&str> {
         if i as usize >= self.offset {
             self.symbols

--- a/biscuit-auth/src/format/convert.rs
+++ b/biscuit-auth/src/format/convert.rs
@@ -11,6 +11,7 @@ use crate::token::Scope;
 use crate::token::{authorizer::AuthorizerPolicies, Block};
 use crate::token::{MAX_SCHEMA_VERSION, MIN_SCHEMA_VERSION};
 
+#[must_use]
 pub fn token_block_to_proto_block(input: &Block) -> schema::Block {
     schema::Block {
         symbols: input.symbols.strings(),
@@ -104,6 +105,7 @@ pub fn proto_block_to_token_block(
     })
 }
 
+#[must_use]
 pub fn authorizer_to_proto_authorizer(input: &AuthorizerPolicies) -> schema::AuthorizerPolicies {
     let mut symbols = input.symbols.clone();
     let policies = input
@@ -188,6 +190,7 @@ pub mod v2 {
     use crate::token::MIN_SCHEMA_VERSION;
     use std::collections::BTreeSet;
 
+    #[must_use]
     pub fn token_fact_to_proto_fact(input: &Fact) -> schema::FactV2 {
         schema::FactV2 {
             predicate: token_predicate_to_proto_predicate(&input.predicate),
@@ -200,6 +203,7 @@ pub mod v2 {
         })
     }
 
+    #[must_use]
     pub fn token_check_to_proto_check(input: &Check) -> schema::CheckV2 {
         schema::CheckV2 {
             queries: input.queries.iter().map(token_rule_to_proto_rule).collect(),
@@ -267,6 +271,7 @@ pub mod v2 {
         Ok(crate::token::builder::Policy { queries, kind })
     }
 
+    #[must_use]
     pub fn token_rule_to_proto_rule(input: &Rule) -> schema::RuleV2 {
         schema::RuleV2 {
             head: token_predicate_to_proto_predicate(&input.head),
@@ -325,6 +330,7 @@ pub mod v2 {
         ))
     }
 
+    #[must_use]
     pub fn token_predicate_to_proto_predicate(input: &Predicate) -> schema::PredicateV2 {
         schema::PredicateV2 {
             name: input.name,
@@ -347,6 +353,7 @@ pub mod v2 {
         })
     }
 
+    #[must_use]
     pub fn token_term_to_proto_id(input: &Term) -> schema::TermV2 {
         use schema::term_v2::Content;
 
@@ -437,6 +444,7 @@ pub mod v2 {
         }
     }
 
+    #[must_use]
     pub fn token_expression_to_proto_expression(input: &Expression) -> schema::ExpressionV2 {
         schema::ExpressionV2 {
             ops: input
@@ -546,6 +554,7 @@ pub mod v2 {
         Ok(Expression { ops })
     }
 
+    #[must_use]
     pub fn token_scope_to_proto_scope(input: &Scope) -> schema::Scope {
         schema::Scope {
             content: Some(match input {

--- a/biscuit-auth/src/format/mod.rs
+++ b/biscuit-auth/src/format/mod.rs
@@ -234,6 +234,7 @@ impl SerializedBiscuit {
     }
 
     /// serializes the token
+    #[must_use]
     pub fn to_proto(&self) -> schema::Biscuit {
         let authority = schema::SignedBlock {
             block: self.authority.data.clone(),
@@ -276,6 +277,7 @@ impl SerializedBiscuit {
         }
     }
 
+    #[must_use]
     pub fn serialized_size(&self) -> usize {
         self.to_proto().encoded_len()
     }

--- a/biscuit-auth/src/token/authorizer.rs
+++ b/biscuit-auth/src/token/authorizer.rs
@@ -952,10 +952,11 @@ impl<'t> Authorizer<'t> {
             }
         }
 
-        let mut policies = Vec::new();
-        for policy in self.policies.iter() {
-            policies.push(policy.to_string());
-        }
+        let policies = self
+            .policies
+            .iter()
+            .map(std::string::ToString::to_string)
+            .collect::<Vec<_>>();
 
         format!(
             "World {{\n  facts: {:#?}\n  rules: {:#?}\n  checks: {:#?}\n  policies: {:#?}\n}}",

--- a/biscuit-auth/src/token/authorizer.rs
+++ b/biscuit-auth/src/token/authorizer.rs
@@ -902,6 +902,7 @@ impl<'t> Authorizer<'t> {
     }
 
     /// prints the content of the authorizer
+    #[must_use]
     pub fn print_world(&self) -> String {
         let facts: BTreeMap<_, _> = self
             .world
@@ -963,6 +964,7 @@ impl<'t> Authorizer<'t> {
     }
 
     /// returns all of the data loaded in the authorizer
+    #[must_use]
     pub fn dump(&self) -> (Vec<Fact>, Vec<Rule>, Vec<Check>, Vec<Policy>) {
         let mut checks = self.authorizer_block_builder.checks.clone();
         checks.extend(
@@ -993,6 +995,7 @@ impl<'t> Authorizer<'t> {
         (facts, rules, checks, self.policies.clone())
     }
 
+    #[must_use]
     pub fn dump_code(&self) -> String {
         let (facts, rules, checks, policies) = self.dump();
         let mut f = String::new();

--- a/biscuit-auth/src/token/builder.rs
+++ b/biscuit-auth/src/token/builder.rs
@@ -29,6 +29,7 @@ pub struct BlockBuilder {
 }
 
 impl BlockBuilder {
+    #[must_use]
     pub fn new() -> BlockBuilder {
         BlockBuilder::default()
     }
@@ -278,6 +279,7 @@ pub struct BiscuitBuilder {
 }
 
 impl BiscuitBuilder {
+    #[must_use]
     pub fn new() -> BiscuitBuilder {
         BiscuitBuilder {
             inner: BlockBuilder::new(),
@@ -343,6 +345,7 @@ impl BiscuitBuilder {
     }
 
     /// returns all of the datalog loaded in the biscuit builder
+    #[must_use]
     pub fn dump(&self) -> (Vec<Fact>, Vec<Rule>, Vec<Check>) {
         (
             self.inner.facts.clone(),
@@ -351,6 +354,7 @@ impl BiscuitBuilder {
         )
     }
 
+    #[must_use]
     pub fn dump_code(&self) -> String {
         let (facts, rules, checks) = self.dump();
         let mut f = String::new();
@@ -956,6 +960,7 @@ pub struct Rule {
 }
 
 impl Rule {
+    #[must_use]
     pub fn new(
         head: Predicate,
         body: Vec<Predicate>,
@@ -1763,11 +1768,13 @@ pub fn check<P: AsRef<Predicate>>(predicates: &[P]) -> Check {
 }
 
 /// creates an integer value
+#[must_use]
 pub fn int(i: i64) -> Term {
     Term::Integer(i)
 }
 
 /// creates a string
+#[must_use]
 pub fn string(s: &str) -> Term {
     Term::Str(s.to_string())
 }
@@ -1775,37 +1782,44 @@ pub fn string(s: &str) -> Term {
 /// creates a date
 ///
 /// internally the date will be stored as seconds since UNIX_EPOCH
+#[must_use]
 pub fn date(t: &SystemTime) -> Term {
     let dur = t.duration_since(UNIX_EPOCH).unwrap();
     Term::Date(dur.as_secs())
 }
 
 /// creates a variable for a rule
+#[must_use]
 pub fn var(s: &str) -> Term {
     Term::Variable(s.to_string())
 }
 
 /// creates a variable for a rule
+#[must_use]
 pub fn variable(s: &str) -> Term {
     Term::Variable(s.to_string())
 }
 
 /// creates a byte array
+#[must_use]
 pub fn bytes(s: &[u8]) -> Term {
     Term::Bytes(s.to_vec())
 }
 
 /// creates a boolean
+#[must_use]
 pub fn boolean(b: bool) -> Term {
     Term::Bool(b)
 }
 
 /// creates a set
+#[must_use]
 pub fn set(s: BTreeSet<Term>) -> Term {
     Term::Set(s)
 }
 
 /// creates a parameter
+#[must_use]
 pub fn parameter(p: &str) -> Term {
     Term::Parameter(p.to_string())
 }

--- a/biscuit-auth/src/token/mod.rs
+++ b/biscuit-auth/src/token/mod.rs
@@ -84,6 +84,7 @@ impl Biscuit {
     /// create the first block's builder
     ///
     /// call [`builder::BiscuitBuilder::build`] to create the token
+    #[must_use]
     pub fn builder() -> BiscuitBuilder {
         BiscuitBuilder::new()
     }
@@ -161,6 +162,7 @@ impl Biscuit {
     ///
     /// the context is a free form text field in which application specific data
     /// can be stored
+    #[must_use]
     pub fn context(&self) -> Vec<Option<String>> {
         let mut res = vec![self.authority.context.clone()];
 
@@ -175,6 +177,7 @@ impl Biscuit {
     ///
     /// revocation identifiers are unique: tokens generated separately with
     /// the same contents will have different revocation ids
+    #[must_use]
     pub fn revocation_identifiers(&self) -> Vec<Vec<u8>> {
         let mut res = vec![self.container.authority.signature.to_bytes().to_vec()];
 
@@ -190,6 +193,7 @@ impl Biscuit {
     /// Blocks carrying an external public key are _third-party blocks_
     /// and their contents can be trusted as coming from the holder of
     /// the corresponding private key
+    #[must_use]
     pub fn external_public_keys(&self) -> Vec<Option<Vec<u8>>> {
         let mut res = vec![None];
 
@@ -206,6 +210,7 @@ impl Biscuit {
     }
 
     /// pretty printer for this token
+    #[must_use]
     pub fn print(&self) -> String {
         let authority = self
             .block(0)
@@ -330,6 +335,7 @@ impl Biscuit {
     }
 
     /// returns the internal representation of the token
+    #[must_use]
     pub fn container(&self) -> &SerializedBiscuit {
         &self.container
     }
@@ -546,6 +552,7 @@ impl Biscuit {
     }
 
     /// returns the number of blocks (at least 1)
+    #[must_use]
     pub fn block_count(&self) -> usize {
         1 + self.blocks.len()
     }

--- a/biscuit-auth/src/token/mod.rs
+++ b/biscuit-auth/src/token/mod.rs
@@ -164,12 +164,9 @@ impl Biscuit {
     /// can be stored
     #[must_use]
     pub fn context(&self) -> Vec<Option<String>> {
-        let mut res = vec![self.authority.context.clone()];
-
-        for b in self.blocks.iter() {
-            res.push(b.context.clone());
-        }
-
+        let mut res = Vec::with_capacity(1 + self.blocks.len());
+        res.push(self.authority.context.clone());
+        res.extend(self.blocks.iter().map(|b| b.context.clone()));
         res
     }
 
@@ -179,12 +176,14 @@ impl Biscuit {
     /// the same contents will have different revocation ids
     #[must_use]
     pub fn revocation_identifiers(&self) -> Vec<Vec<u8>> {
-        let mut res = vec![self.container.authority.signature.to_bytes().to_vec()];
-
-        for block in self.container.blocks.iter() {
-            res.push(block.signature.to_bytes().to_vec());
-        }
-
+        let mut res = Vec::with_capacity(1 + self.container.blocks.len());
+        res.push(self.container.authority.signature.to_bytes().to_vec());
+        res.extend(
+            self.container
+                .blocks
+                .iter()
+                .map(|b| b.signature.to_bytes().to_vec()),
+        );
         res
     }
 
@@ -195,17 +194,13 @@ impl Biscuit {
     /// the corresponding private key
     #[must_use]
     pub fn external_public_keys(&self) -> Vec<Option<Vec<u8>>> {
-        let mut res = vec![None];
-
-        for block in self.container.blocks.iter() {
-            res.push(
-                block
-                    .external_signature
-                    .as_ref()
-                    .map(|sig| sig.public_key.to_bytes().to_vec()),
-            );
-        }
-
+        let mut res = Vec::with_capacity(1 + self.container.blocks.len());
+        res.push(None);
+        res.extend(self.container.blocks.iter().map(|b| {
+            b.external_signature
+                .as_ref()
+                .map(|sig| sig.public_key.to_bytes().to_vec())
+        }));
         res
     }
 

--- a/biscuit-auth/src/token/unverified.rs
+++ b/biscuit-auth/src/token/unverified.rs
@@ -175,6 +175,7 @@ impl UnverifiedBiscuit {
     ///
     /// revocation identifiers are unique: tokens generated separately with
     /// the same contents will have different revocation ids
+    #[must_use]
     pub fn revocation_identifiers(&self) -> Vec<Vec<u8>> {
         let mut res = vec![self.container.authority.signature.to_bytes().to_vec()];
 
@@ -190,6 +191,7 @@ impl UnverifiedBiscuit {
     /// Blocks carrying an external public key are _third-party blocks_
     /// and their contents can be trusted as coming from the holder of
     /// the corresponding private key
+    #[must_use]
     pub fn external_public_keys(&self) -> Vec<Option<Vec<u8>>> {
         let mut res = vec![None];
 
@@ -206,6 +208,7 @@ impl UnverifiedBiscuit {
     }
 
     /// returns the number of blocks (at least 1)
+    #[must_use]
     pub fn block_count(&self) -> usize {
         1 + self.container.blocks.len()
     }

--- a/biscuit-auth/src/token/unverified.rs
+++ b/biscuit-auth/src/token/unverified.rs
@@ -177,12 +177,14 @@ impl UnverifiedBiscuit {
     /// the same contents will have different revocation ids
     #[must_use]
     pub fn revocation_identifiers(&self) -> Vec<Vec<u8>> {
-        let mut res = vec![self.container.authority.signature.to_bytes().to_vec()];
-
-        for block in self.container.blocks.iter() {
-            res.push(block.signature.to_bytes().to_vec());
-        }
-
+        let mut res = Vec::with_capacity(1 + self.container.blocks.len());
+        res.push(self.container.authority.signature.to_bytes().to_vec());
+        res.extend(
+            self.container
+                .blocks
+                .iter()
+                .map(|b| b.signature.to_bytes().to_vec()),
+        );
         res
     }
 
@@ -193,17 +195,13 @@ impl UnverifiedBiscuit {
     /// the corresponding private key
     #[must_use]
     pub fn external_public_keys(&self) -> Vec<Option<Vec<u8>>> {
-        let mut res = vec![None];
-
-        for block in self.container.blocks.iter() {
-            res.push(
-                block
-                    .external_signature
-                    .as_ref()
-                    .map(|sig| sig.public_key.to_bytes().to_vec()),
-            );
-        }
-
+        let mut res = Vec::with_capacity(1 + self.container.blocks.len());
+        res.push(None);
+        res.extend(self.container.blocks.iter().map(|b| {
+            b.external_signature
+                .as_ref()
+                .map(|sig| sig.public_key.to_bytes().to_vec())
+        }));
         res
     }
 

--- a/biscuit-parser/src/builder.rs
+++ b/biscuit-parser/src/builder.rs
@@ -269,6 +269,7 @@ pub struct Rule {
 }
 
 impl Rule {
+    #[must_use]
     pub fn new(
         head: Predicate,
         body: Vec<Predicate>,
@@ -487,11 +488,13 @@ pub fn check<P: AsRef<Predicate>>(predicates: &[P]) -> Check {
 }
 
 /// creates an integer value
+#[must_use]
 pub fn int(i: i64) -> Term {
     Term::Integer(i)
 }
 
 /// creates a string
+#[must_use]
 pub fn string(s: &str) -> Term {
     Term::Str(s.to_string())
 }
@@ -499,37 +502,44 @@ pub fn string(s: &str) -> Term {
 /// creates a date
 ///
 /// internally the date will be stored as seconds since UNIX_EPOCH
+#[must_use]
 pub fn date(t: &SystemTime) -> Term {
     let dur = t.duration_since(UNIX_EPOCH).unwrap();
     Term::Date(dur.as_secs())
 }
 
 /// creates a variable for a rule
+#[must_use]
 pub fn var(s: &str) -> Term {
     Term::Variable(s.to_string())
 }
 
 /// creates a variable for a rule
+#[must_use]
 pub fn variable(s: &str) -> Term {
     Term::Variable(s.to_string())
 }
 
 /// creates a byte array
+#[must_use]
 pub fn bytes(s: &[u8]) -> Term {
     Term::Bytes(s.to_vec())
 }
 
 /// creates a boolean
+#[must_use]
 pub fn boolean(b: bool) -> Term {
     Term::Bool(b)
 }
 
 /// creates a set
+#[must_use]
 pub fn set(s: BTreeSet<Term>) -> Term {
     Term::Set(s)
 }
 
 /// creates a parameter
+#[must_use]
 pub fn parameter(p: &str) -> Term {
     Term::Parameter(p.to_string())
 }

--- a/biscuit-parser/src/parser.rs
+++ b/biscuit-parser/src/parser.rs
@@ -381,6 +381,7 @@ pub enum Expr {
 }
 
 impl Expr {
+    #[must_use]
     pub fn opcodes(self) -> Vec<builder::Op> {
         let mut v = Vec::new();
         self.into_opcodes(&mut v);

--- a/biscuit-quote/src/lib.rs
+++ b/biscuit-quote/src/lib.rs
@@ -253,23 +253,26 @@ impl AuthorizerWithParams {
     ) -> std::result::Result<Self, error::LanguageError> {
         let input = source.as_ref();
         let source_result = parse_source(input)?;
-        let mut facts = Vec::new();
-        let mut rules = Vec::new();
-        let mut checks = Vec::new();
-        let mut policies = Vec::new();
-
-        for (_, fact) in source_result.facts.into_iter() {
-            facts.push(fact);
-        }
-        for (_, rule) in source_result.rules.into_iter() {
-            rules.push(rule);
-        }
-        for (_, check) in source_result.checks.into_iter() {
-            checks.push(check);
-        }
-        for (_, policy) in source_result.policies.into_iter() {
-            policies.push(policy);
-        }
+        let facts = source_result
+            .facts
+            .into_iter()
+            .map(|f| f.1)
+            .collect::<Vec<_>>();
+        let rules = source_result
+            .rules
+            .into_iter()
+            .map(|r| r.1)
+            .collect::<Vec<_>>();
+        let checks = source_result
+            .checks
+            .into_iter()
+            .map(|c| c.1)
+            .collect::<Vec<_>>();
+        let policies = source_result
+            .policies
+            .into_iter()
+            .map(|p| p.1)
+            .collect::<Vec<_>>();
 
         Ok(AuthorizerWithParams {
             facts,
@@ -444,19 +447,21 @@ impl BiscuitWithParams {
     ) -> std::result::Result<Self, error::LanguageError> {
         let input = source.as_ref();
         let source_result = parse_block_source(input)?;
-        let mut facts = Vec::new();
-        let mut rules = Vec::new();
-        let mut checks = Vec::new();
-
-        for (_, fact) in source_result.facts.into_iter() {
-            facts.push(fact);
-        }
-        for (_, rule) in source_result.rules.into_iter() {
-            rules.push(rule);
-        }
-        for (_, check) in source_result.checks.into_iter() {
-            checks.push(check);
-        }
+        let facts = source_result
+            .facts
+            .into_iter()
+            .map(|f| f.1)
+            .collect::<Vec<_>>();
+        let rules = source_result
+            .rules
+            .into_iter()
+            .map(|r| r.1)
+            .collect::<Vec<_>>();
+        let checks = source_result
+            .checks
+            .into_iter()
+            .map(|c| c.1)
+            .collect::<Vec<_>>();
 
         Ok(BiscuitWithParams {
             facts,


### PR DESCRIPTION
Was reading through the code base and made 2 fairly simple refactorings.

- Add `#[must_use]` to help identify when a return value is not being used
- Use `collect()`/`FromIterator` when building `Vec`s to initialize with a capacity and reduce reallocations