### PR TITLE
update the block rules after symbol translation

### DIFF
--- a/biscuit-auth/samples/README.md
+++ b/biscuit-auth/samples/README.md
@@ -2092,7 +2092,7 @@ World {
 }
   rules: {
     (
-        "query(1, 2) <- query(1), query(2) trusting ed25519/3c8aeced6363b8a862552fb2b0b4b8b0f8244e8cef3c11c3e55fd553f3a90f59",
+        "query(1, 2) <- query(1), query(2) trusting ed25519/ecfb8ed11fd9e6be133ca4dd8d229d39c7dcb2d659704c39e82fd7acf0d12dee",
         1,
     ),
 }

--- a/biscuit-auth/samples/samples.json
+++ b/biscuit-auth/samples/samples.json
@@ -2048,7 +2048,7 @@
             ],
             "rules": [
               [
-                "query(1, 2) <- query(1), query(2) trusting ed25519/3c8aeced6363b8a862552fb2b0b4b8b0f8244e8cef3c11c3e55fd553f3a90f59",
+                "query(1, 2) <- query(1), query(2) trusting ed25519/ecfb8ed11fd9e6be133ca4dd8d229d39c7dcb2d659704c39e82fd7acf0d12dee",
                 1
               ]
             ],

--- a/biscuit-auth/src/token/authorizer.rs
+++ b/biscuit-auth/src/token/authorizer.rs
@@ -151,13 +151,13 @@ impl Authorizer {
             self.world.facts.insert(&block_origin, fact);
         }
 
-        for rule in block.rules.iter() {
+        for rule in block.rules.iter_mut() {
             if let Err(_message) = rule.validate_variables(&block_symbols) {
                 return Err(
                     error::Logic::InvalidBlockRule(0, block_symbols.print_rule(rule)).into(),
                 );
             }
-            let rule = rule.translate(&block_symbols, &mut self.symbols)?;
+            *rule = rule.translate(&block_symbols, &mut self.symbols)?;
 
             let rule_trusted_origins = TrustedOrigins::from_scopes(
                 &rule.scopes,
@@ -166,7 +166,9 @@ impl Authorizer {
                 &self.public_key_to_block_id,
             );
 
-            self.world.rules.insert(i, &rule_trusted_origins, rule);
+            self.world
+                .rules
+                .insert(i, &rule_trusted_origins, rule.clone());
         }
 
         for check in block.checks.iter_mut() {

--- a/biscuit-auth/src/token/authorizer.rs
+++ b/biscuit-auth/src/token/authorizer.rs
@@ -105,7 +105,7 @@ impl Authorizer {
         for i in 0..token.block_count() {
             let mut block = token.block(i)?;
 
-            self.add_block(&mut block, i, &token.symbols)?;
+            self.load_and_translate_block(&mut block, i, &token.symbols)?;
 
             blocks.push(block);
         }
@@ -121,7 +121,8 @@ impl Authorizer {
         Ok(())
     }
 
-    fn add_block(
+    /// we need to modify the block loaded from the token, because the authorizer's and th token's symbol table can differ
+    fn load_and_translate_block(
         &mut self,
         block: &mut Block,
         i: usize,

--- a/biscuit-auth/src/token/authorizer.rs
+++ b/biscuit-auth/src/token/authorizer.rs
@@ -146,9 +146,9 @@ impl Authorizer {
             &self.public_key_to_block_id,
         );
 
-        for fact in block.facts.iter() {
-            let fact = Fact::convert_from(fact, &block_symbols)?.convert(&mut self.symbols);
-            self.world.facts.insert(&block_origin, fact);
+        for fact in block.facts.iter_mut() {
+            *fact = Fact::convert_from(fact, &block_symbols)?.convert(&mut self.symbols);
+            self.world.facts.insert(&block_origin, fact.clone());
         }
 
         for rule in block.rules.iter_mut() {

--- a/biscuit-auth/src/token/authorizer/snapshot.rs
+++ b/biscuit-auth/src/token/authorizer/snapshot.rs
@@ -91,7 +91,7 @@ impl super::Authorizer {
                     .push(i);
             }
 
-            authorizer.add_block(&mut block, i, &token_symbols)?;
+            authorizer.load_and_translate_block(&mut block, i, &token_symbols)?;
             blocks.push(block);
         }
 


### PR DESCRIPTION
when loading a token into an authorizer, we must translate the token data, encoded with the token's symbol table, to authorizer data, encoded with the authorizer's symbol table, before loading it into the Datalog world and storing it in the `blocks` field. It was done correctly for facts and checks, but for rules, the translated version was stored in the world but not in `blocks`. This had no incidence on authorization, but meant that snapshots would sometimes store rules with invalid symbols