### PR TITLE
allow reading a token's root key id

### DIFF
--- a/biscuit-auth/src/token/mod.rs
+++ b/biscuit-auth/src/token/mod.rs
@@ -172,6 +172,11 @@ impl Biscuit {
         res
     }
 
+    /// returns an (optional) root key identifier. It provides a hint for public key selection during verification
+    pub fn root_key_id(&self) -> Option<u32> {
+        self.root_key_id
+    }
+
     /// returns a list of revocation identifiers for each block, in order
     ///
     /// revocation identifiers are unique: tokens generated separately with

--- a/biscuit-auth/src/token/unverified.rs
+++ b/biscuit-auth/src/token/unverified.rs
@@ -171,6 +171,11 @@ impl UnverifiedBiscuit {
         })
     }
 
+    /// returns an (optional) root key identifier. It provides a hint for public key selection during verification
+    pub fn root_key_id(&self) -> Option<u32> {
+        self.container.root_key_id
+    }
+
     /// returns a list of revocation identifiers for each block, in order
     ///
     /// revocation identifiers are unique: tokens generated separately with


### PR DESCRIPTION
While this is not strictly needed during parsing, it will be useful when inspecting biscuits with the CLI