### PR TITLE
feature: add a fact! macro for individual facts

### DIFF
--- a/biscuit-quote/src/lib.rs
+++ b/biscuit-quote/src/lib.rs
@@ -720,3 +720,81 @@ pub fn rule(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     })
     .into()
 }
+
+/// Create a `Fact` from a datalog string and optional parameters.
+/// The datalog string is parsed at compile time and replaced by manual
+/// block building.
+///
+/// ```rust
+/// use biscuit_auth::Biscuit;
+/// use biscuit_quote::{fact};
+///
+/// let b = fact!(
+///   r#"user({user_id})"#,
+///   user_id = "1234"
+/// );
+/// ```
+#[proc_macro]
+#[proc_macro_error]
+pub fn fact(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let ParsedCreateNew {
+        datalog,
+        parameters,
+    } = syn::parse_macro_input!(input as ParsedCreateNew);
+
+    // here we reuse the machinery made for managing parameter substitution
+    // for whole blocks. Of course, we're only interested in a single fact
+    // here. The block management happens only at compile-time, so it won't
+    // affect runtime performance.
+    let ty = syn::parse_quote!(::biscuit_auth::builder::BlockBuilder);
+    let builder = Builder::block_source(ty, None, &datalog, parameters)
+        .unwrap_or_else(|e| abort_call_site!(e.to_string()));
+
+    let mut fact_item = if let Some(f) = builder.facts.first() {
+        if builder.facts.len() == 1 {
+            Item::fact(&f)
+        } else {
+            abort_call_site!("The fact macro only accepts a single fact as input")
+        }
+    } else {
+        abort_call_site!("The fact macro only accepts a single fact as input")
+    };
+
+    // here we are only interested in returning the fact, not adding it to a
+    // builder, so we override the default behaviour and just return the fact
+    // instead of calling `add_fact`
+    fact_item.end = quote! {
+      __biscuit_auth_item
+    };
+
+    let params_quote = {
+        let (ident, expr): (Vec<_>, Vec<_>) = builder
+            .parameters
+            .iter()
+            .map(|(name, expr)| {
+                let ident = Ident::new(&name, Span::call_site());
+                (ident, expr)
+            })
+            .unzip();
+
+        // Bind all parameters "in parallel". If this were a sequence of let bindings,
+        // earlier bindings would affect the scope of later bindings.
+        quote! {
+            let (#(#ident),*) = (#(#expr),*);
+        }
+    };
+
+    for param in &builder.datalog_parameters {
+        if fact_item.needs_param(param) {
+            fact_item.add_param(&param, false);
+        }
+    }
+
+    (quote! {
+        {
+            #params_quote
+            #fact_item
+        }
+    })
+    .into()
+}

--- a/biscuit-quote/tests/simple_test.rs
+++ b/biscuit-quote/tests/simple_test.rs
@@ -1,6 +1,6 @@
 use biscuit_auth::builder;
 use biscuit_quote::{
-    authorizer, authorizer_merge, biscuit, biscuit_merge, block, block_merge, rule,
+    authorizer, authorizer_merge, biscuit, biscuit_merge, block, block_merge, fact, rule,
 };
 use std::collections::BTreeSet;
 
@@ -166,4 +166,13 @@ fn rule_macro() {
         b.to_string(),
         r#"rule($0, true) <- fact($0, $1, $2, "my_value", [0]) trusting ed25519/6e9e6d5a75cf0c0e87ec1256b4dfed0ca3ba452912d213fcc70f8516583db9db"#,
     );
+}
+
+#[test]
+fn fact_macro() {
+    let mut term_set = BTreeSet::new();
+    term_set.insert(builder::int(0i64));
+    let b = fact!(r#"fact({my_key}, {term_set})"#, my_key = "my_value",);
+
+    assert_eq!(b.to_string(), r#"fact("my_value", [0])"#,);
 }


### PR DESCRIPTION
In most cases, we can add facts to a block or an authorizer with the `block_merge!` and `authorizer_merge!` macros, but in some scenarios we still want to manipulate individual facts.

This macro does just that.

Same as the `rule!` macro, it parses a whole block and ensures that it contains exactly one fact, and then emits code to build this fact. The whole block business only happens at compile time, so there is no runtime impact of doing it like this.