### PR TITLE
add `impl From<BTreeSet<Term>> for Term`

### DIFF
--- a/biscuit-quote/tests/simple_test.rs
+++ b/biscuit-quote/tests/simple_test.rs
@@ -1,9 +1,13 @@
+use biscuit_auth::builder;
 use biscuit_quote::{authorizer, authorizer_merge, biscuit, biscuit_merge, block, block_merge};
+use std::collections::BTreeSet;
 
 #[test]
 fn block_macro() {
+    let mut term_set = BTreeSet::new();
+    term_set.insert(builder::int(0i64));
     let mut b = block!(
-        r#"fact("test", hex:aabbcc, [true], {my_key});
+        r#"fact("test", hex:aabbcc, [true], {my_key}, {term_set});
             rule($0, true) <- fact($0, $1, $2, {my_key});
             check if {my_key}.starts_with("my");
             "#,
@@ -14,7 +18,7 @@ fn block_macro() {
 
     assert_eq!(
         b.to_string(),
-        r#"fact("test", hex:aabbcc, [true], "my_value");
+        r#"fact("test", hex:aabbcc, [true], "my_value", [0]);
 appended(true);
 rule($0, true) <- fact($0, $1, $2, "my_value");
 check if "my_value".starts_with("my");


### PR DESCRIPTION
This makes it a bit nicer to work with set values.

My initial plan was to have it work with any iterator whose item type is `Into<Term>`, but i can't add a blanket implementation on any iterator.
My second attempt was to add `fn as_term_set<T: Into<Term>, I: Iterator<Item = T>(values: I) -> BTreeSet<Term> {}` function, but turning regular collections into iterators introduces references, and we usually dont have `Into<Term>` instances for those.

If you have any idea for a nice way to turn arbitrary collections into sets of terms, i'm all ears.