### PR TITLE
Support for biscuit web keys

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Build
       run: cargo build --verbose
     - name: Run tests
-      run: cargo test --features serde-error --verbose
+      run: cargo test --features="serde-error,bwk" --verbose
     - name: Check samples
       run: |
         cd biscuit-auth

--- a/biscuit-auth/CHANGELOG.md
+++ b/biscuit-auth/CHANGELOG.md
@@ -1,3 +1,7 @@
+# not released
+
+- Optional support for Biscuit Web Key representation (#173) (Clément Delafargue)
+
 # `3.2.0`
 
 - Support for chained method calls (#153) (Geoffroy Couprie)

--- a/biscuit-auth/Cargo.toml
+++ b/biscuit-auth/Cargo.toml
@@ -20,6 +20,8 @@ wasm = ["wasm-bindgen", "getrandom/wasm-bindgen"]
 serde-error = ["serde", "biscuit-parser/serde-error"]
 # used by biscuit-quote to parse datalog at compile-time
 datalog-macro = ["biscuit-quote"]
+# used to expose public key information in a standard format
+bwk = ["chrono", "serde"]
 docsrs = []
 uuid = ["dep:uuid"]
 
@@ -44,11 +46,13 @@ time = { version = "0.3.7", features = ["formatting", "parsing"] }
 uuid = { version = "1", optional = true }
 biscuit-parser = { version = "0.1.1", path = "../biscuit-parser" }
 biscuit-quote = { version = "0.2.1", optional = true, path = "../biscuit-quote" }
+chrono = { version = "0.4.26", optional = true, default-features = false, features = ["serde"] }
 
 
 [dev-dependencies]
 bencher = "0.1.5"
 rand = "0.8"
+chrono = { version = "0.4.26", features = ["serde", "clock"] }
 colored-diff = "0.2.3"
 prost-build = "0.10"
 serde = { version = "1.0.130", features = ["derive"] }

--- a/biscuit-auth/src/bwk.rs
+++ b/biscuit-auth/src/bwk.rs
@@ -1,0 +1,209 @@
+use std::convert::TryFrom;
+
+use chrono::{DateTime, FixedOffset};
+use serde::{Deserialize, Serialize};
+
+use crate::{error, PublicKey};
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(into = "BiscuitWebKeyRepr")]
+#[serde(try_from = "BiscuitWebKeyRepr")]
+pub struct BiscuitWebKey {
+    pub public_key: PublicKey,
+    pub key_id: u32,
+    pub issuer: Option<String>,
+    pub expires_at: Option<DateTime<FixedOffset>>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct BiscuitWebKeyRepr {
+    pub algorithm: String,
+    pub key_bytes: String,
+    pub key_id: u32,
+    pub issuer: Option<String>,
+    pub expires_at: Option<DateTime<FixedOffset>>,
+}
+
+impl From<BiscuitWebKey> for BiscuitWebKeyRepr {
+    fn from(value: BiscuitWebKey) -> Self {
+        BiscuitWebKeyRepr {
+            algorithm: "ed25519".to_string(),
+            key_bytes: value.public_key.to_bytes_hex(),
+            key_id: value.key_id,
+            issuer: value.issuer,
+            expires_at: value.expires_at,
+        }
+    }
+}
+
+impl TryFrom<BiscuitWebKeyRepr> for BiscuitWebKey {
+    type Error = error::Format;
+
+    fn try_from(value: BiscuitWebKeyRepr) -> Result<Self, Self::Error> {
+        if value.algorithm != "ed25519" {
+            return Err(error::Format::DeserializationError(format!(
+                "deserialization error: unexpected key algorithm {}",
+                value.algorithm
+            )));
+        }
+
+        let public_key = PublicKey::from_bytes_hex(&value.key_bytes)?;
+
+        Ok(BiscuitWebKey {
+            public_key,
+            key_id: value.key_id,
+            issuer: value.issuer,
+            expires_at: value.expires_at,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::KeyPair;
+    use chrono::Utc;
+
+    use super::*;
+
+    #[test]
+    fn roundtrips() {
+        let keypair = KeyPair::new();
+        let bwk = BiscuitWebKey {
+            public_key: keypair.public(),
+            key_id: 12,
+            expires_at: None,
+            issuer: None,
+        };
+
+        let serialized = serde_json::to_string(&bwk).unwrap();
+        let parsed: BiscuitWebKey = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(parsed, bwk);
+
+        let keypair = KeyPair::new();
+        let bwk = BiscuitWebKey {
+            public_key: keypair.public(),
+            key_id: 0,
+            expires_at: None,
+            issuer: Some("test".to_string()),
+        };
+
+        let serialized = serde_json::to_string(&bwk).unwrap();
+        let parsed: BiscuitWebKey = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(parsed, bwk);
+
+        let keypair = KeyPair::new();
+        let bwk = BiscuitWebKey {
+            public_key: keypair.public(),
+            key_id: 0,
+            expires_at: Some(Utc::now().fixed_offset()),
+            issuer: Some("test".to_string()),
+        };
+
+        let serialized = serde_json::to_string(&bwk).unwrap();
+        let parsed: BiscuitWebKey = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(parsed, bwk);
+    }
+    #[test]
+    fn samples() {
+        assert_eq!(
+            serde_json::from_str::<BiscuitWebKey>(
+                r#"
+             {
+                "algorithm": "ed25519",
+                "key_bytes": "63c7a8628c14b778a4b66a22e1f53dab4542423295b6fb5a52283da58bcf6d9a",
+                "key_id": 12,
+                "expires_at": "2023-06-28T11:20:00+02:00",
+                "issuer": "test"
+             }
+        "#
+            )
+            .unwrap(),
+            BiscuitWebKey {
+                public_key: PublicKey::from_bytes_hex(
+                    "63c7a8628c14b778a4b66a22e1f53dab4542423295b6fb5a52283da58bcf6d9a"
+                )
+                .unwrap(),
+                key_id: 12,
+                expires_at: Some(
+                    DateTime::parse_from_rfc3339("2023-06-28T11:20:00+02:00").unwrap()
+                ),
+                issuer: Some("test".to_string())
+            }
+        );
+        assert_eq!(
+            serde_json::from_str::<BiscuitWebKey>(
+                r#"
+             {
+                "algorithm": "ed25519",
+                "key_bytes": "63c7a8628c14b778a4b66a22e1f53dab4542423295b6fb5a52283da58bcf6d9a",
+                "key_id": 12,
+                "expires_at": null,
+                "issuer": null
+             }
+        "#
+            )
+            .unwrap(),
+            BiscuitWebKey {
+                public_key: PublicKey::from_bytes_hex(
+                    "63c7a8628c14b778a4b66a22e1f53dab4542423295b6fb5a52283da58bcf6d9a"
+                )
+                .unwrap(),
+                key_id: 12,
+                expires_at: None,
+                issuer: None
+            }
+        );
+        assert_eq!(
+            serde_json::from_str::<BiscuitWebKey>(
+                r#"
+             {
+                "algorithm": "ed25519",
+                "key_bytes": "63c7a8628c14b778a4b66a22e1f53dab4542423295b6fb5a52283da58bcf6d9a",
+                "key_id": 12
+             }
+        "#
+            )
+            .unwrap(),
+            BiscuitWebKey {
+                public_key: PublicKey::from_bytes_hex(
+                    "63c7a8628c14b778a4b66a22e1f53dab4542423295b6fb5a52283da58bcf6d9a"
+                )
+                .unwrap(),
+                key_id: 12,
+                expires_at: None,
+                issuer: None
+            }
+        );
+        assert_eq!(
+            serde_json::from_str::<BiscuitWebKey>(
+                r#"
+             {
+                "algorithm": "ed25519",
+                "key_bytes": "63c7a8628c14b778a4b66a22e1f53dab4542423295b6fb5a52283da58bcf6d9a",
+                "key_id": 4294967295
+             }
+        "#
+            )
+            .unwrap(),
+            BiscuitWebKey {
+                public_key: PublicKey::from_bytes_hex(
+                    "63c7a8628c14b778a4b66a22e1f53dab4542423295b6fb5a52283da58bcf6d9a"
+                )
+                .unwrap(),
+                key_id: u32::MAX,
+                expires_at: None,
+                issuer: None
+            }
+        );
+        assert!(serde_json::from_str::<BiscuitWebKey>(
+            r#"
+             {
+                "algorithm": "invalid",
+                "key_bytes": "63c7a8628c14b778a4b66a22e1f53dab4542423295b6fb5a52283da58bcf6d9a",
+                "key_id": 4294967295
+             }
+        "#
+        )
+        .is_err());
+    }
+}

--- a/biscuit-auth/src/lib.rs
+++ b/biscuit-auth/src/lib.rs
@@ -241,6 +241,11 @@ mod capi;
 #[cfg(cargo_c)]
 pub use capi::*;
 
+#[cfg(bwk)]
+mod bwk;
+#[cfg(bwk)]
+pub use bwk::*;
+
 mod time;
 
 /// Procedural macros to construct Datalog policies


### PR DESCRIPTION
See https://github.com/biscuit-auth/biscuit/blob/master/biscuit-web-key/SPECIFICATIONS.md

This adds `Serialize` and `Deserialize` instances for `BiscuitWebKey`, which groups a `PublicKey`, a mandatory `u32` `key_id` and an optional `issuer` `String`.

Enabling the `bwk` feature adds `serde` and `chrono` as dependencies