### PR TITLE
feat: detect free variables in rule expressions

### DIFF
--- a/biscuit-auth/src/parser.rs
+++ b/biscuit-auth/src/parser.rs
@@ -154,13 +154,25 @@ mod tests {
     }
 
     #[test]
-    fn rule_with_unused_head_variables() {
+    fn rule_with_free_head_variables() {
         assert_eq!(
             biscuit_parser::parser::rule("right($0, $test) <- resource($0), operation(\"read\")"),
             Err( nom::Err::Failure(Error {
-                input: "right($0, $test)",
+                input: "right($0, $test) <- resource($0), operation(\"read\")",
                 code: ErrorKind::Satisfy,
-                message: Some("rule head contains variables that are not used in predicates of the rule's body: $test".to_string()),
+                message: Some("the rule contains variables that are not bound by predicates in the rule's body: $test".to_string()),
+            }))
+        );
+    }
+
+    #[test]
+    fn rule_with_free_expression_variables() {
+        assert_eq!(
+            biscuit_parser::parser::rule("right($0) <- resource($0), operation(\"read\"), $test"),
+            Err( nom::Err::Failure(Error {
+                input: "right($0) <- resource($0), operation(\"read\"), $test",
+                code: ErrorKind::Satisfy,
+                message: Some("the rule contains variables that are not bound by predicates in the rule's body: $test".to_string()),
             }))
         );
     }


### PR DESCRIPTION
Free variables are already forbidden in rule heads, but not in rule expressions.

# Open questions

The reported error span was the rule head when we were looking for free variables in the rule head. Now free variables can be found in the whole expression, so for now the whole expression is reported as the error span, which is not perfect.
The ideal solution would be to have multiple errors, one per free variable instance, with the span being only the variable itself. That may be hard to achieve, so maybe just being able to keep the expression span (or the rule head span) would be good, but that's still quite a bit of work.

I noticed a fair amount of duplication between the `builder` module in `biscuit-parser` and the one in `biscuit-auth`. For instance, `validate_variables` from biscuit-auth is not used anywhere, only the one from `biscuit-parser`. Could the `biscuit-auth` `builder` module be significantly reduced to use types and functions from `biscuit-parser`?

# ToDo

- checks
- policies
- queries