### PR TITLE
Update changelogs

### DIFF
--- a/biscuit-auth/CHANGELOG.md
+++ b/biscuit-auth/CHANGELOG.md
@@ -1,3 +1,14 @@
+# `3.2.0` (not released yet)
+
+- Support for chained method calls (#153) (Geoffroy Couprie)
+- Prevent facts from carrying variables (#154) (Clément Delafargue)
+- Make the authorizer text representation stable (#155) Clément Delafargue
+- Improve samples (#156, #158, #160, #161) (Clément Delafargue, Geoffroy Couprie)
+- Fix rule symbol translation in snapshots (#159) (Geoffroy Couprie)
+- Make the TTL check helper more compact (#162) (Clément Delafargue)
+- Root key provider improvements (#164, #168) (Tristan Germain)
+- Allow reading a token root key id (#167) (Clément Delafargue)
+
 # `3.1.0`
 
 - Add missing support for equality on booleans (#149) (Geoffroy Couprie)

--- a/biscuit-auth/CHANGELOG.md
+++ b/biscuit-auth/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Support for chained method calls (#153) (Geoffroy Couprie)
 - Prevent facts from carrying variables (#154) (Clément Delafargue)
-- Make the authorizer text representation stable (#155) Clément Delafargue
+- Make the authorizer text representation stable (#155) (Clément Delafargue)
 - Improve samples (#156, #158, #160, #161) (Clément Delafargue, Geoffroy Couprie)
 - Fix rule symbol translation in snapshots (#159) (Geoffroy Couprie)
 - Make the TTL check helper more compact (#162) (Clément Delafargue)

--- a/biscuit-parser/CHANGELOG.md
+++ b/biscuit-parser/CHANGELOG.md
@@ -1,3 +1,7 @@
-# `0.1.0` (Unreleased)
+# `0.1.1` (not released yet)
+
+- Support chained method calls
+
+# `0.1.0` 
 
 - Initial release


### PR DESCRIPTION
Assuming the upcoming releases are 3.2.0 for biscuit-auth and 0.1.1 for biscuit-parser