### PR TITLE
Implement smart pointers for `RooKeyProvider`

### DIFF
--- a/biscuit-auth/src/token/mod.rs
+++ b/biscuit-auth/src/token/mod.rs
@@ -659,6 +659,24 @@ pub trait RootKeyProvider {
     fn choose(&self, key_id: Option<u32>) -> Result<PublicKey, error::Format>;
 }
 
+impl RootKeyProvider for Box<dyn RootKeyProvider> {
+    fn choose(&self, key_id: Option<u32>) -> Result<PublicKey, error::Format> {
+        self.as_ref().choose(key_id)
+    }
+}
+
+impl RootKeyProvider for std::rc::Rc<dyn RootKeyProvider> {
+    fn choose(&self, key_id: Option<u32>) -> Result<PublicKey, error::Format> {
+        self.as_ref().choose(key_id)
+    }
+}
+
+impl RootKeyProvider for std::sync::Arc<dyn RootKeyProvider> {
+    fn choose(&self, key_id: Option<u32>) -> Result<PublicKey, error::Format> {
+        self.as_ref().choose(key_id)
+    }
+}
+
 impl RootKeyProvider for PublicKey {
     fn choose(&self, _: Option<u32>) -> Result<PublicKey, error::Format> {
         Ok(*self)


### PR DESCRIPTION
Continuation of https://github.com/biscuit-auth/biscuit-rust/pull/166 closing (passing `&RootKeyProvider` as function argument), this PR allows to pass smart pointers `Box`, `Rc` or `Arc`.

Thanks to that, https://github.com/biscuit-auth/biscuit-actix-middleware/pull/8 implementation clone a `Rc` at each call instead of the whole list.

Moreover, `PublicKey` clone overhead can be limited using `Box<PublicKey>`.