### PR TITLE
feat: support UUIDs as params

### DIFF
--- a/biscuit-auth/Cargo.toml
+++ b/biscuit-auth/Cargo.toml
@@ -21,6 +21,7 @@ serde-error = ["serde", "biscuit-parser/serde-error"]
 # used by biscuit-quote to parse datalog at compile-time
 datalog-macro = ["biscuit-quote"]
 docsrs = []
+uuid = ["dep:uuid"]
 
 [dependencies]
 rand_core = "^0.5"
@@ -39,7 +40,8 @@ base64 = "0.13.0"
 ed25519-dalek = "1.0.1"
 serde = { version = "1.0.132", optional = true, features = ["derive"] }
 getrandom = { version = "0.1.16" }
-time = {version = "0.3.7", features = ["formatting", "parsing"]}
+time = { version = "0.3.7", features = ["formatting", "parsing"] }
+uuid = { version = "1", optional = true }
 biscuit-parser = { version = "0.1.0-alpha2", path = "../biscuit-parser" }
 biscuit-quote = { version = "0.2.0-alpha2", optional = true, path = "../biscuit-quote" }
 

--- a/biscuit-auth/src/token/builder.rs
+++ b/biscuit-auth/src/token/builder.rs
@@ -1951,6 +1951,13 @@ impl ToAnyParam for [u8] {
     }
 }
 
+#[cfg(feature = "uuid")]
+impl ToAnyParam for uuid::Uuid {
+    fn to_any_param(&self) -> AnyParam {
+        AnyParam::Term(Term::Bytes(self.as_bytes().to_vec()))
+    }
+}
+
 impl From<SystemTime> for Term {
     fn from(t: SystemTime) -> Self {
         let dur = t.duration_since(UNIX_EPOCH).unwrap();


### PR DESCRIPTION
Our application uses UUIDs instead of sequential integers as keys, and with the `biscuit-quote` macros it would be an improvement in readability if no manual conversion were necessary:

```rust
biscuit!(
  r#"
    some:id({id});
  "#,
  id = some.id.as_bytes().to_vec(),
  // becomes
  id = some.id,
)
```

Clearly, adding `ToAnyParam` impls for every type that users might want to use is unrealistic. But perhaps Uuids are widespread enough to warrant inclusion.

Is there a way to allow external conversion impls without wrapper types?
 
<details>
  <summary>Technically possible, but really bad idea</summary>


  ```rust
enum AnyParam {
    Bytes(Vec<u8>)
}

trait ToAnyParam {
    fn to_any_param(&self) -> AnyParam;
}

impl ToAnyParam for Vec<u8> {
    fn to_any_param(&self) -> AnyParam { AnyParam::Bytes(self.clone()) }
}

trait SeparateAnyParam {
    fn to_any_param(&self) -> AnyParam;
}

impl SeparateAnyParam for uuid::Uuid {
    fn to_any_param(&self) -> AnyParam { AnyParam::Bytes(self.as_bytes().to_vec()) }
}

fn foo() {
    let b = vec![1, 2, 3].to_any_param();

    // with a macro, we don't *have* to use trait constraints
    // (although we usually should, for error messages)
    let u = uuid::Uuid::new_v4().to_any_param();
}
```
</details>