### PR TITLE
rewrite Authorizer::print_world to generate code

### DIFF
--- a/biscuit-auth/src/datalog/origin.rs
+++ b/biscuit-auth/src/datalog/origin.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeSet;
 use std::collections::HashMap;
+use std::fmt::Display;
 use std::hash::Hash;
 use std::iter::FromIterator;
 
@@ -51,6 +52,29 @@ impl FromIterator<usize> for Origin {
         Self {
             inner: iter.into_iter().collect(),
         }
+    }
+}
+
+impl Display for Origin {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut it = self.inner.iter();
+
+        if let Some(i) = it.next() {
+            if *i == usize::MAX {
+                write!(f, "authorizer")?;
+            } else {
+                write!(f, "{i}")?;
+            }
+        }
+
+        for i in it.next() {
+            if *i == usize::MAX {
+                write!(f, ", authorizer")?;
+            } else {
+                write!(f, ", {i}")?;
+            }
+        }
+        Ok(())
     }
 }
 
@@ -117,5 +141,11 @@ impl FromIterator<usize> for TrustedOrigins {
 impl<'a> FromIterator<&'a usize> for TrustedOrigins {
     fn from_iter<T: IntoIterator<Item = &'a usize>>(iter: T) -> Self {
         Self(iter.into_iter().cloned().collect())
+    }
+}
+
+impl Display for TrustedOrigins {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
     }
 }

--- a/biscuit-auth/src/datalog/origin.rs
+++ b/biscuit-auth/src/datalog/origin.rs
@@ -143,9 +143,3 @@ impl<'a> FromIterator<&'a usize> for TrustedOrigins {
         Self(iter.into_iter().cloned().collect())
     }
 }
-
-impl Display for TrustedOrigins {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.0.fmt(f)
-    }
-}

--- a/biscuit-auth/src/token/authorizer.rs
+++ b/biscuit-auth/src/token/authorizer.rs
@@ -948,11 +948,24 @@ impl Authorizer {
             write!(&mut result, "// Rules:\n");
         }
 
-        for (origin, ruleset) in &self.world.rules.inner {
-            write!(&mut result, "// origin: {origin}\n");
+        let mut rules_map: BTreeMap<usize, Vec<String>> = BTreeMap::new();
+        for ruleset in self.world.rules.inner.values() {
+            for (origin, rule) in ruleset {
+                rules_map
+                    .entry(*origin)
+                    .or_default()
+                    .push(self.symbols.print_rule(&rule));
+            }
+        }
+        for (origin, rule_list) in &rules_map {
+            if *origin == usize::MAX {
+                write!(&mut result, "// origin: authorizer\n");
+            } else {
+                write!(&mut result, "// origin: {origin}\n");
+            }
 
-            for (_, rule) in ruleset {
-                write!(&mut result, "{};\n", self.symbols.print_rule(&rule));
+            for rule in rule_list {
+                write!(&mut result, "{};\n", rule);
             }
         }
 

--- a/biscuit-auth/src/token/authorizer.rs
+++ b/biscuit-auth/src/token/authorizer.rs
@@ -926,6 +926,76 @@ impl Authorizer {
 
     /// prints the content of the authorizer
     pub fn print_world(&self) -> String {
+        let mut result = String::new();
+
+        if !self.world.facts.is_empty() {
+            write!(&mut result, "// Facts:\n");
+        }
+
+        for (origin, factset) in &self.world.facts.inner {
+            write!(&mut result, "// origin: {origin}\n");
+
+            for fact in factset {
+                write!(&mut result, "{};\n", self.symbols.print_fact(&fact));
+            }
+        }
+
+        if !self.world.facts.is_empty() {
+            write!(&mut result, "\n");
+        }
+
+        if !self.world.rules.inner.is_empty() {
+            write!(&mut result, "// Rules:\n");
+        }
+
+        for (origin, ruleset) in &self.world.rules.inner {
+            write!(&mut result, "// origin: {origin}\n");
+
+            for (_, rule) in ruleset {
+                write!(&mut result, "{};\n", self.symbols.print_rule(&rule));
+            }
+        }
+
+        if !self.world.rules.inner.is_empty() {
+            write!(&mut result, "\n");
+        }
+
+        // TODO: test blocks too
+        //if !self.authorizer_block_builder.checks.is_empty() {
+        write!(&mut result, "// Checks:\n");
+        //}
+
+        if !self.authorizer_block_builder.checks.is_empty() {
+            write!(&mut result, "// origin: authorizer\n");
+
+            for check in &self.authorizer_block_builder.checks {
+                write!(&mut result, "{check};\n");
+            }
+        }
+
+        if let Some(blocks) = &self.blocks {
+            for (i, block) in blocks.iter().enumerate() {
+                if !block.checks.is_empty() {
+                    write!(&mut result, "// origin: {i}\n");
+
+                    for check in &block.checks {
+                        write!(&mut result, "{};\n", self.symbols.print_check(check));
+                    }
+                }
+            }
+        }
+
+        if !self.authorizer_block_builder.checks.is_empty() {
+            write!(&mut result, "\n");
+        }
+
+        if !self.policies.is_empty() {
+            write!(&mut result, "// Policies:\n");
+        }
+        for policy in self.policies.iter() {
+            write!(&mut result, "{policy};\n");
+        }
+
         let facts: BTreeMap<_, _> = self
             .world
             .facts
@@ -984,7 +1054,8 @@ impl Authorizer {
         format!(
             "World {{\n  facts: {:#?}\n  rules: {:#?}\n  checks: {:#?}\n  policies: {:#?}\n}}",
             facts, rules, checks, policies
-        )
+        );
+        result
     }
 
     /// returns all of the data loaded in the authorizer


### PR DESCRIPTION
Previously, we printed something that looks like a structure dump, but that was not easy to understand. This looks more like a code dump, with the origin indicated in comments