### PR TITLE
Add Box trait implementation for RootKeyProvider 

### DIFF
--- a/biscuit-auth/src/token/mod.rs
+++ b/biscuit-auth/src/token/mod.rs
@@ -2,6 +2,7 @@
 use std::collections::HashMap;
 use std::convert::TryInto;
 use std::fmt::Display;
+use std::rc::Rc;
 
 use self::public_keys::PublicKeys;
 
@@ -660,6 +661,12 @@ pub trait RootKeyProvider {
 }
 
 impl RootKeyProvider for Box<dyn RootKeyProvider> {
+    fn choose(&self, key_id: Option<u32>) -> Result<PublicKey, error::Format> {
+        self.as_ref().choose(key_id)
+    }
+}
+
+impl RootKeyProvider for Rc<dyn RootKeyProvider> {
     fn choose(&self, key_id: Option<u32>) -> Result<PublicKey, error::Format> {
         self.as_ref().choose(key_id)
     }

--- a/biscuit-auth/src/token/mod.rs
+++ b/biscuit-auth/src/token/mod.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use std::convert::TryInto;
 use std::fmt::Display;
 use std::rc::Rc;
+use std::sync::Arc;
 
 use self::public_keys::PublicKeys;
 
@@ -667,6 +668,12 @@ impl RootKeyProvider for Box<dyn RootKeyProvider> {
 }
 
 impl RootKeyProvider for Rc<dyn RootKeyProvider> {
+    fn choose(&self, key_id: Option<u32>) -> Result<PublicKey, error::Format> {
+        self.as_ref().choose(key_id)
+    }
+}
+
+impl RootKeyProvider for Arc<dyn RootKeyProvider> {
     fn choose(&self, key_id: Option<u32>) -> Result<PublicKey, error::Format> {
         self.as_ref().choose(key_id)
     }

--- a/biscuit-auth/src/token/mod.rs
+++ b/biscuit-auth/src/token/mod.rs
@@ -659,6 +659,12 @@ pub trait RootKeyProvider {
     fn choose(&self, key_id: Option<u32>) -> Result<PublicKey, error::Format>;
 }
 
+impl RootKeyProvider for Box<dyn RootKeyProvider> {
+    fn choose(&self, key_id: Option<u32>) -> Result<PublicKey, error::Format> {
+        self.as_ref().choose(key_id)
+    }
+}
+
 impl RootKeyProvider for PublicKey {
     fn choose(&self, _: Option<u32>) -> Result<PublicKey, error::Format> {
         Ok(*self)


### PR DESCRIPTION
Addition to enable passing `Box<RootKeyProvider>` to functions with `RootKeyProvider` trait argument. 

Eg: `pub fn from_base64<T, KP>(slice: T, key_provider: KP) -> Result<Self, error::Token>
    where
        T: AsRef<[u8]>,
        KP: RootKeyProvider,`

It is especially useful for middlewares that abstract public keys rotation.

```rust
struct Middleware {
    public_key: Box<dyn RootKeyProvider>
}

impl Middleware{
    fn extract_biscuit(&self, req: ServiceRequest) -> MiddlewareResult<Biscuit> {
        let token = //...

        Biscuit::from_base64(token, self.public_key).map_err(|_e| {
            //...
        })
    }
}
```