### PR TITLE
make sure that we actually need to run the datalog engine

### DIFF
--- a/biscuit-auth/src/datalog/mod.rs
+++ b/biscuit-auth/src/datalog/mod.rs
@@ -834,6 +834,11 @@ impl RuleSet {
             .iter()
             .flat_map(move |(ids, rules)| rules.iter().map(move |(_, rule)| (ids, rule)))
     }
+
+    /// number of rules of a specific origin
+    pub fn len(&self) -> usize {
+        self.inner.iter().fold(0, |acc, v| acc+v.1.len())
+    }
 }
 
 pub struct SchemaVersion {


### PR DESCRIPTION
the authorizer needs the datalog engine to have executed before performing certain tasks, but we might have already done it precedently, without having added facts or rules.
This adds a boolean tracking if we need to run: if we added facts or rules, it is set to true, if we have just run the datalog engine, it is set to false