### PR TITLE
feat: Open the biscuit-auth::builder::Convert trait

### DIFF
--- a/biscuit-auth/src/token/builder.rs
+++ b/biscuit-auth/src/token/builder.rs
@@ -389,7 +389,7 @@ impl BiscuitBuilder {
     }
 }
 
-pub(crate) trait Convert<T>: Sized {
+pub trait Convert<T>: Sized {
     fn convert(&self, symbols: &mut SymbolTable) -> T;
     fn convert_from(f: &T, symbols: &SymbolTable) -> Result<Self, error::Format>;
 }


### PR DESCRIPTION
## Why
Allow to use the Convert trait outside the crate.

Like to serialiaze with protobuf, data coming from a datalog string
