### PR TITLE
RootKeyProvider implementation update to enable its use in middleware

### DIFF
--- a/biscuit-auth/examples/verifying_printer.rs
+++ b/biscuit-auth/examples/verifying_printer.rs
@@ -16,7 +16,7 @@ fn main() {
         &hex::decode("acdd6d5b53bfee478bf689f8e012fe7988bf755e3d7c5152947abc149bc20189").unwrap(),
     )
     .unwrap();
-    let token = biscuit_auth::Biscuit::from(&data[..], &root).unwrap();
+    let token = biscuit_auth::Biscuit::from(&data[..], root).unwrap();
 
     println!("Token content:");
     for i in 0..token.block_count() {

--- a/biscuit-auth/src/format/mod.rs
+++ b/biscuit-auth/src/format/mod.rs
@@ -15,6 +15,7 @@ use crate::crypto::ExternalSignature;
 use crate::datalog::SymbolTable;
 use crate::token::RootKeyProvider;
 use ed25519_dalek::Signer;
+use std::borrow::Borrow;
 use std::collections::HashMap;
 use std::convert::TryInto;
 
@@ -40,13 +41,13 @@ pub struct SerializedBiscuit {
 }
 
 impl SerializedBiscuit {
-    pub fn from_slice<KP>(slice: &[u8], key_provider: &KP) -> Result<Self, error::Format>
+    pub fn from_slice<KP>(slice: &[u8], key_provider: KP) -> Result<Self, error::Format>
     where
-        KP: RootKeyProvider,
+        KP: Borrow<dyn RootKeyProvider>,
     {
         let deser = SerializedBiscuit::deserialize(slice)?;
 
-        let root = key_provider.choose(deser.root_key_id)?;
+        let root = key_provider.borrow().choose(deser.root_key_id)?;
         deser.verify(&root)?;
 
         Ok(deser)

--- a/biscuit-auth/src/format/mod.rs
+++ b/biscuit-auth/src/format/mod.rs
@@ -40,7 +40,7 @@ pub struct SerializedBiscuit {
 }
 
 impl SerializedBiscuit {
-    pub fn from_slice<KP>(slice: &[u8], key_provider: KP) -> Result<Self, error::Format>
+    pub fn from_slice<KP>(slice: &[u8], key_provider: &KP) -> Result<Self, error::Format>
     where
         KP: RootKeyProvider,
     {

--- a/biscuit-auth/src/lib.rs
+++ b/biscuit-auth/src/lib.rs
@@ -59,7 +59,7 @@
 //!   // we want to limit access to `/a/file1.txt` and to read operations
 //!   let token2 = {
 //!     // the token is deserialized, the signature is verified
-//!     let deser = Biscuit::from(&token1,  &root.public())?;
+//!     let deser = Biscuit::from(&token1, root.public())?;
 //!
 //!     // biscuits can be attenuated by appending checks
 //!     let biscuit = deser.append(block!(r#"
@@ -81,7 +81,7 @@
 //!   /************** VERIFICATION ****************/
 //!
 //!   // let's deserialize the token:
-//!   let biscuit2 = Biscuit::from(&token2,  &root.public())?;
+//!   let biscuit2 = Biscuit::from(&token2, &root.public())?;
 //!
 //!   // let's define 3 authorizers (corresponding to 3 different requests):
 //!   // - one for /a/file1.txt and a read operation

--- a/biscuit-auth/src/lib.rs
+++ b/biscuit-auth/src/lib.rs
@@ -59,7 +59,7 @@
 //!   // we want to limit access to `/a/file1.txt` and to read operations
 //!   let token2 = {
 //!     // the token is deserialized, the signature is verified
-//!     let deser = Biscuit::from(&token1,  root.public())?;
+//!     let deser = Biscuit::from(&token1,  &root.public())?;
 //!
 //!     // biscuits can be attenuated by appending checks
 //!     let biscuit = deser.append(block!(r#"
@@ -81,7 +81,7 @@
 //!   /************** VERIFICATION ****************/
 //!
 //!   // let's deserialize the token:
-//!   let biscuit2 = Biscuit::from(&token2,  root.public())?;
+//!   let biscuit2 = Biscuit::from(&token2,  &root.public())?;
 //!
 //!   // let's define 3 authorizers (corresponding to 3 different requests):
 //!   // - one for /a/file1.txt and a read operation

--- a/biscuit-auth/src/lib.rs
+++ b/biscuit-auth/src/lib.rs
@@ -59,7 +59,7 @@
 //!   // we want to limit access to `/a/file1.txt` and to read operations
 //!   let token2 = {
 //!     // the token is deserialized, the signature is verified
-//!     let deser = Biscuit::from(&token1, root.public())?;
+//!     let deser = Biscuit::from(&token1, &root.public())?;
 //!
 //!     // biscuits can be attenuated by appending checks
 //!     let biscuit = deser.append(block!(r#"

--- a/biscuit-auth/src/token/mod.rs
+++ b/biscuit-auth/src/token/mod.rs
@@ -92,7 +92,7 @@ impl Biscuit {
     }
 
     /// deserializes a token and validates the signature using the root public key
-    pub fn from<T, KP>(slice: T, key_provider: KP) -> Result<Self, error::Token>
+    pub fn from<T, KP>(slice: T, key_provider: &KP) -> Result<Self, error::Token>
     where
         T: AsRef<[u8]>,
         KP: RootKeyProvider,
@@ -101,7 +101,7 @@ impl Biscuit {
     }
 
     /// deserializes a token and validates the signature using the root public key
-    pub fn from_base64<T, KP>(slice: T, key_provider: KP) -> Result<Self, error::Token>
+    pub fn from_base64<T, KP>(slice: T, key_provider: &KP) -> Result<Self, error::Token>
     where
         T: AsRef<[u8]>,
         KP: RootKeyProvider,
@@ -263,7 +263,7 @@ impl Biscuit {
     /// deserializes a token and validates the signature using the root public key, with a custom symbol table
     fn from_with_symbols<KP>(
         slice: &[u8],
-        key_provider: KP,
+        key_provider: &KP,
         symbols: SymbolTable,
     ) -> Result<Self, error::Token>
     where
@@ -296,7 +296,7 @@ impl Biscuit {
     /// deserializes a token and validates the signature using the root public key, with a custom symbol table
     fn from_base64_with_symbols<T, KP>(
         slice: T,
-        key_provider: KP,
+        key_provider: &KP,
         symbols: SymbolTable,
     ) -> Result<Self, error::Token>
     where
@@ -794,7 +794,7 @@ mod tests {
         println!("generated biscuit token 2: {} bytes", serialized2.len());
 
         let serialized3 = {
-            let biscuit2_deser = Biscuit::from(&serialized2, root.public()).unwrap();
+            let biscuit2_deser = Biscuit::from(&serialized2, &root.public()).unwrap();
 
             // new check: can only access file1
             let mut block3 = BlockBuilder::new();
@@ -1352,7 +1352,7 @@ mod tests {
         //panic!();
 
         let serialized2 = {
-            let biscuit1_deser = Biscuit::from(&serialized1, |_| Ok(root.public())).unwrap();
+            let biscuit1_deser = Biscuit::from(&serialized1, &root.public()).unwrap();
 
             // new check: can only have read access1
             let mut block2 = BlockBuilder::new();

--- a/biscuit-auth/src/token/mod.rs
+++ b/biscuit-auth/src/token/mod.rs
@@ -2,6 +2,7 @@
 use std::collections::HashMap;
 use std::convert::TryInto;
 use std::fmt::Display;
+use std::rc::Rc;
 
 use self::public_keys::PublicKeys;
 
@@ -660,6 +661,12 @@ pub trait RootKeyProvider {
 }
 
 impl RootKeyProvider for Box<dyn RootKeyProvider> {
+    fn choose(&self, key_id: Option<u32>) -> Result<PublicKey, error::Format> {
+        self.as_ref().choose(key_id)
+    }
+}
+
+impl RootKeyProvider for Rc<dyn RootKeyProvider> {
     fn choose(&self, key_id: Option<u32>) -> Result<PublicKey, error::Format> {
         self.as_ref().choose(key_id)
     }

--- a/biscuit-auth/src/token/mod.rs
+++ b/biscuit-auth/src/token/mod.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use std::convert::TryInto;
 use std::fmt::Display;
 use std::rc::Rc;
+use std::sync::Arc;
 
 use self::public_keys::PublicKeys;
 
@@ -667,6 +668,12 @@ impl RootKeyProvider for Box<dyn RootKeyProvider> {
 }
 
 impl RootKeyProvider for Rc<dyn RootKeyProvider> {
+    fn choose(&self, key_id: Option<u32>) -> Result<PublicKey, error::Format> {
+        self.as_ref().choose(key_id)
+    }
+}
+
+impl RootKeyProvider for Arc<dyn RootKeyProvider> {
     fn choose(&self, key_id: Option<u32>) -> Result<PublicKey, error::Format> {
         self.as_ref().choose(key_id)
     }

--- a/biscuit-auth/src/token/mod.rs
+++ b/biscuit-auth/src/token/mod.rs
@@ -659,6 +659,12 @@ pub trait RootKeyProvider {
     fn choose(&self, key_id: Option<u32>) -> Result<PublicKey, error::Format>;
 }
 
+impl RootKeyProvider for Box<dyn RootKeyProvider> {
+    fn choose(&self, key_id: Option<u32>) -> Result<PublicKey, error::Format> {
+        self.as_ref().choose(key_id)
+    }
+}
+
 impl RootKeyProvider for PublicKey {
     fn choose(&self, _: Option<u32>) -> Result<PublicKey, error::Format> {
         Ok(*self)


### PR DESCRIPTION
This PR is the continuation of https://github.com/biscuit-auth/biscuit-rust/pull/165 and is related to https://github.com/biscuit-auth/biscuit-actix-middleware/pull/8.

It contains necessary changes to allow use of `RootKeyProvider` in middlewares:
- `Box`, `Rc`, `Arc` implementations (actix uses `Rc`, the rest can be useful for other web frameworks)
- Change `RootKeyProvider` functions argument by `&RootKeyProvider` to  avoid cloning `PublicKey` list foreach call https://github.com/Tipnos/biscuit-rust/commit/fca6c48a722de5941935b11a41bb3cfa40f0efcb

