### PR TITLE
make AuthorizerLimits cover the entire execution of the Authorizer

### DIFF
--- a/biscuit-auth/src/datalog/mod.rs
+++ b/biscuit-auth/src/datalog/mod.rs
@@ -548,6 +548,7 @@ pub fn match_preds(rule_pred: &Predicate, fact_pred: &Predicate) -> bool {
 pub struct World {
     pub facts: FactSet,
     pub rules: RuleSet,
+    pub iterations: u32,
 }
 
 impl World {
@@ -564,13 +565,13 @@ impl World {
     }
 
     pub fn run(&mut self, symbols: &SymbolTable) -> Result<(), crate::error::RunLimit> {
-        self.run_with_limits(symbols, &mut RunLimits::default())
+        self.run_with_limits(symbols, RunLimits::default())
     }
 
     pub fn run_with_limits(
         &mut self,
         symbols: &SymbolTable,
-        limits: &mut RunLimits,
+        limits: RunLimits,
     ) -> Result<(), crate::error::RunLimit> {
         let start = Instant::now();
         let time_limit = start + limits.max_time;
@@ -608,13 +609,7 @@ impl World {
             }
         };
 
-        limits.max_iterations -= index;
-        if res == Err(crate::error::RunLimit::Timeout) {
-            limits.max_time = Duration::from_secs(0);
-        } else {
-            let now = Instant::now();
-            limits.max_time = limits.max_time - (now - start);
-        }
+        self.iterations += index;
 
         res
     }

--- a/biscuit-auth/src/token/authorizer.rs
+++ b/biscuit-auth/src/token/authorizer.rs
@@ -462,10 +462,16 @@ impl Authorizer {
         self.authorizer_block_builder.add_scope(scope);
     }
 
+    /// Returns the runtime limits of the authorizer
+    ///
+    /// Those limits cover all the executions under the `authorize`, `query` and `query_all` methods
     pub fn limits(&self) -> &AuthorizerLimits {
         &self.limits
     }
 
+    /// Sets the runtime limits of the authorizer
+    ///
+    /// Those limits cover all the executions under the `authorize`, `query` and `query_all` methods
     pub fn set_limits(&mut self, limits: AuthorizerLimits) {
         self.limits = limits;
     }
@@ -509,7 +515,7 @@ impl Authorizer {
     ///
     /// this only sees facts from the authorizer and the authority block
     ///
-    /// this method can specify custom runtime limits
+    /// this method overrides the authorizer's runtime limits, just for this calls
     pub fn query_with_limits<R: TryInto<Rule>, T: TryFrom<Fact, Error = E>, E: Into<error::Token>>(
         &mut self,
         rule: R,
@@ -600,7 +606,7 @@ impl Authorizer {
     ///
     /// this has access to the facts generated when evaluating all the blocks
     ///
-    /// this method can specify custom runtime limits
+    /// this method overrides the authorizer's runtime limits, just for this calls
     pub fn query_all_with_limits<
         R: TryInto<Rule>,
         T: TryFrom<Fact, Error = E>,
@@ -688,7 +694,7 @@ impl Authorizer {
         self.add_policy("deny if true")
     }
 
-    /// verifies the checks and policiies
+    /// verifies the checks and policies
     ///
     /// on error, this can return a list of all the failed checks or deny policy
     /// on success, it returns the index of the policy that matched
@@ -703,12 +709,12 @@ impl Authorizer {
         self.authorize_with_limits(limits)
     }
 
-    /// verifies the checks and policiies
+    /// TODO: consume the input to prevent further direct use
+    /// verifies the checks and policies
     ///
     /// on error, this can return a list of all the failed checks or deny policy
     ///
-    /// this method can specify custom runtime limits
-    /// todo consume the input to prevent further direct use
+    /// this method overrides the authorizer's runtime limits, just for this calls
     pub fn authorize_with_limits(
         &mut self,
         limits: AuthorizerLimits,

--- a/biscuit-auth/src/token/mod.rs
+++ b/biscuit-auth/src/token/mod.rs
@@ -1375,11 +1375,10 @@ mod tests {
             .unwrap();
         authorizer.deny().unwrap();
 
-        let res =
-            authorizer.authorize_with_limits(&mut crate::token::authorizer::AuthorizerLimits {
-                max_time: Duration::from_secs(1),
-                ..Default::default()
-            });
+        let res = authorizer.authorize_with_limits(crate::token::authorizer::AuthorizerLimits {
+            max_time: Duration::from_secs(1),
+            ..Default::default()
+        });
         println!("res1: {:?}", res);
         println!("authorizer:\n{}", authorizer.print_world());
 

--- a/biscuit-auth/src/token/mod.rs
+++ b/biscuit-auth/src/token/mod.rs
@@ -1375,10 +1375,11 @@ mod tests {
             .unwrap();
         authorizer.deny().unwrap();
 
-        let res = authorizer.authorize_with_limits(crate::token::authorizer::AuthorizerLimits {
-            max_time: Duration::from_secs(1),
-            ..Default::default()
-        });
+        let res =
+            authorizer.authorize_with_limits(&mut crate::token::authorizer::AuthorizerLimits {
+                max_time: Duration::from_secs(1),
+                ..Default::default()
+            });
         println!("res1: {:?}", res);
         println!("authorizer:\n{}", authorizer.print_world());
 


### PR DESCRIPTION
The authorizer now contains an `AuthorizerLimits` field that applies to all cumulative executions of the authorizer, ie any call to `authorize`, `query` and `query_all`.
To that end, `Authorizer` now contains an `execution_time` field that measures the total execution time, and `datalog::World` now contains an `iterations` field to count the total number of iterations.

It is possible to override temporarily the limit by calling `query_with_limits`, `query_all_with_limits` or `authorize_with_limits`.