### PR TITLE
remove the token reference from the authorizer

### DIFF
--- a/biscuit-auth/cbindgen.toml
+++ b/biscuit-auth/cbindgen.toml
@@ -5,7 +5,7 @@ language = "C"
 # An optional string of text to output at the beginning of the generated file
 # default: doesn't emit anything
 header = '''/*
- * Copyright 2020 Clever Cloud
+ * Copyright 2020 Clever Cloud, 2021 Geoffroy Couprie
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/biscuit-auth/samples/README.md
+++ b/biscuit-auth/samples/README.md
@@ -51,7 +51,9 @@ World {
     "right(\"file2\", \"read\")",
 }
   rules: {}
-  checks: {}
+  checks: {
+    "check if resource($0), operation(\"read\"), right($0, \"read\")",
+}
   policies: {
     "allow if true",
 }
@@ -280,7 +282,9 @@ World {
   rules: {
     "right($0, \"read\") <- resource($0), user_id($1), owner($1, $0)",
 }
-  checks: {}
+  checks: {
+    "check if resource($0), operation(\"read\"), right($0, \"read\")",
+}
   policies: {
     "allow if true",
 }
@@ -347,7 +351,9 @@ World {
     "right(\"file2\", \"read\")",
 }
   rules: {}
-  checks: {}
+  checks: {
+    "check if resource($0), operation(\"read\"), right($0, \"read\")",
+}
   policies: {
     "allow if true",
 }
@@ -404,7 +410,10 @@ World {
     "time(2020-12-21T09:23:12Z)",
 }
   rules: {}
-  checks: {}
+  checks: {
+    "check if resource(\"file1\")",
+    "check if time($time), $time <= 2018-12-20T00:00:00Z",
+}
   policies: {
     "allow if true",
 }
@@ -560,7 +569,9 @@ World {
     "resource(\"file1\")",
 }
   rules: {}
-  checks: {}
+  checks: {
+    "check if resource(\"file1\")",
+}
   policies: {
     "allow if true",
 }
@@ -589,7 +600,9 @@ World {
     "resource(\"file2\")",
 }
   rules: {}
-  checks: {}
+  checks: {
+    "check if resource(\"file1\")",
+}
   policies: {
     "allow if true",
 }
@@ -653,7 +666,9 @@ World {
     "valid_date(\"file1\") <- time($0), resource(\"file1\"), $0 <= 2030-12-31T12:59:59Z",
     "valid_date($1) <- time($0), resource($1), $0 <= 1999-12-31T12:59:59Z, ![\"file1\"].contains($1)",
 }
-  checks: {}
+  checks: {
+    "check if valid_date($0), resource($0)",
+}
   policies: {
     "allow if true",
 }
@@ -688,7 +703,9 @@ World {
     "valid_date(\"file1\") <- time($0), resource(\"file1\"), $0 <= 2030-12-31T12:59:59Z",
     "valid_date($1) <- time($0), resource($1), $0 <= 1999-12-31T12:59:59Z, ![\"file1\"].contains($1)",
 }
-  checks: {}
+  checks: {
+    "check if valid_date($0), resource($0)",
+}
   policies: {
     "allow if true",
 }
@@ -731,7 +748,9 @@ World {
     "resource(\"file1\")",
 }
   rules: {}
-  checks: {}
+  checks: {
+    "check if resource($0), $0.matches(\"file[0-9]+.txt\")",
+}
   policies: {
     "allow if true",
 }
@@ -758,7 +777,9 @@ World {
     "resource(\"file123.txt\")",
 }
   rules: {}
-  checks: {}
+  checks: {
+    "check if resource($0), $0.matches(\"file[0-9]+.txt\")",
+}
   policies: {
     "allow if true",
 }
@@ -854,7 +875,9 @@ World {
     "query(\"test\")",
 }
   rules: {}
-  checks: {}
+  checks: {
+    "check if resource(\"hello\")",
+}
   policies: {
     "allow if true",
 }
@@ -924,7 +947,39 @@ authorizer world:
 World {
   facts: {}
   rules: {}
-  checks: {}
+  checks: {
+    "check if !false",
+    "check if !false && true",
+    "check if \"aaabde\" == \"aaa\" + \"b\" + \"de\"",
+    "check if \"aaabde\".contains(\"abd\")",
+    "check if \"aaabde\".matches(\"a*c?.e\")",
+    "check if \"abcD12\" == \"abcD12\"",
+    "check if \"hello world\".starts_with(\"hello\") && \"hello world\".ends_with(\"world\")",
+    "check if (true || false) && true",
+    "check if 1 + 2 * 3 - 4 / 2 == 5",
+    "check if 1 < 2",
+    "check if 1 <= 1",
+    "check if 1 <= 2",
+    "check if 1 | 2 ^ 3 == 0",
+    "check if 2 > 1",
+    "check if 2 >= 1",
+    "check if 2 >= 2",
+    "check if 2019-12-04T09:46:41Z < 2020-12-04T09:46:41Z",
+    "check if 2019-12-04T09:46:41Z <= 2020-12-04T09:46:41Z",
+    "check if 2020-12-04T09:46:41Z == 2020-12-04T09:46:41Z",
+    "check if 2020-12-04T09:46:41Z > 2019-12-04T09:46:41Z",
+    "check if 2020-12-04T09:46:41Z >= 2019-12-04T09:46:41Z",
+    "check if 2020-12-04T09:46:41Z >= 2020-12-04T09:46:41Z",
+    "check if 3 == 3",
+    "check if [\"abc\", \"def\"].contains(\"abc\")",
+    "check if [1, 2].contains(2)",
+    "check if [2019-12-04T09:46:41Z, 2020-12-04T09:46:41Z].contains(2020-12-04T09:46:41Z)",
+    "check if [false, true].contains(true)",
+    "check if [hex:12ab, hex:34de].contains(hex:34de)",
+    "check if false or true",
+    "check if hex:12ab == hex:12ab",
+    "check if true",
+}
   policies: {
     "allow if true",
 }
@@ -1008,7 +1063,9 @@ World {
   rules: {
     "operation(\"read\") <- operation($any)",
 }
-  checks: {}
+  checks: {
+    "check if operation(\"read\")",
+}
   policies: {
     "allow if true",
 }
@@ -1068,7 +1125,9 @@ World {
     "right(\"file2\", \"read\")",
 }
   rules: {}
-  checks: {}
+  checks: {
+    "check if resource($0), operation(\"read\"), right($0, \"read\")",
+}
   policies: {
     "allow if true",
 }
@@ -1275,7 +1334,10 @@ World {
     "block1_fact(1)",
 }
   rules: {}
-  checks: {}
+  checks: {
+    "check if authority_fact($var)",
+    "check if block1_fact($var)",
+}
   policies: {
     "allow if true",
 }
@@ -1331,7 +1393,10 @@ World {
     "right(\"read\")",
 }
   rules: {}
-  checks: {}
+  checks: {
+    "check if group(\"admin\") trusting ed25519/a424157b8c00c25214ea39894bf395650d88426147679a9dd43a64d65ae5bc25",
+    "check if right(\"read\")",
+}
   policies: {
     "allow if true",
 }
@@ -1378,7 +1443,9 @@ World {
     "operation(\"B\")",
 }
   rules: {}
-  checks: {}
+  checks: {
+    "check all operation($op), allowed_operations($allowed), $allowed.contains($op)",
+}
   policies: {
     "allow if true",
 }
@@ -1408,7 +1475,9 @@ World {
     "operation(\"invalid\")",
 }
   rules: {}
-  checks: {}
+  checks: {
+    "check all operation($op), allowed_operations($allowed), $allowed.contains($op)",
+}
   policies: {
     "allow if true",
 }
@@ -1518,7 +1587,12 @@ World {
     "query(1, 2) <- query(1), query(2) trusting ed25519/ecfb8ed11fd9e6be133ca4dd8d229d39c7dcb2d659704c39e82fd7acf0d12dee",
 }
   checks: {
+    "check if query(1) trusting ed25519/3c8aeced6363b8a862552fb2b0b4b8b0f8244e8cef3c11c3e55fd553f3a90f59",
     "check if query(1, 2) trusting ed25519/3c8aeced6363b8a862552fb2b0b4b8b0f8244e8cef3c11c3e55fd553f3a90f59, ed25519/ecfb8ed11fd9e6be133ca4dd8d229d39c7dcb2d659704c39e82fd7acf0d12dee",
+    "check if query(2) trusting ed25519/ecfb8ed11fd9e6be133ca4dd8d229d39c7dcb2d659704c39e82fd7acf0d12dee",
+    "check if query(2), query(3) trusting ed25519/ecfb8ed11fd9e6be133ca4dd8d229d39c7dcb2d659704c39e82fd7acf0d12dee",
+    "check if query(4) trusting ed25519/2e0118e63beb7731dab5119280ddb117234d0cdc41b7dd5dc4241bcbbb585d14",
+    "check if true trusting previous, ed25519/3c8aeced6363b8a862552fb2b0b4b8b0f8244e8cef3c11c3e55fd553f3a90f59",
 }
   policies: {
     "allow if true",

--- a/biscuit-auth/samples/samples.json
+++ b/biscuit-auth/samples/samples.json
@@ -34,7 +34,9 @@
               "right(\"file2\", \"read\")"
             ],
             "rules": [],
-            "checks": [],
+            "checks": [
+              "check if resource($0), operation(\"read\"), right($0, \"read\")"
+            ],
             "policies": [
               "allow if true"
             ]
@@ -310,7 +312,9 @@
             "rules": [
               "right($0, \"read\") <- resource($0), user_id($1), owner($1, $0)"
             ],
-            "checks": [],
+            "checks": [
+              "check if resource($0), operation(\"read\"), right($0, \"read\")"
+            ],
             "policies": [
               "allow if true"
             ]
@@ -383,7 +387,9 @@
               "right(\"file2\", \"read\")"
             ],
             "rules": [],
-            "checks": [],
+            "checks": [
+              "check if resource($0), operation(\"read\"), right($0, \"read\")"
+            ],
             "policies": [
               "allow if true"
             ]
@@ -446,7 +452,10 @@
               "time(2020-12-21T09:23:12Z)"
             ],
             "rules": [],
-            "checks": [],
+            "checks": [
+              "check if resource(\"file1\")",
+              "check if time($time), $time <= 2018-12-20T00:00:00Z"
+            ],
             "policies": [
               "allow if true"
             ]
@@ -620,7 +629,9 @@
               "resource(\"file1\")"
             ],
             "rules": [],
-            "checks": [],
+            "checks": [
+              "check if resource(\"file1\")"
+            ],
             "policies": [
               "allow if true"
             ]
@@ -640,7 +651,9 @@
               "resource(\"file2\")"
             ],
             "rules": [],
-            "checks": [],
+            "checks": [
+              "check if resource(\"file1\")"
+            ],
             "policies": [
               "allow if true"
             ]
@@ -710,7 +723,9 @@
               "valid_date(\"file1\") <- time($0), resource(\"file1\"), $0 <= 2030-12-31T12:59:59Z",
               "valid_date($1) <- time($0), resource($1), $0 <= 1999-12-31T12:59:59Z, ![\"file1\"].contains($1)"
             ],
-            "checks": [],
+            "checks": [
+              "check if valid_date($0), resource($0)"
+            ],
             "policies": [
               "allow if true"
             ]
@@ -736,7 +751,9 @@
               "valid_date(\"file1\") <- time($0), resource(\"file1\"), $0 <= 2030-12-31T12:59:59Z",
               "valid_date($1) <- time($0), resource($1), $0 <= 1999-12-31T12:59:59Z, ![\"file1\"].contains($1)"
             ],
-            "checks": [],
+            "checks": [
+              "check if valid_date($0), resource($0)"
+            ],
             "policies": [
               "allow if true"
             ]
@@ -790,7 +807,9 @@
               "resource(\"file1\")"
             ],
             "rules": [],
-            "checks": [],
+            "checks": [
+              "check if resource($0), $0.matches(\"file[0-9]+.txt\")"
+            ],
             "policies": [
               "allow if true"
             ]
@@ -826,7 +845,9 @@
               "resource(\"file123.txt\")"
             ],
             "rules": [],
-            "checks": [],
+            "checks": [
+              "check if resource($0), $0.matches(\"file[0-9]+.txt\")"
+            ],
             "policies": [
               "allow if true"
             ]
@@ -907,7 +928,9 @@
               "query(\"test\")"
             ],
             "rules": [],
-            "checks": [],
+            "checks": [
+              "check if resource(\"hello\")"
+            ],
             "policies": [
               "allow if true"
             ]
@@ -969,7 +992,39 @@
           "world": {
             "facts": [],
             "rules": [],
-            "checks": [],
+            "checks": [
+              "check if !false",
+              "check if !false && true",
+              "check if \"aaabde\" == \"aaa\" + \"b\" + \"de\"",
+              "check if \"aaabde\".contains(\"abd\")",
+              "check if \"aaabde\".matches(\"a*c?.e\")",
+              "check if \"abcD12\" == \"abcD12\"",
+              "check if \"hello world\".starts_with(\"hello\") && \"hello world\".ends_with(\"world\")",
+              "check if (true || false) && true",
+              "check if 1 + 2 * 3 - 4 / 2 == 5",
+              "check if 1 < 2",
+              "check if 1 <= 1",
+              "check if 1 <= 2",
+              "check if 1 | 2 ^ 3 == 0",
+              "check if 2 > 1",
+              "check if 2 >= 1",
+              "check if 2 >= 2",
+              "check if 2019-12-04T09:46:41Z < 2020-12-04T09:46:41Z",
+              "check if 2019-12-04T09:46:41Z <= 2020-12-04T09:46:41Z",
+              "check if 2020-12-04T09:46:41Z == 2020-12-04T09:46:41Z",
+              "check if 2020-12-04T09:46:41Z > 2019-12-04T09:46:41Z",
+              "check if 2020-12-04T09:46:41Z >= 2019-12-04T09:46:41Z",
+              "check if 2020-12-04T09:46:41Z >= 2020-12-04T09:46:41Z",
+              "check if 3 == 3",
+              "check if [\"abc\", \"def\"].contains(\"abc\")",
+              "check if [1, 2].contains(2)",
+              "check if [2019-12-04T09:46:41Z, 2020-12-04T09:46:41Z].contains(2020-12-04T09:46:41Z)",
+              "check if [false, true].contains(true)",
+              "check if [hex:12ab, hex:34de].contains(hex:34de)",
+              "check if false or true",
+              "check if hex:12ab == hex:12ab",
+              "check if true"
+            ],
             "policies": [
               "allow if true"
             ]
@@ -1055,7 +1110,9 @@
             "rules": [
               "operation(\"read\") <- operation($any)"
             ],
-            "checks": [],
+            "checks": [
+              "check if operation(\"read\")"
+            ],
             "policies": [
               "allow if true"
             ]
@@ -1121,7 +1178,9 @@
               "right(\"file2\", \"read\")"
             ],
             "rules": [],
-            "checks": [],
+            "checks": [
+              "check if resource($0), operation(\"read\"), right($0, \"read\")"
+            ],
             "policies": [
               "allow if true"
             ]
@@ -1274,7 +1333,10 @@
               "block1_fact(1)"
             ],
             "rules": [],
-            "checks": [],
+            "checks": [
+              "check if authority_fact($var)",
+              "check if block1_fact($var)"
+            ],
             "policies": [
               "allow if true"
             ]
@@ -1335,7 +1397,10 @@
               "right(\"read\")"
             ],
             "rules": [],
-            "checks": [],
+            "checks": [
+              "check if group(\"admin\") trusting ed25519/a424157b8c00c25214ea39894bf395650d88426147679a9dd43a64d65ae5bc25",
+              "check if right(\"read\")"
+            ],
             "policies": [
               "allow if true"
             ]
@@ -1377,7 +1442,9 @@
               "operation(\"B\")"
             ],
             "rules": [],
-            "checks": [],
+            "checks": [
+              "check all operation($op), allowed_operations($allowed), $allowed.contains($op)"
+            ],
             "policies": [
               "allow if true"
             ]
@@ -1398,7 +1465,9 @@
               "operation(\"invalid\")"
             ],
             "rules": [],
-            "checks": [],
+            "checks": [
+              "check all operation($op), allowed_operations($allowed), $allowed.contains($op)"
+            ],
             "policies": [
               "allow if true"
             ]
@@ -1486,7 +1555,12 @@
               "query(1, 2) <- query(1), query(2) trusting ed25519/ecfb8ed11fd9e6be133ca4dd8d229d39c7dcb2d659704c39e82fd7acf0d12dee"
             ],
             "checks": [
-              "check if query(1, 2) trusting ed25519/3c8aeced6363b8a862552fb2b0b4b8b0f8244e8cef3c11c3e55fd553f3a90f59, ed25519/ecfb8ed11fd9e6be133ca4dd8d229d39c7dcb2d659704c39e82fd7acf0d12dee"
+              "check if query(1) trusting ed25519/3c8aeced6363b8a862552fb2b0b4b8b0f8244e8cef3c11c3e55fd553f3a90f59",
+              "check if query(1, 2) trusting ed25519/3c8aeced6363b8a862552fb2b0b4b8b0f8244e8cef3c11c3e55fd553f3a90f59, ed25519/ecfb8ed11fd9e6be133ca4dd8d229d39c7dcb2d659704c39e82fd7acf0d12dee",
+              "check if query(2) trusting ed25519/ecfb8ed11fd9e6be133ca4dd8d229d39c7dcb2d659704c39e82fd7acf0d12dee",
+              "check if query(2), query(3) trusting ed25519/ecfb8ed11fd9e6be133ca4dd8d229d39c7dcb2d659704c39e82fd7acf0d12dee",
+              "check if query(4) trusting ed25519/2e0118e63beb7731dab5119280ddb117234d0cdc41b7dd5dc4241bcbbb585d14",
+              "check if true trusting previous, ed25519/3c8aeced6363b8a862552fb2b0b4b8b0f8244e8cef3c11c3e55fd553f3a90f59"
             ],
             "policies": [
               "allow if true",

--- a/biscuit-auth/src/capi.rs
+++ b/biscuit-auth/src/capi.rs
@@ -291,7 +291,7 @@ pub struct KeyPair(crate::crypto::KeyPair);
 pub struct PublicKey(crate::crypto::PublicKey);
 pub struct BiscuitBuilder(crate::token::builder::BiscuitBuilder);
 pub struct BlockBuilder(crate::token::builder::BlockBuilder);
-pub struct Authorizer<'t>(crate::token::authorizer::Authorizer<'t>);
+pub struct Authorizer(crate::token::authorizer::Authorizer);
 
 #[no_mangle]
 pub unsafe extern "C" fn key_pair_new<'a>(
@@ -950,9 +950,9 @@ pub unsafe extern "C" fn biscuit_append_block(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn biscuit_authorizer<'a, 'b>(
+pub unsafe extern "C" fn biscuit_authorizer<'a>(
     biscuit: Option<&'a Biscuit>,
-) -> Option<Box<Authorizer<'a>>> {
+) -> Option<Box<Authorizer>> {
     if biscuit.is_none() {
         update_last_error(Error::InvalidArgument);
     }

--- a/biscuit-auth/tests/capi.rs
+++ b/biscuit-auth/tests/capi.rs
@@ -129,6 +129,7 @@ World {
   rules: {}
   checks: [
     "Authorizer[0]: check if right(\"efgh\")",
+    "Block[1][0]: check if operation(\"read\")",
 ]
   policies: [
     "allow if true",


### PR DESCRIPTION
this was done originally to avoid copies, but is less useful now that the symbols need to be converted