### PR TITLE
sort rules when displaying an authorizer contents

### DIFF
--- a/biscuit-auth/src/token/authorizer.rs
+++ b/biscuit-auth/src/token/authorizer.rs
@@ -1048,7 +1048,9 @@ impl std::fmt::Display for Authorizer {
                 write!(f, "// origin: {origin}\n")?;
             }
 
-            for rule in rule_list {
+            let mut sorted_rule_list = rule_list.clone();
+            sorted_rule_list.sort();
+            for rule in sorted_rule_list {
                 write!(f, "{};\n", rule)?;
             }
         }


### PR DESCRIPTION
The rules order is not always the same, which makes it inconvenient to use `.to_string()` in tests. Sorting rules solves the issue, as is already done with facts.

This solves a flaky test issue on biscuit-python