### PR TITLE
feat(quote): allow appending to an existing builder

### DIFF
--- a/biscuit-auth/src/token/authorizer.rs
+++ b/biscuit-auth/src/token/authorizer.rs
@@ -260,8 +260,16 @@ impl<'t> Authorizer<'t> {
             */
     }
 
-    pub fn append(&mut self, other: BlockBuilder) {
-        self.authorizer_block_builder.append(other)
+    /// Add the rules, facts, checks, and policies of another `Authorizer`.
+    /// If a token has already been added to `other`, it is not merged into `self`.
+    pub fn merge(&mut self, mut other: Authorizer) {
+        self.merge_block(other.authorizer_block_builder);
+        self.policies.append(&mut other.policies);
+    }
+
+    /// Add the rules, facts, and checks of another `BlockBuilder`.
+    pub fn merge_block(&mut self, other: BlockBuilder) {
+        self.authorizer_block_builder.merge(other)
     }
 
     pub fn add_fact<F: TryInto<Fact>>(&mut self, fact: F) -> Result<(), error::Token>

--- a/biscuit-auth/src/token/authorizer.rs
+++ b/biscuit-auth/src/token/authorizer.rs
@@ -39,7 +39,7 @@ pub struct Authorizer<'t> {
 
 impl<'t> Authorizer<'t> {
     pub(crate) fn from_token(token: &'t Biscuit) -> Result<Self, error::Token> {
-        let mut v = Authorizer::new()?;
+        let mut v = Authorizer::new();
         v.add_token(token)?;
 
         Ok(v)
@@ -54,12 +54,12 @@ impl<'t> Authorizer<'t> {
     /// In the latter case, we can create an empty authorizer, load it
     /// with the facts, rules and checks, and each time a token must be checked,
     /// clone the authorizer and load the token with [`Authorizer::add_token`]
-    pub fn new() -> Result<Self, error::Logic> {
+    pub fn new() -> Self {
         let world = datalog::World::new();
         let symbols = super::default_symbol_table();
         let authorizer_block_builder = BlockBuilder::new();
 
-        Ok(Authorizer {
+        Authorizer {
             authorizer_block_builder,
             world,
             symbols,
@@ -68,7 +68,7 @@ impl<'t> Authorizer<'t> {
             token: None,
             blocks: vec![],
             public_key_to_block_id: HashMap::new(),
-        })
+        }
     }
 
     /// creates an `Authorizer` from a serialized [crate::format::schema::AuthorizerPolicies]
@@ -86,7 +86,7 @@ impl<'t> Authorizer<'t> {
             policies,
         } = crate::format::convert::proto_authorizer_to_authorizer(&data)?;
 
-        let mut authorizer = Self::new()?;
+        let mut authorizer = Self::new();
 
         for fact in facts {
             authorizer
@@ -292,7 +292,7 @@ impl<'t> Authorizer<'t> {
     ///
     /// use biscuit::Authorizer;
     ///
-    /// let mut authorizer = Authorizer::new().unwrap();
+    /// let mut authorizer = Authorizer::new();
     ///
     /// authorizer.add_code(r#"
     ///   resource("/file1.txt");
@@ -1164,14 +1164,14 @@ mod tests {
 
     #[test]
     fn empty_authorizer() {
-        let mut authorizer = Authorizer::new().unwrap();
+        let mut authorizer = Authorizer::new();
         authorizer.add_policy("allow if true").unwrap();
         assert_eq!(authorizer.authorize(), Ok(0));
     }
 
     #[test]
     fn parameter_substitution() {
-        let mut authorizer = Authorizer::new().unwrap();
+        let mut authorizer = Authorizer::new();
         let mut params = HashMap::new();
         params.insert("p1".to_string(), "value".into());
         params.insert("p2".to_string(), 0i64.into());
@@ -1201,7 +1201,7 @@ mod tests {
 
     #[test]
     fn forbid_unbound_parameters() {
-        let mut builder = Authorizer::new().unwrap();
+        let mut builder = Authorizer::new();
 
         let mut fact = Fact::try_from("fact({p1}, {p4})").unwrap();
         fact.set("p1", "hello").unwrap();
@@ -1259,7 +1259,7 @@ mod tests {
 
     #[test]
     fn forbid_unbound_parameters_in_add_code() {
-        let mut builder = Authorizer::new().unwrap();
+        let mut builder = Authorizer::new();
         let mut params = HashMap::new();
         params.insert("p1".to_string(), "hello".into());
         params.insert("p2".to_string(), 1i64.into());
@@ -1355,7 +1355,7 @@ mod tests {
         let res = req.create_block(&external.private(), builder).unwrap();
         let biscuit2 = biscuit1.append_third_party(external.public(), res).unwrap();
 
-        let mut authorizer = Authorizer::new().unwrap();
+        let mut authorizer = Authorizer::new();
         let external2 = KeyPair::new();
 
         let mut scope_params = HashMap::new();

--- a/biscuit-auth/src/token/builder.rs
+++ b/biscuit-auth/src/token/builder.rs
@@ -33,16 +33,11 @@ impl BlockBuilder {
         BlockBuilder::default()
     }
 
-    pub fn append(&mut self, other: BlockBuilder) {
-        for fact in other.facts {
-            self.facts.push(fact);
-        }
-        for rule in other.rules {
-            self.rules.push(rule);
-        }
-        for check in other.checks {
-            self.checks.push(check);
-        }
+    pub fn merge(&mut self, mut other: BlockBuilder) {
+        self.facts.append(&mut other.facts);
+        self.rules.append(&mut other.rules);
+        self.checks.append(&mut other.checks);
+
         if let Some(c) = other.context {
             self.set_context(c);
         }
@@ -285,8 +280,8 @@ impl BiscuitBuilder {
         }
     }
 
-    pub fn append(&mut self, other: BlockBuilder) {
-        self.inner.append(other)
+    pub fn merge(&mut self, other: BlockBuilder) {
+        self.inner.merge(other)
     }
 
     pub fn add_fact<F: TryInto<Fact>>(&mut self, fact: F) -> Result<(), error::Token>

--- a/biscuit-parser/Cargo.toml
+++ b/biscuit-parser/Cargo.toml
@@ -13,6 +13,7 @@ repository = "https://github.com/biscuit-auth/biscuit-rust"
 [dependencies]
 hex = "0.4.3"
 nom = "7.1.1"
+proc-macro2 = "1"
 quote = "1.0.21"
 serde = { version = "1.0.132", optional = true, features = ["derive"] }
 thiserror = "1.0.32"

--- a/biscuit-parser/src/builder.rs
+++ b/biscuit-parser/src/builder.rs
@@ -43,7 +43,7 @@ impl AsRef<Term> for Term {
 
 #[cfg(feature = "datalog-macro")]
 impl ToTokens for Term {
-    fn to_tokens(&self, tokens: &mut quote::__private::TokenStream) {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
         tokens.extend(match self {
             Term::Variable(v) => quote! { ::biscuit_auth::builder::Term::Variable(#v.to_string()) },
             Term::Integer(v) => quote! { ::biscuit_auth::builder::Term::Integer(#v) },
@@ -69,7 +69,7 @@ pub enum Scope {
 
 #[cfg(feature = "datalog-macro")]
 impl ToTokens for Scope {
-    fn to_tokens(&self, tokens: &mut quote::__private::TokenStream) {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
         tokens.extend(match self {
             Scope::Authority => quote! { ::biscuit_auth::builder::Scope::Authority},
             Scope::Previous => quote! { ::biscuit_auth::builder::Scope::Previous},
@@ -104,7 +104,7 @@ impl Predicate {
 
 #[cfg(feature = "datalog-macro")]
 impl ToTokens for Predicate {
-    fn to_tokens(&self, tokens: &mut quote::__private::TokenStream) {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
         let name = &self.name;
         let terms = self.terms.iter();
         tokens.extend(quote! {
@@ -142,7 +142,7 @@ impl Fact {
 
 #[cfg(feature = "datalog-macro")]
 impl ToTokens for Fact {
-    fn to_tokens(&self, tokens: &mut quote::__private::TokenStream) {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
         let name = &self.predicate.name;
         let terms = self.predicate.terms.iter();
         tokens.extend(quote! {
@@ -162,7 +162,7 @@ pub struct Expression {
 
 #[cfg(feature = "datalog-macro")]
 impl ToTokens for Expression {
-    fn to_tokens(&self, tokens: &mut quote::__private::TokenStream) {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
         let ops = self.ops.iter();
         tokens.extend(quote! {
           ::biscuit_auth::builder::Expression {
@@ -210,7 +210,7 @@ pub enum Binary {
 
 #[cfg(feature = "datalog-macro")]
 impl ToTokens for Op {
-    fn to_tokens(&self, tokens: &mut quote::__private::TokenStream) {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
         tokens.extend(match self {
             Op::Value(t) => quote! { ::biscuit_auth::builder::Op::Value(#t) },
             Op::Unary(u) => quote! { ::biscuit_auth::builder::Op::Unary(#u) },
@@ -221,7 +221,7 @@ impl ToTokens for Op {
 
 #[cfg(feature = "datalog-macro")]
 impl ToTokens for Unary {
-    fn to_tokens(&self, tokens: &mut quote::__private::TokenStream) {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
         tokens.extend(match self {
             Unary::Negate => quote! {::biscuit_auth::datalog::Unary::Negate },
             Unary::Parens => quote! {::biscuit_auth::datalog::Unary::Parens },
@@ -232,7 +232,7 @@ impl ToTokens for Unary {
 
 #[cfg(feature = "datalog-macro")]
 impl ToTokens for Binary {
-    fn to_tokens(&self, tokens: &mut quote::__private::TokenStream) {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
         tokens.extend(match self {
             Binary::LessThan => quote! { ::biscuit_auth::datalog::Binary::LessThan  },
             Binary::GreaterThan => quote! { ::biscuit_auth::datalog::Binary::GreaterThan  },
@@ -355,7 +355,7 @@ impl Rule {
 
 #[cfg(feature = "datalog-macro")]
 impl ToTokens for Rule {
-    fn to_tokens(&self, tokens: &mut quote::__private::TokenStream) {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
         let head = &self.head;
         let body = self.body.iter();
         let expressions = self.expressions.iter();
@@ -379,7 +379,7 @@ pub struct Check {
 
 #[cfg(feature = "datalog-macro")]
 impl ToTokens for Check {
-    fn to_tokens(&self, tokens: &mut quote::__private::TokenStream) {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
         let queries = self.queries.iter();
         tokens.extend(quote! {
           ::biscuit_auth::builder::Check {
@@ -397,7 +397,7 @@ pub enum PolicyKind {
 
 #[cfg(feature = "datalog-macro")]
 impl ToTokens for PolicyKind {
-    fn to_tokens(&self, tokens: &mut quote::__private::TokenStream) {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
         tokens.extend(match self {
             PolicyKind::Allow => quote! {
               ::biscuit_auth::builder::PolicyKind::Allow
@@ -418,7 +418,7 @@ pub struct Policy {
 
 #[cfg(feature = "datalog-macro")]
 impl ToTokens for Policy {
-    fn to_tokens(&self, tokens: &mut quote::__private::TokenStream) {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
         let queries = self.queries.iter();
         let kind = &self.kind;
         tokens.extend(quote! {

--- a/biscuit-quote/Cargo.toml
+++ b/biscuit-quote/Cargo.toml
@@ -11,6 +11,7 @@ proc-macro = true
 
 [dependencies]
 biscuit-parser = { path = "../biscuit-parser", features = ["datalog-macro"], version = "0.1.0-alpha2" }
+proc-macro2 = "1"
 quote = "1.0.14"
 syn = { version = "1.0.85", features = ["full", "extra-traits"] }
 proc-macro-error = "1.0"

--- a/biscuit-quote/src/lib.rs
+++ b/biscuit-quote/src/lib.rs
@@ -39,14 +39,12 @@
 //! )).expect("Failed to authorize biscuit");
 //! ```
 
-extern crate proc_macro;
-extern crate proc_macro_error;
 use biscuit_parser::{
     builder::{Check, Fact, Policy, Rule},
     error,
     parser::{parse_block_source, parse_source},
 };
-use proc_macro::TokenStream;
+use proc_macro2::TokenStream;
 use proc_macro_error::{abort_call_site, proc_macro_error};
 use quote::{quote, ToTokens};
 use std::collections::{HashMap, HashSet};
@@ -140,7 +138,7 @@ impl Parse for ParsedMerge {
 /// ```
 #[proc_macro]
 #[proc_macro_error]
-pub fn block(input: TokenStream) -> TokenStream {
+pub fn block(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let ParsedCreateNew {
         datalog,
         parameters,
@@ -177,7 +175,7 @@ pub fn block(input: TokenStream) -> TokenStream {
 /// ```
 #[proc_macro]
 #[proc_macro_error]
-pub fn block_merge(input: TokenStream) -> TokenStream {
+pub fn block_merge(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let ParsedMerge {
         target,
         datalog,
@@ -209,7 +207,7 @@ pub fn block_merge(input: TokenStream) -> TokenStream {
 /// ```
 #[proc_macro]
 #[proc_macro_error]
-pub fn authorizer(input: TokenStream) -> TokenStream {
+pub fn authorizer(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let ParsedCreateNew {
         datalog,
         parameters,
@@ -246,7 +244,7 @@ pub fn authorizer(input: TokenStream) -> TokenStream {
 /// ```
 #[proc_macro]
 #[proc_macro_error]
-pub fn authorizer_merge(input: TokenStream) -> TokenStream {
+pub fn authorizer_merge(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let ParsedMerge {
         target,
         datalog,
@@ -281,7 +279,7 @@ pub fn authorizer_merge(input: TokenStream) -> TokenStream {
 /// ```
 #[proc_macro]
 #[proc_macro_error]
-pub fn biscuit(input: TokenStream) -> TokenStream {
+pub fn biscuit(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let ParsedCreateNew {
         datalog,
         parameters,
@@ -324,7 +322,7 @@ pub fn biscuit(input: TokenStream) -> TokenStream {
 /// ```
 #[proc_macro]
 #[proc_macro_error]
-pub fn biscuit_merge(input: TokenStream) -> TokenStream {
+pub fn biscuit_merge(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let ParsedMerge {
         target,
         datalog,
@@ -378,7 +376,7 @@ impl Builder {
         }
     }
 
-    pub fn block_source<T: AsRef<str>>(
+    fn block_source<T: AsRef<str>>(
         builder_type: TypePath,
         target: Option<Expr>,
         source: T,
@@ -395,7 +393,7 @@ impl Builder {
         Ok(builder)
     }
 
-    pub fn source<T: AsRef<str>>(
+    fn source<T: AsRef<str>>(
         builder_type: TypePath,
         target: Option<Expr>,
         source: T,
@@ -480,7 +478,7 @@ impl Builder {
 }
 
 impl ToTokens for Builder {
-    fn to_tokens(&self, tokens: &mut quote::__private::TokenStream) {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
         let (param_names, param_values): (Vec<String>, Vec<Expr>) =
             self.parameters.clone().into_iter().unzip();
 

--- a/biscuit-quote/tests/simple_test.rs
+++ b/biscuit-quote/tests/simple_test.rs
@@ -34,8 +34,9 @@ fn block_macro_trailing_comma() {
 
 #[test]
 fn authorizer_macro() {
+    let external_key = "test";
     let mut b = authorizer!(
-        r#"fact("test", hex:aabbcc, [ true], {my_key});
+        r#"fact({external_key}, hex:aabbcc, [ true], {my_key});
         rule($0, true) <- fact($0, $1, $2, {my_key});
         check if {my_key}.starts_with("my");
         allow if {other_key};
@@ -81,13 +82,15 @@ fn biscuit_macro() {
     )
     .unwrap();
 
+    let s = String::from("my_value");
     let mut b = biscuit!(
-        r#"fact("test", hex:aabbcc, [ true], {my_key});
-        rule($0, true) <- fact($0, $1, $2, {my_key});
+        r#"fact("test", hex:aabbcc, [ true], {my_key}, {my_key_bytes});
+        rule($0, true) <- fact($0, $1, $2, {my_key}, {my_key_bytes});
         check if {my_key}.starts_with("my") trusting {pubkey};
         check if true trusting ed25519/6e9e6d5a75cf0c0e87ec1256b4dfed0ca3ba452912d213fcc70f8516583db9db;
         "#,
         my_key = "my_value",
+        my_key_bytes = s.into_bytes(),
         pubkey = pubkey,
     );
 
@@ -100,9 +103,9 @@ fn biscuit_macro() {
 
     assert_eq!(
         b.dump_code(),
-        r#"fact("test", hex:aabbcc, [ true], "my_value");
+        r#"fact("test", hex:aabbcc, [ true], "my_value", hex:6d795f76616c7565);
 appended(true);
-rule($0, true) <- fact($0, $1, $2, "my_value");
+rule($0, true) <- fact($0, $1, $2, "my_value", hex:6d795f76616c7565);
 check if "my_value".starts_with("my") trusting ed25519/6e9e6d5a75cf0c0e87ec1256b4dfed0ca3ba452912d213fcc70f8516583db9db;
 check if true trusting ed25519/6e9e6d5a75cf0c0e87ec1256b4dfed0ca3ba452912d213fcc70f8516583db9db;
 check if true;

--- a/biscuit-quote/tests/simple_test.rs
+++ b/biscuit-quote/tests/simple_test.rs
@@ -1,19 +1,21 @@
-//extern crate biscuit_auth;
-extern crate biscuit_quote;
-use biscuit_quote::{authorizer, biscuit, block};
+use biscuit_quote::{authorizer, authorizer_merge, biscuit, biscuit_merge, block, block_merge};
 
 #[test]
 fn block_macro() {
-    let b = block!(
+    let mut b = block!(
         r#"fact("test", hex:aabbcc, [true], {my_key});
             rule($0, true) <- fact($0, $1, $2, {my_key});
             check if {my_key}.starts_with("my");
             "#,
         my_key = "my_value",
     );
+
+    block_merge!(&mut b, r#"appended(true);"#);
+
     assert_eq!(
         b.to_string(),
         r#"fact("test", hex:aabbcc, [ true], "my_value");
+appended(true);
 rule($0, true) <- fact($0, $1, $2, "my_value");
 check if "my_value".starts_with("my");
 "#,
@@ -32,7 +34,7 @@ fn block_macro_trailing_comma() {
 
 #[test]
 fn authorizer_macro() {
-    let b = authorizer!(
+    let mut b = authorizer!(
         r#"fact("test", hex:aabbcc, [ true], {my_key});
         rule($0, true) <- fact($0, $1, $2, {my_key});
         check if {my_key}.starts_with("my");
@@ -41,22 +43,32 @@ fn authorizer_macro() {
         my_key = "my_value",
         other_key = false,
     );
+
+    authorizer_merge!(
+        &mut b,
+        r#"appended(true);
+        allow if true;
+      "#
+    );
+
     assert_eq!(
         b.dump_code(),
         r#"fact("test", hex:aabbcc, [ true], "my_value");
+appended(true);
 rule($0, true) <- fact($0, $1, $2, "my_value");
 check if "my_value".starts_with("my");
 allow if false;
+allow if true;
 "#,
     );
 }
 
 #[test]
 fn authorizer_macro_trailing_comma() {
-    let b = authorizer!(r#"fact("test");"#, my_key = "my_value",);
+    let b = authorizer!(r#"fact("test", {my_key});"#, my_key = "my_value",);
     assert_eq!(
         b.dump_code(),
-        r#"fact("test");
+        r#"fact("test", "my_value");
 "#,
     );
 }
@@ -69,32 +81,41 @@ fn biscuit_macro() {
     )
     .unwrap();
 
-    let b = biscuit!(
+    let mut b = biscuit!(
         r#"fact("test", hex:aabbcc, [ true], {my_key});
         rule($0, true) <- fact($0, $1, $2, {my_key});
         check if {my_key}.starts_with("my") trusting {pubkey};
         check if true trusting ed25519/6e9e6d5a75cf0c0e87ec1256b4dfed0ca3ba452912d213fcc70f8516583db9db;
         "#,
         my_key = "my_value",
-        other_key = false,
         pubkey = pubkey,
     );
+
+    biscuit_merge!(
+        &mut b,
+        r#"appended(true);
+        check if true;
+      "#
+    );
+
     assert_eq!(
         b.dump_code(),
         r#"fact("test", hex:aabbcc, [ true], "my_value");
+appended(true);
 rule($0, true) <- fact($0, $1, $2, "my_value");
 check if "my_value".starts_with("my") trusting ed25519/6e9e6d5a75cf0c0e87ec1256b4dfed0ca3ba452912d213fcc70f8516583db9db;
 check if true trusting ed25519/6e9e6d5a75cf0c0e87ec1256b4dfed0ca3ba452912d213fcc70f8516583db9db;
+check if true;
 "#,
     );
 }
 
 #[test]
 fn biscuit_macro_trailing_comma() {
-    let b = biscuit!(r#"fact("test");"#, my_key = "my_value",);
+    let b = biscuit!(r#"fact("test", {my_key});"#, my_key = "my_value",);
     assert_eq!(
         b.dump_code(),
-        r#"fact("test");
+        r#"fact("test", "my_value");
 "#,
     );
 }


### PR DESCRIPTION
This PR alters the biscuit-quote macros to support *appending* to existing builders, instead of creating new ones. The goal is to allow composition of facts and checks, instead of having to create the entire biscuit in one place.

It is currently possible to sort-of append biscuit builders, by using the `block!` macro and appending that to a `BiscuitBuilder`, but that causes avoidable allocations, and doesn't parse policies. With this PR,

```rust
b.append(block!(
  r#"
    fact(42);
  "#
));
```

becomes

```rust
biscuit!(
  &mut b,
  r#"
    fact(42);
  "#
);
```

- The macros evaluate to values of different types now, depending on if the caller passes a builder. With a builder it returns a `&mut B`, but a `B` without it.
- Distinguishing between clean creation and appending by looking at the first token type feels a bit wrong.
  - I didn't want to have duplicate versions of all three macros for appending.
  - Is there a better syntax?
- The implementation in `ParsedQuery` and `ParsedBiscuitQuery` is duplicated, and should probably be merged into one. I left it as-is for the moment, in case you want to evolve the syntax of them in different directions, but would be happy to adjust the PR to eliminate one of them.