### PR TITLE
handle expression execution failure

### DIFF
--- a/biscuit-auth/samples/README.md
+++ b/biscuit-auth/samples/README.md
@@ -1660,5 +1660,5 @@ World {
 }
 ```
 
-result: `Err(FailedLogic(Unauthorized { policy: Allow(0), checks: [Block(FailedBlockCheck { block_id: 0, check_id: 0, rule: "check if true || 10000000000 * 10000000000 != 0" }), Block(FailedBlockCheck { block_id: 0, check_id: 1, rule: "check if true || 9223372036854775807 + 1 != 0" }), Block(FailedBlockCheck { block_id: 0, check_id: 2, rule: "check if true || -9223372036854775808 - 1 != 0" })] }))`
+result: `Err(Execution(Overflow))`
 

--- a/biscuit-auth/samples/samples.json
+++ b/biscuit-auth/samples/samples.json
@@ -1617,36 +1617,7 @@
           },
           "result": {
             "Err": {
-              "FailedLogic": {
-                "Unauthorized": {
-                  "policy": {
-                    "Allow": 0
-                  },
-                  "checks": [
-                    {
-                      "Block": {
-                        "block_id": 0,
-                        "check_id": 0,
-                        "rule": "check if true || 10000000000 * 10000000000 != 0"
-                      }
-                    },
-                    {
-                      "Block": {
-                        "block_id": 0,
-                        "check_id": 1,
-                        "rule": "check if true || 9223372036854775807 + 1 != 0"
-                      }
-                    },
-                    {
-                      "Block": {
-                        "block_id": 0,
-                        "check_id": 2,
-                        "rule": "check if true || -9223372036854775808 - 1 != 0"
-                      }
-                    }
-                  ]
-                }
-              }
+              "Execution": "Overflow"
             }
           },
           "authorizer_code": "allow if true;\n",

--- a/biscuit-auth/src/capi.rs
+++ b/biscuit-auth/src/capi.rs
@@ -96,6 +96,7 @@ pub enum ErrorKind {
     FormatBlockSignatureDeserializationError,
     FormatSignatureInvalidSignatureGeneration,
     AlreadySealed,
+    Execution,
 }
 
 #[no_mangle]
@@ -175,6 +176,7 @@ pub extern "C" fn error_kind() -> ErrorKind {
                     Token::RunLimit(RunLimit::Timeout) => ErrorKind::Timeout,
                     Token::ConversionError(_) => ErrorKind::ConversionError,
                     Token::Base64(_) => ErrorKind::FormatDeserializationError,
+                    Token::Execution(_) => ErrorKind::Execution,
                 }
             }
         },

--- a/biscuit-auth/src/datalog/expression.rs
+++ b/biscuit-auth/src/datalog/expression.rs
@@ -205,6 +205,10 @@ impl Binary {
             // boolean
             (Binary::And, Term::Bool(i), Term::Bool(j)) => Ok(Term::Bool(i & j)),
             (Binary::Or, Term::Bool(i), Term::Bool(j)) => Ok(Term::Bool(i | j)),
+
+            (Binary::Equal, _, _) => Ok(Term::Bool(false)),
+            (Binary::NotEqual, _, _) => Ok(Term::Bool(true)),
+
             _ => {
                 //println!("unexpected value type on the stack");
                 Err(error::Expression::InvalidType)

--- a/biscuit-auth/src/datalog/mod.rs
+++ b/biscuit-auth/src/datalog/mod.rs
@@ -1,5 +1,6 @@
 //! Logic language implementation for checks
 use crate::builder::{CheckKind, Convert};
+use crate::error::Execution;
 use crate::time::Instant;
 use crate::token::{Scope, MIN_SCHEMA_VERSION};
 use crate::{builder, error};
@@ -125,7 +126,7 @@ impl Rule {
         facts: IT,
         rule_origin: usize,
         symbols: &'a SymbolTable,
-    ) -> impl Iterator<Item = (Origin, Fact)> + 'a
+    ) -> impl Iterator<Item = Result<(Origin, Fact), &'static str>> + 'a
     where
         IT: Iterator<Item = (&'a Origin, &'a Fact)> + Clone + 'a,
     {
@@ -133,35 +134,44 @@ impl Rule {
         let variables = MatchedVariables::new(self.variables_set());
 
         CombineIt::new(variables, &self.body, facts, symbols)
-        .filter(move |(_, variables)| {
+        .map(move |(origin, variables)| {
                     let mut temporary_symbols = TemporarySymbolTable::new(&symbols);
                     for e in self.expressions.iter() {
                         match e.evaluate(&variables, &mut temporary_symbols) {
                             Some(Term::Bool(true)) => {}
+                            Some(Term::Bool(false)) => return Ok((origin, variables, false)),
                             _res => {
                                 //println!("expr returned {:?}", res);
-                                return false;
+                                return Err("expression failed");
                             }
                         }
                     }
-            true
-        }).filter_map(move |(mut origin,h)| {
-            let mut p = head.clone();
-            for index in 0..p.terms.len() {
-                match &p.terms[index] {
-                    Term::Variable(i) => match h.get(i) {
-                      Some(val) => p.terms[index] = val.clone(),
-                      None => {
-                        println!("error: variables that appear in the head should appear in the body and constraints as well");
-                        return None;
-                      }
-                    },
-                    _ => continue,
-                };
+            Ok((origin, variables, true))
+        }).filter_map(move |res/*(mut origin,h, expression_res)*/| {
+            match res {
+                Ok((mut origin,h , expression_res)) => {
+                    if expression_res {
+                    let mut p = head.clone();
+                    for index in 0..p.terms.len() {
+                        match &p.terms[index] {
+                            Term::Variable(i) => match h.get(i) {
+                              Some(val) => p.terms[index] = val.clone(),
+                              None => {
+                                println!("error: variables that appear in the head should appear in the body and constraints as well");
+                                return None;
+                              }
+                            },
+                            _ => continue,
+                        };
+                    }
+        
+                    origin.insert(rule_origin);
+                    Some(Ok((origin, Fact { predicate: p })))
+                } else {None}
+                },
+                Err(e) => Some(Err(e))
             }
-
-            origin.insert(rule_origin);
-            Some((origin, Fact { predicate: p }))
+          
         })
     }
 
@@ -171,12 +181,16 @@ impl Rule {
         origin: usize,
         scope: &TrustedOrigins,
         symbols: &SymbolTable,
-    ) -> bool {
+    ) -> Result<bool, Execution> {
         let fact_it = facts.iterator(scope);
         let mut it = self.apply(fact_it, origin, symbols);
 
         let next = it.next();
-        next.is_some()
+        match next {
+            None => Ok(false),
+            Some(Ok(_)) => Ok(true),
+            Some(Err(e)) => Err(Execution::Expression(e))
+        }
     }
 
     pub fn check_match_all(
@@ -184,7 +198,7 @@ impl Rule {
         facts: &FactSet,
         scope: &TrustedOrigins,
         symbols: &SymbolTable,
-    ) -> bool {
+    ) -> Result<bool, Execution> {
         let fact_it = facts.iterator(scope);
         let variables = MatchedVariables::new(self.variables_set());
         let mut found = false;
@@ -196,15 +210,17 @@ impl Rule {
             for e in self.expressions.iter() {
                 match e.evaluate(&variables, &mut temporary_symbols) {
                     Some(Term::Bool(true)) => {}
-                    _res => {
+
+                    Some(Term::Bool(false)) => {
                         //println!("expr returned {:?}", res);
-                        return false;
+                        return Ok(false);
                     }
+                    _ => return Err(Execution::Expression("expression execution failure")),
                 }
             }
         }
 
-        found
+        Ok(found)
     }
 
     // use this to translate rules and checks from token to authorizer world without translating
@@ -564,7 +580,7 @@ impl World {
         self.rules.insert(origin, scope, rule);
     }
 
-    pub fn run(&mut self, symbols: &SymbolTable) -> Result<(), crate::error::RunLimit> {
+    pub fn run(&mut self, symbols: &SymbolTable) -> Result<(), crate::error::Execution> {
         self.run_with_limits(symbols, RunLimits::default())
     }
 
@@ -572,7 +588,7 @@ impl World {
         &mut self,
         symbols: &SymbolTable,
         limits: RunLimits,
-    ) -> Result<(), crate::error::RunLimit> {
+    ) -> Result<(), crate::error::Execution> {
         let start = Instant::now();
         let time_limit = start + limits.max_time;
         let mut index = 0;
@@ -583,7 +599,17 @@ impl World {
             for (scope, rules) in self.rules.inner.iter() {
                 let it = self.facts.iterator(scope);
                 for (origin, rule) in rules {
-                    new_facts.extend(rule.apply(it.clone(), *origin, symbols));
+                    for res in rule.apply(it.clone(), *origin, symbols) {
+                        match res {
+                            Ok((origin,fact)) => {
+                                new_facts.insert(&origin, fact);
+
+                            },
+                            Err(e)  => {
+                                return Err(Execution::Expression(e));
+                            }
+                        }
+                    }
                     //println!("new_facts after applying {:?}:\n{:#?}", rule, new_facts);
                 }
             }
@@ -596,16 +622,16 @@ impl World {
 
             index += 1;
             if index == limits.max_iterations {
-                break Err(crate::error::RunLimit::TooManyIterations);
+                break Err(Execution::RunLimit( crate::error::RunLimit::TooManyIterations));
             }
 
             if self.facts.len() >= limits.max_facts as usize {
-                break Err(crate::error::RunLimit::TooManyFacts);
+                break Err(Execution::RunLimit(crate::error::RunLimit::TooManyFacts));
             }
 
             let now = Instant::now();
             if now >= time_limit {
-                break Err(crate::error::RunLimit::Timeout);
+                break Err(Execution::RunLimit(crate::error::RunLimit::Timeout));
             }
         };
 
@@ -643,12 +669,23 @@ impl World {
         origin: usize,
         scope: &TrustedOrigins,
         symbols: &SymbolTable,
-    ) -> FactSet {
+    ) -> Result<FactSet, Execution> {
         let mut new_facts = FactSet::default();
         let it = self.facts.iterator(scope);
-        new_facts.extend(rule.apply(it, origin, symbols));
+        //new_facts.extend(rule.apply(it, origin, symbols));
+        for res in rule.apply(it.clone(), origin, symbols) {
+            match res {
+                Ok((origin,fact)) => {
+                    new_facts.insert(&origin, fact);
 
-        new_facts
+                },
+                Err(e)  => {
+                    return Err(Execution::Expression(e));
+                }
+            }
+        }
+
+        Ok(new_facts)
     }
 
     pub fn query_match(
@@ -657,7 +694,7 @@ impl World {
         origin: usize,
         scope: &TrustedOrigins,
         symbols: &SymbolTable,
-    ) -> bool {
+    ) -> Result<bool, Execution> {
         rule.find_match(&self.facts, origin, scope, symbols)
     }
 
@@ -666,7 +703,7 @@ impl World {
         rule: Rule,
         scope: &TrustedOrigins,
         symbols: &SymbolTable,
-    ) -> bool {
+    ) -> Result<bool, Execution> {
         rule.check_match_all(&self.facts, scope, symbols)
     }
 }
@@ -958,7 +995,7 @@ mod tests {
             0,
             &[0].iter().collect(),
             &syms,
-        );
+        ).unwrap();
 
         for (origin, fact) in res.iterator(&[0].iter().collect()) {
             println!("\t{:?}\t{}", origin, syms.print_fact(fact));
@@ -1007,7 +1044,7 @@ mod tests {
             0,
             &[0].iter().collect(),
             &syms,
-        );
+        ).unwrap();
         println!("grandparents after inserting parent(C, E): {:?}", res);
 
         let res = res
@@ -1080,7 +1117,8 @@ mod tests {
             0,
             &[0].iter().collect(),
             &syms,
-        );
+        ).unwrap();
+
         for (_, fact) in res.iter_all() {
             println!("\t{}", syms.print_fact(fact));
         }
@@ -1126,7 +1164,8 @@ mod tests {
             0,
             &[0].iter().collect(),
             &syms,
-        );
+        ).unwrap();
+
         for (_, fact) in res.iter_all() {
             println!("\t{}", syms.print_fact(fact));
         }
@@ -1210,7 +1249,7 @@ mod tests {
                 0,
                 &[0].iter().collect(),
                 &syms,
-            )
+            ).unwrap()
             .iter_all()
             .map(|(_, fact)| fact.clone())
             .collect()
@@ -1289,7 +1328,7 @@ mod tests {
         );
 
         println!("testing r1: {}", syms.print_rule(&r1));
-        let res = w.query_rule(r1, 0, &[0].iter().collect(), &syms);
+        let res = w.query_rule(r1, 0, &[0].iter().collect(), &syms).unwrap();
         for (_, fact) in res.iter_all() {
             println!("\t{}", syms.print_fact(fact));
         }
@@ -1327,7 +1366,7 @@ mod tests {
         );
 
         println!("testing r2: {}", syms.print_rule(&r2));
-        let res = w.query_rule(r2, 0, &[0].iter().collect(), &syms);
+        let res = w.query_rule(r2, 0, &[0].iter().collect(), &syms).unwrap();
         for (_, fact) in res.iter_all() {
             println!("\t{}", syms.print_fact(fact));
         }
@@ -1389,7 +1428,7 @@ mod tests {
             0,
             &[0].iter().collect(),
             &syms,
-        );
+        ).unwrap();
 
         for (_, fact) in res.iter_all() {
             println!("\t{}", syms.print_fact(fact));
@@ -1438,7 +1477,7 @@ mod tests {
             0,
             &[0].iter().collect(),
             &syms,
-        );
+        ).unwrap();
 
         for (_, fact) in res.iter_all() {
             println!("\t{}", syms.print_fact(fact));
@@ -1481,7 +1520,8 @@ mod tests {
             0,
             &[0].iter().collect(),
             &syms,
-        );
+        ).unwrap();
+
         for (_, fact) in res.iter_all() {
             println!("\t{}", syms.print_fact(fact));
         }
@@ -1523,7 +1563,7 @@ mod tests {
             0,
             &[0].iter().collect(),
             &syms,
-        );
+        ).unwrap();
 
         for (_, fact) in res.iter_all() {
             println!("\t{}", syms.print_fact(fact));
@@ -1544,7 +1584,7 @@ mod tests {
             0,
             &[0].iter().collect(),
             &syms,
-        );
+        ).unwrap();
 
         for (_, fact) in res.iter_all() {
             println!("\t{}", syms.print_fact(fact));
@@ -1585,7 +1625,7 @@ mod tests {
 
         println!("world:\n{}\n", syms.print_world(&w));
         println!("\ntesting r1: {}\n", syms.print_rule(&r1));
-        let res = w.query_rule(r1, 0, &[0].iter().collect(), &syms);
+        let res = w.query_rule(r1, 0, &[0].iter().collect(), &syms).unwrap();
         for (_, fact) in res.iter_all() {
             println!("\t{}", syms.print_fact(fact));
         }
@@ -1624,7 +1664,7 @@ mod tests {
         );
         println!("world:\n{}\n", syms.print_world(&w));
         println!("\ntesting r1: {}\n", syms.print_rule(&r1));
-        let res = w.query_rule(r1, 0, &[0].iter().collect(), &syms);
+        let res = w.query_rule(r1, 0, &[0].iter().collect(), &syms).unwrap();
 
         println!("generated facts:");
         for (_, fact) in res.iter_all() {
@@ -1640,7 +1680,7 @@ mod tests {
         let r2 = rule(check, &[&read], &[pred(operation, &[&read])]);
         println!("world:\n{}\n", syms.print_world(&w));
         println!("\ntesting r2: {}\n", syms.print_rule(&r2));
-        let res = w.query_rule(r2, 0, &[0].iter().collect(), &syms);
+        let res = w.query_rule(r2, 0, &[0].iter().collect(), &syms).unwrap();
 
         println!("generated facts:");
         for (_, fact) in res.iter_all() {

--- a/biscuit-auth/src/datalog/origin.rs
+++ b/biscuit-auth/src/datalog/origin.rs
@@ -67,7 +67,7 @@ impl Display for Origin {
             }
         }
 
-        for i in it.next() {
+        for i in it {
             if *i == usize::MAX {
                 write!(f, ", authorizer")?;
             } else {

--- a/biscuit-auth/src/error.rs
+++ b/biscuit-auth/src/error.rs
@@ -27,7 +27,7 @@ pub enum Token {
     #[error("Cannot decode base64 token: {0}")]
     Base64(Base64Error),
     #[error("Datalog  execution failure: {0}")]
-    Execution(&'static str),
+    Execution(Expression),
 }
 
 impl From<Infallible> for Token {
@@ -229,7 +229,25 @@ pub enum Execution {
     #[error("Reached Datalog execution limits")]
     RunLimit(RunLimit),
     #[error("Expression execution failure")]
-    Expression(&'static str),
+    Expression(Expression),
+}
+
+/// Datalog expression execution failure
+#[derive(Error, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde-error", derive(serde::Serialize, serde::Deserialize))]
+pub enum Expression {
+    #[error("Unknown symbol")]
+    UnknownSymbol(u64),
+    #[error("Unknown variable")]
+    UnknownVariable(u32),
+    #[error("Invalid type")]
+    InvalidType,
+    #[error("Overflow")]
+    Overflow,
+    #[error("Division by zero")]
+    DivideByZero,
+    #[error("Wrong number of elements on stack")]
+    InvalidStack,
 }
 
 /// runtime limits errors

--- a/biscuit-auth/src/error.rs
+++ b/biscuit-auth/src/error.rs
@@ -26,6 +26,8 @@ pub enum Token {
     ConversionError(String),
     #[error("Cannot decode base64 token: {0}")]
     Base64(Base64Error),
+    #[error("Datalog  execution failure: {0}")]
+    Execution(&'static str),
 }
 
 impl From<Infallible> for Token {
@@ -65,6 +67,15 @@ impl From<base64::DecodeError> for Token {
         };
 
         Token::Base64(err)
+    }
+}
+
+impl From<Execution> for Token {
+    fn from(e: Execution) -> Self {
+        match e {
+            Execution::RunLimit(limit) => Token::RunLimit(limit),
+            Execution::Expression(e) => Token::Execution(e),
+        }
     }
 }
 
@@ -209,6 +220,16 @@ pub struct FailedAuthorizerCheck {
     pub check_id: u32,
     /// pretty print of the rule that failed
     pub rule: String,
+}
+
+/// Datalog execution errors
+#[derive(Error, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde-error", derive(serde::Serialize, serde::Deserialize))]
+pub enum Execution {
+    #[error("Reached Datalog execution limits")]
+    RunLimit(RunLimit),
+    #[error("Expression execution failure")]
+    Expression(&'static str),
 }
 
 /// runtime limits errors


### PR DESCRIPTION
if an expression fails (example: integer overflow), it should be a hard error instead of returning false, because that boolean might be interpreted at a later stage, like in `deny` policies.

With this change, an expression can return either true, false or an execution error

TODO:
- [ ] add tests
- [ ] define a proper error structure instead of a static string

should the error structure for execution errors indicate which kind of error we got? Should there be some context about which rule or expression triggered it?
With this, type errors (like adding an int and a string) become hard errors and fail the entire rule execution, instead just returning false for the expression evaluation. Are there cases where users relied on relaxed type evaluation?