### PR TITLE
use objects instead of tuples in the generated samples

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Check samples
       run: |
         cd biscuit-auth
-        cargo run --release --example testcases --features serde-error -- ./samples  > ./samples/README.md
+        cargo run --release --example testcases --features serde-error -- ./samples --json > ./samples/samples.json
         git diff --exit-code
       
 

--- a/biscuit-auth/examples/testcases.rs
+++ b/biscuit-auth/examples/testcases.rs
@@ -414,12 +414,13 @@ fn validate_token(root: &KeyPair, data: &[u8], authorizer_code: &str) -> Validat
             authorizer_facts.push(AuthorizerFactSet { origin, facts });
         }
     }
+    authorizer_facts.sort();
 
     Validation {
         world: Some(AuthorizerWorld {
             facts: authorizer_facts,
             rules: authorizer_rules,
-            checks: authorizer_checks, //checks.drain(..).map(|c| c.to_string()).collect(),
+            checks: authorizer_checks,
             policies: policies.drain(..).map(|p| p.to_string()).collect(),
         }),
         result: match res {

--- a/biscuit-auth/examples/testcases.rs
+++ b/biscuit-auth/examples/testcases.rs
@@ -253,7 +253,7 @@ struct AuthorizerWorld {
     pub facts: Vec<AuthorizerFactSet>,
     pub rules: Vec<AuthorizerRuleSet>,
     pub checks: Vec<AuthorizerCheckSet>,
-    pub policies: BTreeSet<String>,
+    pub policies: Vec<String>,
 }
 
 #[derive(Debug, Serialize, PartialEq, Eq, PartialOrd, Ord)]
@@ -317,7 +317,7 @@ fn validate_token(root: &KeyPair, data: &[u8], authorizer_code: &str) -> Validat
 
     let res = authorizer.authorize();
     //println!("authorizer world:\n{}", authorizer.print_world());
-    let (_, _, _, mut policies) = authorizer.dump();
+    let (_, _, _, policies) = authorizer.dump();
     let snapshot = authorizer.snapshot().unwrap();
 
     let symbols = SymbolTable::from_symbols_and_public_keys(
@@ -421,7 +421,7 @@ fn validate_token(root: &KeyPair, data: &[u8], authorizer_code: &str) -> Validat
             facts: authorizer_facts,
             rules: authorizer_rules,
             checks: authorizer_checks,
-            policies: policies.drain(..).map(|p| p.to_string()).collect(),
+            policies: policies.into_iter().map(|p| p.to_string()).collect(),
         }),
         result: match res {
             Ok(i) => AuthorizerResult::Ok(i),

--- a/biscuit-auth/samples/README.md
+++ b/biscuit-auth/samples/README.md
@@ -67,9 +67,16 @@ World {
     },
 ]
   rules: []
-  checks: {
-    "check if resource($0), operation(\"read\"), right($0, \"read\")",
-}
+  checks: [
+    AuthorizerCheckSet {
+        origin: Some(
+            1,
+        ),
+        checks: [
+            "check if resource($0), operation(\"read\"), right($0, \"read\")",
+        ],
+    },
+]
   policies: {
     "allow if true",
 }
@@ -330,9 +337,16 @@ World {
         ],
     },
 ]
-  checks: {
-    "check if resource($0), operation(\"read\"), right($0, \"read\")",
-}
+  checks: [
+    AuthorizerCheckSet {
+        origin: Some(
+            1,
+        ),
+        checks: [
+            "check if resource($0), operation(\"read\"), right($0, \"read\")",
+        ],
+    },
+]
   policies: {
     "allow if true",
 }
@@ -395,21 +409,21 @@ World {
   facts: [
     AuthorizerFactSet {
         origin: {
-            None,
-        },
-        facts: [
-            "operation(\"read\")",
-            "resource(\"file2\")",
-        ],
-    },
-    AuthorizerFactSet {
-        origin: {
             Some(
                 0,
             ),
         },
         facts: [
             "right(\"file1\", \"read\")",
+        ],
+    },
+    AuthorizerFactSet {
+        origin: {
+            None,
+        },
+        facts: [
+            "operation(\"read\")",
+            "resource(\"file2\")",
         ],
     },
     AuthorizerFactSet {
@@ -424,9 +438,16 @@ World {
     },
 ]
   rules: []
-  checks: {
-    "check if resource($0), operation(\"read\"), right($0, \"read\")",
-}
+  checks: [
+    AuthorizerCheckSet {
+        origin: Some(
+            1,
+        ),
+        checks: [
+            "check if resource($0), operation(\"read\"), right($0, \"read\")",
+        ],
+    },
+]
   policies: {
     "allow if true",
 }
@@ -490,10 +511,17 @@ World {
     },
 ]
   rules: []
-  checks: {
-    "check if resource(\"file1\")",
-    "check if time($time), $time <= 2018-12-20T00:00:00Z",
-}
+  checks: [
+    AuthorizerCheckSet {
+        origin: Some(
+            1,
+        ),
+        checks: [
+            "check if resource(\"file1\")",
+            "check if time($time), $time <= 2018-12-20T00:00:00Z",
+        ],
+    },
+]
   policies: {
     "allow if true",
 }
@@ -548,11 +576,12 @@ World {
   facts: [
     AuthorizerFactSet {
         origin: {
-            None,
+            Some(
+                1,
+            ),
         },
         facts: [
-            "operation(\"read\")",
-            "resource(\"file2\")",
+            "right(\"file2\", \"read\")",
         ],
     },
     AuthorizerFactSet {
@@ -567,19 +596,25 @@ World {
     },
     AuthorizerFactSet {
         origin: {
-            Some(
-                1,
-            ),
+            None,
         },
         facts: [
-            "right(\"file2\", \"read\")",
+            "operation(\"read\")",
+            "resource(\"file2\")",
         ],
     },
 ]
   rules: []
-  checks: {
-    "check if right($0, $1), resource($0), operation($1)",
-}
+  checks: [
+    AuthorizerCheckSet {
+        origin: Some(
+            18446744073709551615,
+        ),
+        checks: [
+            "check if right($0, $1), resource($0), operation($1)",
+        ],
+    },
+]
   policies: {
     "allow if true",
 }
@@ -643,9 +678,16 @@ World {
     },
 ]
   rules: []
-  checks: {
-    "check if right($0, $1), resource($0), operation($1)",
-}
+  checks: [
+    AuthorizerCheckSet {
+        origin: Some(
+            18446744073709551615,
+        ),
+        checks: [
+            "check if right($0, $1), resource($0), operation($1)",
+        ],
+    },
+]
   policies: {
     "allow if true",
 }
@@ -697,9 +739,16 @@ World {
     },
 ]
   rules: []
-  checks: {
-    "check if resource(\"file1\")",
-}
+  checks: [
+    AuthorizerCheckSet {
+        origin: Some(
+            0,
+        ),
+        checks: [
+            "check if resource(\"file1\")",
+        ],
+    },
+]
   policies: {
     "allow if true",
 }
@@ -735,9 +784,16 @@ World {
     },
 ]
   rules: []
-  checks: {
-    "check if resource(\"file1\")",
-}
+  checks: [
+    AuthorizerCheckSet {
+        origin: Some(
+            0,
+        ),
+        checks: [
+            "check if resource(\"file1\")",
+        ],
+    },
+]
   policies: {
     "allow if true",
 }
@@ -834,9 +890,16 @@ World {
         ],
     },
 ]
-  checks: {
-    "check if valid_date($0), resource($0)",
-}
+  checks: [
+    AuthorizerCheckSet {
+        origin: Some(
+            1,
+        ),
+        checks: [
+            "check if valid_date($0), resource($0)",
+        ],
+    },
+]
   policies: {
     "allow if true",
 }
@@ -894,9 +957,16 @@ World {
         ],
     },
 ]
-  checks: {
-    "check if valid_date($0), resource($0)",
-}
+  checks: [
+    AuthorizerCheckSet {
+        origin: Some(
+            1,
+        ),
+        checks: [
+            "check if valid_date($0), resource($0)",
+        ],
+    },
+]
   policies: {
     "allow if true",
 }
@@ -946,9 +1016,16 @@ World {
     },
 ]
   rules: []
-  checks: {
-    "check if resource($0), $0.matches(\"file[0-9]+.txt\")",
-}
+  checks: [
+    AuthorizerCheckSet {
+        origin: Some(
+            0,
+        ),
+        checks: [
+            "check if resource($0), $0.matches(\"file[0-9]+.txt\")",
+        ],
+    },
+]
   policies: {
     "allow if true",
 }
@@ -982,9 +1059,16 @@ World {
     },
 ]
   rules: []
-  checks: {
-    "check if resource($0), $0.matches(\"file[0-9]+.txt\")",
-}
+  checks: [
+    AuthorizerCheckSet {
+        origin: Some(
+            0,
+        ),
+        checks: [
+            "check if resource($0), $0.matches(\"file[0-9]+.txt\")",
+        ],
+    },
+]
   policies: {
     "allow if true",
 }
@@ -1036,9 +1120,16 @@ World {
     },
 ]
   rules: []
-  checks: {
-    "check if must_be_present($0) or must_be_present($0)",
-}
+  checks: [
+    AuthorizerCheckSet {
+        origin: Some(
+            18446744073709551615,
+        ),
+        checks: [
+            "check if must_be_present($0) or must_be_present($0)",
+        ],
+    },
+]
   policies: {
     "allow if true",
 }
@@ -1098,9 +1189,16 @@ World {
     },
 ]
   rules: []
-  checks: {
-    "check if resource(\"hello\")",
-}
+  checks: [
+    AuthorizerCheckSet {
+        origin: Some(
+            0,
+        ),
+        checks: [
+            "check if resource(\"hello\")",
+        ],
+    },
+]
   policies: {
     "allow if true",
 }
@@ -1177,46 +1275,54 @@ authorizer world:
 World {
   facts: []
   rules: []
-  checks: {
-    "check if !false",
-    "check if !false && true",
-    "check if \"aaabde\" == \"aaa\" + \"b\" + \"de\"",
-    "check if \"aaabde\".contains(\"abd\")",
-    "check if \"aaabde\".matches(\"a*c?.e\")",
-    "check if \"abcD12\" == \"abcD12\"",
-    "check if \"hello world\".starts_with(\"hello\") && \"hello world\".ends_with(\"world\")",
-    "check if (true || false) && true",
-    "check if 1 + 2 * 3 - 4 / 2 == 5",
-    "check if 1 < 2",
-    "check if 1 <= 1",
-    "check if 1 <= 2",
-    "check if 2 > 1",
-    "check if 2 >= 1",
-    "check if 2 >= 2",
-    "check if 2019-12-04T09:46:41Z < 2020-12-04T09:46:41Z",
-    "check if 2019-12-04T09:46:41Z <= 2020-12-04T09:46:41Z",
-    "check if 2020-12-04T09:46:41Z == 2020-12-04T09:46:41Z",
-    "check if 2020-12-04T09:46:41Z > 2019-12-04T09:46:41Z",
-    "check if 2020-12-04T09:46:41Z >= 2019-12-04T09:46:41Z",
-    "check if 2020-12-04T09:46:41Z >= 2020-12-04T09:46:41Z",
-    "check if 3 == 3",
-    "check if [\"abc\", \"def\"].contains(\"abc\")",
-    "check if [1, 2, 3].intersection([1, 2]).contains(1)",
-    "check if [1, 2, 3].intersection([1, 2]).length() == 2",
-    "check if [1, 2] == [1, 2]",
-    "check if [1, 2].contains(2)",
-    "check if [1, 2].contains([2])",
-    "check if [1, 2].intersection([2, 3]) == [2]",
-    "check if [1, 2].union([2, 3]) == [1, 2, 3]",
-    "check if [2019-12-04T09:46:41Z, 2020-12-04T09:46:41Z].contains(2020-12-04T09:46:41Z)",
-    "check if [false, true].contains(true)",
-    "check if [hex:12ab, hex:34de].contains(hex:34de)",
-    "check if false == false",
-    "check if false || true",
-    "check if hex:12ab == hex:12ab",
-    "check if true",
-    "check if true == true",
-}
+  checks: [
+    AuthorizerCheckSet {
+        origin: Some(
+            0,
+        ),
+        checks: [
+            "check if !false",
+            "check if !false && true",
+            "check if \"aaabde\" == \"aaa\" + \"b\" + \"de\"",
+            "check if \"aaabde\".contains(\"abd\")",
+            "check if \"aaabde\".matches(\"a*c?.e\")",
+            "check if \"abcD12\" == \"abcD12\"",
+            "check if \"hello world\".starts_with(\"hello\") && \"hello world\".ends_with(\"world\")",
+            "check if (true || false) && true",
+            "check if 1 + 2 * 3 - 4 / 2 == 5",
+            "check if 1 < 2",
+            "check if 1 <= 1",
+            "check if 1 <= 2",
+            "check if 2 > 1",
+            "check if 2 >= 1",
+            "check if 2 >= 2",
+            "check if 2019-12-04T09:46:41Z < 2020-12-04T09:46:41Z",
+            "check if 2019-12-04T09:46:41Z <= 2020-12-04T09:46:41Z",
+            "check if 2020-12-04T09:46:41Z == 2020-12-04T09:46:41Z",
+            "check if 2020-12-04T09:46:41Z > 2019-12-04T09:46:41Z",
+            "check if 2020-12-04T09:46:41Z >= 2019-12-04T09:46:41Z",
+            "check if 2020-12-04T09:46:41Z >= 2020-12-04T09:46:41Z",
+            "check if 2020-12-04T09:46:41Z >= 2020-12-04T09:46:41Z",
+            "check if 3 == 3",
+            "check if [\"abc\", \"def\"].contains(\"abc\")",
+            "check if [1, 2, 3].intersection([1, 2]).contains(1)",
+            "check if [1, 2, 3].intersection([1, 2]).length() == 2",
+            "check if [1, 2] == [1, 2]",
+            "check if [1, 2].contains(2)",
+            "check if [1, 2].contains([2])",
+            "check if [1, 2].intersection([2, 3]) == [2]",
+            "check if [1, 2].union([2, 3]) == [1, 2, 3]",
+            "check if [2019-12-04T09:46:41Z, 2020-12-04T09:46:41Z].contains(2020-12-04T09:46:41Z)",
+            "check if [false, true].contains(true)",
+            "check if [hex:12ab, hex:34de].contains(hex:34de)",
+            "check if false == false",
+            "check if false || true",
+            "check if hex:12ab == hex:12ab",
+            "check if true",
+            "check if true == true",
+        ],
+    },
+]
   policies: {
     "allow if true",
 }
@@ -1324,9 +1430,16 @@ World {
         ],
     },
 ]
-  checks: {
-    "check if operation(\"read\")",
-}
+  checks: [
+    AuthorizerCheckSet {
+        origin: Some(
+            0,
+        ),
+        checks: [
+            "check if operation(\"read\")",
+        ],
+    },
+]
   policies: {
     "allow if true",
 }
@@ -1381,15 +1494,6 @@ World {
   facts: [
     AuthorizerFactSet {
         origin: {
-            None,
-        },
-        facts: [
-            "operation(\"read\")",
-            "resource(\"file1\")",
-        ],
-    },
-    AuthorizerFactSet {
-        origin: {
             Some(
                 0,
             ),
@@ -1400,11 +1504,27 @@ World {
             "right(\"file2\", \"read\")",
         ],
     },
+    AuthorizerFactSet {
+        origin: {
+            None,
+        },
+        facts: [
+            "operation(\"read\")",
+            "resource(\"file1\")",
+        ],
+    },
 ]
   rules: []
-  checks: {
-    "check if resource($0), operation(\"read\"), right($0, \"read\")",
-}
+  checks: [
+    AuthorizerCheckSet {
+        origin: Some(
+            1,
+        ),
+        checks: [
+            "check if resource($0), operation(\"read\"), right($0, \"read\")",
+        ],
+    },
+]
   policies: {
     "allow if true",
 }
@@ -1456,9 +1576,16 @@ World {
     },
 ]
   rules: []
-  checks: {
-    "check if ns::fact_123(\"hello é\t😁\")",
-}
+  checks: [
+    AuthorizerCheckSet {
+        origin: Some(
+            18446744073709551615,
+        ),
+        checks: [
+            "check if ns::fact_123(\"hello é\t😁\")",
+        ],
+    },
+]
   policies: {
     "allow if true",
 }
@@ -1564,9 +1691,16 @@ World {
     },
 ]
   rules: []
-  checks: {
-    "check if read(0), write(1), resource(2), operation(3), right(4), time(5), role(6), owner(7), tenant(8), namespace(9), user(10), team(11), service(12), admin(13), email(14), group(15), member(16), ip_address(17), client(18), client_ip(19), domain(20), path(21), version(22), cluster(23), node(24), hostname(25), nonce(26), query(27)",
-}
+  checks: [
+    AuthorizerCheckSet {
+        origin: Some(
+            18446744073709551615,
+        ),
+        checks: [
+            "check if read(0), write(1), resource(2), operation(3), right(4), time(5), role(6), owner(7), tenant(8), namespace(9), user(10), team(11), service(12), admin(13), email(14), group(15), member(16), ip_address(17), client(18), client_ip(19), domain(20), path(21), version(22), cluster(23), node(24), hostname(25), nonce(26), query(27)",
+        ],
+    },
+]
   policies: {
     "allow if true",
 }
@@ -1647,10 +1781,17 @@ World {
     },
 ]
   rules: []
-  checks: {
-    "check if authority_fact($var)",
-    "check if block1_fact($var)",
-}
+  checks: [
+    AuthorizerCheckSet {
+        origin: Some(
+            2,
+        ),
+        checks: [
+            "check if authority_fact($var)",
+            "check if block1_fact($var)",
+        ],
+    },
+]
   policies: {
     "allow if true",
 }
@@ -1705,16 +1846,6 @@ World {
     AuthorizerFactSet {
         origin: {
             Some(
-                1,
-            ),
-        },
-        facts: [
-            "group(\"admin\")",
-        ],
-    },
-    AuthorizerFactSet {
-        origin: {
-            Some(
                 0,
             ),
         },
@@ -1722,12 +1853,36 @@ World {
             "right(\"read\")",
         ],
     },
+    AuthorizerFactSet {
+        origin: {
+            Some(
+                1,
+            ),
+        },
+        facts: [
+            "group(\"admin\")",
+        ],
+    },
 ]
   rules: []
-  checks: {
-    "check if group(\"admin\") trusting ed25519/acdd6d5b53bfee478bf689f8e012fe7988bf755e3d7c5152947abc149bc20189",
-    "check if right(\"read\")",
-}
+  checks: [
+    AuthorizerCheckSet {
+        origin: Some(
+            0,
+        ),
+        checks: [
+            "check if group(\"admin\") trusting ed25519/acdd6d5b53bfee478bf689f8e012fe7988bf755e3d7c5152947abc149bc20189",
+        ],
+    },
+    AuthorizerCheckSet {
+        origin: Some(
+            1,
+        ),
+        checks: [
+            "check if right(\"read\")",
+        ],
+    },
+]
   policies: {
     "allow if true",
 }
@@ -1790,9 +1945,16 @@ World {
     },
 ]
   rules: []
-  checks: {
-    "check all operation($op), allowed_operations($allowed), $allowed.contains($op)",
-}
+  checks: [
+    AuthorizerCheckSet {
+        origin: Some(
+            0,
+        ),
+        checks: [
+            "check all operation($op), allowed_operations($allowed), $allowed.contains($op)",
+        ],
+    },
+]
   policies: {
     "allow if true",
 }
@@ -1819,6 +1981,15 @@ World {
   facts: [
     AuthorizerFactSet {
         origin: {
+            None,
+        },
+        facts: [
+            "operation(\"A\")",
+            "operation(\"invalid\")",
+        ],
+    },
+    AuthorizerFactSet {
+        origin: {
             Some(
                 0,
             ),
@@ -1827,20 +1998,18 @@ World {
             "allowed_operations([\"A\", \"B\"])",
         ],
     },
-    AuthorizerFactSet {
-        origin: {
-            None,
-        },
-        facts: [
-            "operation(\"A\")",
-            "operation(\"invalid\")",
+]
+  rules: []
+  checks: [
+    AuthorizerCheckSet {
+        origin: Some(
+            0,
+        ),
+        checks: [
+            "check all operation($op), allowed_operations($allowed), $allowed.contains($op)",
         ],
     },
 ]
-  rules: []
-  checks: {
-    "check all operation($op), allowed_operations($allowed), $allowed.contains($op)",
-}
   policies: {
     "allow if true",
 }
@@ -1944,16 +2113,6 @@ World {
             Some(
                 1,
             ),
-        },
-        facts: [
-            "query(1)",
-        ],
-    },
-    AuthorizerFactSet {
-        origin: {
-            Some(
-                1,
-            ),
             Some(
                 2,
             ),
@@ -1965,11 +2124,31 @@ World {
     AuthorizerFactSet {
         origin: {
             Some(
+                1,
+            ),
+        },
+        facts: [
+            "query(1)",
+        ],
+    },
+    AuthorizerFactSet {
+        origin: {
+            Some(
                 3,
             ),
         },
         facts: [
             "query(3)",
+        ],
+    },
+    AuthorizerFactSet {
+        origin: {
+            Some(
+                4,
+            ),
+        },
+        facts: [
+            "query(4)",
         ],
     },
     AuthorizerFactSet {
@@ -1992,16 +2171,6 @@ World {
             "query(2)",
         ],
     },
-    AuthorizerFactSet {
-        origin: {
-            Some(
-                4,
-            ),
-        },
-        facts: [
-            "query(4)",
-        ],
-    },
 ]
   rules: [
     AuthorizerRuleSet {
@@ -2013,14 +2182,60 @@ World {
         ],
     },
 ]
-  checks: {
-    "check if query(1) trusting ed25519/acdd6d5b53bfee478bf689f8e012fe7988bf755e3d7c5152947abc149bc20189",
-    "check if query(1, 2) trusting ed25519/acdd6d5b53bfee478bf689f8e012fe7988bf755e3d7c5152947abc149bc20189, ed25519/a060270db7e9c9f06e8f9cc33a64e99f6596af12cb01c4b638df8afc7b642463",
-    "check if query(2) trusting ed25519/a060270db7e9c9f06e8f9cc33a64e99f6596af12cb01c4b638df8afc7b642463",
-    "check if query(2), query(3) trusting ed25519/a060270db7e9c9f06e8f9cc33a64e99f6596af12cb01c4b638df8afc7b642463",
-    "check if query(4) trusting ed25519/f98da8c1cf907856431bfc3dc87531e0eaadba90f919edc232405b85877ef136",
-    "check if true trusting previous, ed25519/acdd6d5b53bfee478bf689f8e012fe7988bf755e3d7c5152947abc149bc20189",
-}
+  checks: [
+    AuthorizerCheckSet {
+        origin: Some(
+            0,
+        ),
+        checks: [
+            "check if true trusting previous, ed25519/acdd6d5b53bfee478bf689f8e012fe7988bf755e3d7c5152947abc149bc20189",
+        ],
+    },
+    AuthorizerCheckSet {
+        origin: Some(
+            1,
+        ),
+        checks: [
+            "check if query(1) trusting ed25519/acdd6d5b53bfee478bf689f8e012fe7988bf755e3d7c5152947abc149bc20189",
+            "check if query(2), query(3) trusting ed25519/a060270db7e9c9f06e8f9cc33a64e99f6596af12cb01c4b638df8afc7b642463",
+        ],
+    },
+    AuthorizerCheckSet {
+        origin: Some(
+            2,
+        ),
+        checks: [
+            "check if query(1) trusting ed25519/acdd6d5b53bfee478bf689f8e012fe7988bf755e3d7c5152947abc149bc20189",
+            "check if query(2), query(3) trusting ed25519/a060270db7e9c9f06e8f9cc33a64e99f6596af12cb01c4b638df8afc7b642463",
+        ],
+    },
+    AuthorizerCheckSet {
+        origin: Some(
+            3,
+        ),
+        checks: [
+            "check if query(1) trusting ed25519/acdd6d5b53bfee478bf689f8e012fe7988bf755e3d7c5152947abc149bc20189",
+            "check if query(2), query(3) trusting ed25519/a060270db7e9c9f06e8f9cc33a64e99f6596af12cb01c4b638df8afc7b642463",
+        ],
+    },
+    AuthorizerCheckSet {
+        origin: Some(
+            4,
+        ),
+        checks: [
+            "check if query(2) trusting ed25519/a060270db7e9c9f06e8f9cc33a64e99f6596af12cb01c4b638df8afc7b642463",
+            "check if query(4) trusting ed25519/f98da8c1cf907856431bfc3dc87531e0eaadba90f919edc232405b85877ef136",
+        ],
+    },
+    AuthorizerCheckSet {
+        origin: Some(
+            18446744073709551615,
+        ),
+        checks: [
+            "check if query(1, 2) trusting ed25519/acdd6d5b53bfee478bf689f8e012fe7988bf755e3d7c5152947abc149bc20189, ed25519/a060270db7e9c9f06e8f9cc33a64e99f6596af12cb01c4b638df8afc7b642463",
+        ],
+    },
+]
   policies: {
     "allow if true",
     "deny if query(0) trusting ed25519/acdd6d5b53bfee478bf689f8e012fe7988bf755e3d7c5152947abc149bc20189",
@@ -2064,11 +2279,18 @@ authorizer world:
 World {
   facts: []
   rules: []
-  checks: {
-    "check if true || -9223372036854775808 - 1 != 0",
-    "check if true || 10000000000 * 10000000000 != 0",
-    "check if true || 9223372036854775807 + 1 != 0",
-}
+  checks: [
+    AuthorizerCheckSet {
+        origin: Some(
+            0,
+        ),
+        checks: [
+            "check if true || -9223372036854775808 - 1 != 0",
+            "check if true || 10000000000 * 10000000000 != 0",
+            "check if true || 9223372036854775807 + 1 != 0",
+        ],
+    },
+]
   policies: {
     "allow if true",
 }
@@ -2112,14 +2334,21 @@ authorizer world:
 World {
   facts: []
   rules: []
-  checks: {
-    "check if \"abcD12x\" != \"abcD12\"",
-    "check if 1 != 3",
-    "check if 1 | 2 ^ 3 == 0",
-    "check if 2022-12-04T09:46:41Z != 2020-12-04T09:46:41Z",
-    "check if [1, 4] != [1, 2]",
-    "check if hex:12abcd != hex:12ab",
-}
+  checks: [
+    AuthorizerCheckSet {
+        origin: Some(
+            0,
+        ),
+        checks: [
+            "check if \"abcD12x\" != \"abcD12\"",
+            "check if 1 != 3",
+            "check if 1 | 2 ^ 3 == 0",
+            "check if 2022-12-04T09:46:41Z != 2020-12-04T09:46:41Z",
+            "check if [1, 4] != [1, 2]",
+            "check if hex:12abcd != hex:12ab",
+        ],
+    },
+]
   policies: {
     "allow if true",
 }

--- a/biscuit-auth/samples/README.md
+++ b/biscuit-auth/samples/README.md
@@ -77,9 +77,9 @@ World {
         ],
     },
 ]
-  policies: {
+  policies: [
     "allow if true",
-}
+]
 }
 ```
 
@@ -347,9 +347,9 @@ World {
         ],
     },
 ]
-  policies: {
+  policies: [
     "allow if true",
-}
+]
 }
 ```
 
@@ -448,9 +448,9 @@ World {
         ],
     },
 ]
-  policies: {
+  policies: [
     "allow if true",
-}
+]
 }
 ```
 
@@ -522,9 +522,9 @@ World {
         ],
     },
 ]
-  policies: {
+  policies: [
     "allow if true",
-}
+]
 }
 ```
 
@@ -615,9 +615,9 @@ World {
         ],
     },
 ]
-  policies: {
+  policies: [
     "allow if true",
-}
+]
 }
 ```
 
@@ -688,9 +688,9 @@ World {
         ],
     },
 ]
-  policies: {
+  policies: [
     "allow if true",
-}
+]
 }
 ```
 
@@ -749,9 +749,9 @@ World {
         ],
     },
 ]
-  policies: {
+  policies: [
     "allow if true",
-}
+]
 }
 ```
 
@@ -794,9 +794,9 @@ World {
         ],
     },
 ]
-  policies: {
+  policies: [
     "allow if true",
-}
+]
 }
 ```
 
@@ -900,9 +900,9 @@ World {
         ],
     },
 ]
-  policies: {
+  policies: [
     "allow if true",
-}
+]
 }
 ```
 
@@ -967,9 +967,9 @@ World {
         ],
     },
 ]
-  policies: {
+  policies: [
     "allow if true",
-}
+]
 }
 ```
 
@@ -1026,9 +1026,9 @@ World {
         ],
     },
 ]
-  policies: {
+  policies: [
     "allow if true",
-}
+]
 }
 ```
 
@@ -1069,9 +1069,9 @@ World {
         ],
     },
 ]
-  policies: {
+  policies: [
     "allow if true",
-}
+]
 }
 ```
 
@@ -1130,9 +1130,9 @@ World {
         ],
     },
 ]
-  policies: {
+  policies: [
     "allow if true",
-}
+]
 }
 ```
 
@@ -1199,9 +1199,9 @@ World {
         ],
     },
 ]
-  policies: {
+  policies: [
     "allow if true",
-}
+]
 }
 ```
 
@@ -1323,9 +1323,9 @@ World {
         ],
     },
 ]
-  policies: {
+  policies: [
     "allow if true",
-}
+]
 }
 ```
 
@@ -1440,9 +1440,9 @@ World {
         ],
     },
 ]
-  policies: {
+  policies: [
     "allow if true",
-}
+]
 }
 ```
 
@@ -1525,9 +1525,9 @@ World {
         ],
     },
 ]
-  policies: {
+  policies: [
     "allow if true",
-}
+]
 }
 ```
 
@@ -1586,9 +1586,9 @@ World {
         ],
     },
 ]
-  policies: {
+  policies: [
     "allow if true",
-}
+]
 }
 ```
 
@@ -1701,9 +1701,9 @@ World {
         ],
     },
 ]
-  policies: {
+  policies: [
     "allow if true",
-}
+]
 }
 ```
 
@@ -1792,9 +1792,9 @@ World {
         ],
     },
 ]
-  policies: {
+  policies: [
     "allow if true",
-}
+]
 }
 ```
 
@@ -1883,9 +1883,9 @@ World {
         ],
     },
 ]
-  policies: {
+  policies: [
     "allow if true",
-}
+]
 }
 ```
 
@@ -1955,9 +1955,9 @@ World {
         ],
     },
 ]
-  policies: {
+  policies: [
     "allow if true",
-}
+]
 }
 ```
 
@@ -2010,9 +2010,9 @@ World {
         ],
     },
 ]
-  policies: {
+  policies: [
     "allow if true",
-}
+]
 }
 ```
 
@@ -2236,12 +2236,12 @@ World {
         ],
     },
 ]
-  policies: {
-    "allow if true",
-    "deny if query(0) trusting ed25519/acdd6d5b53bfee478bf689f8e012fe7988bf755e3d7c5152947abc149bc20189",
-    "deny if query(1, 2)",
+  policies: [
     "deny if query(3)",
-}
+    "deny if query(1, 2)",
+    "deny if query(0) trusting ed25519/acdd6d5b53bfee478bf689f8e012fe7988bf755e3d7c5152947abc149bc20189",
+    "allow if true",
+]
 }
 ```
 
@@ -2291,9 +2291,9 @@ World {
         ],
     },
 ]
-  policies: {
+  policies: [
     "allow if true",
-}
+]
 }
 ```
 
@@ -2349,9 +2349,9 @@ World {
         ],
     },
 ]
-  policies: {
+  policies: [
     "allow if true",
-}
+]
 }
 ```
 

--- a/biscuit-auth/samples/README.md
+++ b/biscuit-auth/samples/README.md
@@ -47,6 +47,14 @@ World {
   facts: [
     AuthorizerFactSet {
         origin: {
+            None,
+        },
+        facts: [
+            "resource(\"file1\")",
+        ],
+    },
+    AuthorizerFactSet {
+        origin: {
             Some(
                 0,
             ),
@@ -55,14 +63,6 @@ World {
             "right(\"file1\", \"read\")",
             "right(\"file1\", \"write\")",
             "right(\"file2\", \"read\")",
-        ],
-    },
-    AuthorizerFactSet {
-        origin: {
-            None,
-        },
-        facts: [
-            "resource(\"file1\")",
         ],
     },
 ]
@@ -298,6 +298,15 @@ World {
   facts: [
     AuthorizerFactSet {
         origin: {
+            None,
+        },
+        facts: [
+            "operation(\"read\")",
+            "resource(\"file2\")",
+        ],
+    },
+    AuthorizerFactSet {
+        origin: {
             Some(
                 0,
             ),
@@ -305,15 +314,6 @@ World {
         facts: [
             "owner(\"alice\", \"file1\")",
             "user_id(\"alice\")",
-        ],
-    },
-    AuthorizerFactSet {
-        origin: {
-            None,
-        },
-        facts: [
-            "operation(\"read\")",
-            "resource(\"file2\")",
         ],
     },
     AuthorizerFactSet {
@@ -409,21 +409,21 @@ World {
   facts: [
     AuthorizerFactSet {
         origin: {
+            None,
+        },
+        facts: [
+            "operation(\"read\")",
+            "resource(\"file2\")",
+        ],
+    },
+    AuthorizerFactSet {
+        origin: {
             Some(
                 0,
             ),
         },
         facts: [
             "right(\"file1\", \"read\")",
-        ],
-    },
-    AuthorizerFactSet {
-        origin: {
-            None,
-        },
-        facts: [
-            "operation(\"read\")",
-            "resource(\"file2\")",
         ],
     },
     AuthorizerFactSet {
@@ -576,12 +576,11 @@ World {
   facts: [
     AuthorizerFactSet {
         origin: {
-            Some(
-                1,
-            ),
+            None,
         },
         facts: [
-            "right(\"file2\", \"read\")",
+            "operation(\"read\")",
+            "resource(\"file2\")",
         ],
     },
     AuthorizerFactSet {
@@ -596,11 +595,12 @@ World {
     },
     AuthorizerFactSet {
         origin: {
-            None,
+            Some(
+                1,
+            ),
         },
         facts: [
-            "operation(\"read\")",
-            "resource(\"file2\")",
+            "right(\"file2\", \"read\")",
         ],
     },
 ]
@@ -659,21 +659,21 @@ World {
   facts: [
     AuthorizerFactSet {
         origin: {
+            None,
+        },
+        facts: [
+            "operation(\"read\")",
+            "resource(\"file2\")",
+        ],
+    },
+    AuthorizerFactSet {
+        origin: {
             Some(
                 0,
             ),
         },
         facts: [
             "right(\"file1\", \"read\")",
-        ],
-    },
-    AuthorizerFactSet {
-        origin: {
-            None,
-        },
-        facts: [
-            "operation(\"read\")",
-            "resource(\"file2\")",
         ],
     },
 ]
@@ -849,17 +849,6 @@ World {
   facts: [
     AuthorizerFactSet {
         origin: {
-            Some(
-                0,
-            ),
-        },
-        facts: [
-            "right(\"file1\", \"read\")",
-            "right(\"file2\", \"read\")",
-        ],
-    },
-    AuthorizerFactSet {
-        origin: {
             None,
         },
         facts: [
@@ -876,6 +865,17 @@ World {
         },
         facts: [
             "valid_date(\"file1\")",
+        ],
+    },
+    AuthorizerFactSet {
+        origin: {
+            Some(
+                0,
+            ),
+        },
+        facts: [
+            "right(\"file1\", \"read\")",
+            "right(\"file2\", \"read\")",
         ],
     },
 ]
@@ -1403,20 +1403,20 @@ World {
     AuthorizerFactSet {
         origin: {
             None,
+        },
+        facts: [
+            "operation(\"write\")",
+        ],
+    },
+    AuthorizerFactSet {
+        origin: {
+            None,
             Some(
                 1,
             ),
         },
         facts: [
             "operation(\"read\")",
-        ],
-    },
-    AuthorizerFactSet {
-        origin: {
-            None,
-        },
-        facts: [
-            "operation(\"write\")",
         ],
     },
 ]
@@ -1494,6 +1494,15 @@ World {
   facts: [
     AuthorizerFactSet {
         origin: {
+            None,
+        },
+        facts: [
+            "operation(\"read\")",
+            "resource(\"file1\")",
+        ],
+    },
+    AuthorizerFactSet {
+        origin: {
             Some(
                 0,
             ),
@@ -1502,15 +1511,6 @@ World {
             "right(\"file1\", \"read\")",
             "right(\"file1\", \"write\")",
             "right(\"file2\", \"read\")",
-        ],
-    },
-    AuthorizerFactSet {
-        origin: {
-            None,
-        },
-        facts: [
-            "operation(\"read\")",
-            "resource(\"file1\")",
         ],
     },
 ]
@@ -1926,21 +1926,21 @@ World {
   facts: [
     AuthorizerFactSet {
         origin: {
+            None,
+        },
+        facts: [
+            "operation(\"A\")",
+            "operation(\"B\")",
+        ],
+    },
+    AuthorizerFactSet {
+        origin: {
             Some(
                 0,
             ),
         },
         facts: [
             "allowed_operations([\"A\", \"B\"])",
-        ],
-    },
-    AuthorizerFactSet {
-        origin: {
-            None,
-        },
-        facts: [
-            "operation(\"A\")",
-            "operation(\"B\")",
         ],
     },
 ]
@@ -2111,6 +2111,26 @@ World {
     AuthorizerFactSet {
         origin: {
             Some(
+                0,
+            ),
+        },
+        facts: [
+            "query(0)",
+        ],
+    },
+    AuthorizerFactSet {
+        origin: {
+            Some(
+                1,
+            ),
+        },
+        facts: [
+            "query(1)",
+        ],
+    },
+    AuthorizerFactSet {
+        origin: {
+            Some(
                 1,
             ),
             Some(
@@ -2124,11 +2144,11 @@ World {
     AuthorizerFactSet {
         origin: {
             Some(
-                1,
+                2,
             ),
         },
         facts: [
-            "query(1)",
+            "query(2)",
         ],
     },
     AuthorizerFactSet {
@@ -2149,26 +2169,6 @@ World {
         },
         facts: [
             "query(4)",
-        ],
-    },
-    AuthorizerFactSet {
-        origin: {
-            Some(
-                0,
-            ),
-        },
-        facts: [
-            "query(0)",
-        ],
-    },
-    AuthorizerFactSet {
-        origin: {
-            Some(
-                2,
-            ),
-        },
-        facts: [
-            "query(2)",
         ],
     },
 ]

--- a/biscuit-auth/samples/README.md
+++ b/biscuit-auth/samples/README.md
@@ -44,39 +44,29 @@ revocation ids:
 authorizer world:
 ```
 World {
-  facts: {
-    (
-        "resource(\"file1\")",
-        {
+  facts: [
+    AuthorizerFactSet {
+        origin: {
+            Some(
+                0,
+            ),
+        },
+        facts: [
+            "right(\"file1\", \"read\")",
+            "right(\"file1\", \"write\")",
+            "right(\"file2\", \"read\")",
+        ],
+    },
+    AuthorizerFactSet {
+        origin: {
             None,
         },
-    ),
-    (
-        "right(\"file1\", \"read\")",
-        {
-            Some(
-                0,
-            ),
-        },
-    ),
-    (
-        "right(\"file1\", \"write\")",
-        {
-            Some(
-                0,
-            ),
-        },
-    ),
-    (
-        "right(\"file2\", \"read\")",
-        {
-            Some(
-                0,
-            ),
-        },
-    ),
-}
-  rules: {}
+        facts: [
+            "resource(\"file1\")",
+        ],
+    },
+]
+  rules: []
   checks: {
     "check if resource($0), operation(\"read\"), right($0, \"read\")",
 }
@@ -298,52 +288,48 @@ revocation ids:
 authorizer world:
 ```
 World {
-  facts: {
-    (
-        "operation(\"read\")",
-        {
-            None,
-        },
-    ),
-    (
-        "owner(\"alice\", \"file1\")",
-        {
+  facts: [
+    AuthorizerFactSet {
+        origin: {
             Some(
                 0,
             ),
         },
-    ),
-    (
-        "owner(\"alice\", \"file2\")",
-        {
+        facts: [
+            "owner(\"alice\", \"file1\")",
+            "user_id(\"alice\")",
+        ],
+    },
+    AuthorizerFactSet {
+        origin: {
+            None,
+        },
+        facts: [
+            "operation(\"read\")",
+            "resource(\"file2\")",
+        ],
+    },
+    AuthorizerFactSet {
+        origin: {
             Some(
                 2,
             ),
         },
-    ),
-    (
-        "resource(\"file2\")",
-        {
-            None,
-        },
-    ),
-    (
-        "user_id(\"alice\")",
-        {
-            Some(
-                0,
-            ),
-        },
-    ),
-}
-  rules: {
-    (
-        "right($0, \"read\") <- resource($0), user_id($1), owner($1, $0)",
-        Some(
+        facts: [
+            "owner(\"alice\", \"file2\")",
+        ],
+    },
+]
+  rules: [
+    AuthorizerRuleSet {
+        origin: Some(
             1,
         ),
-    ),
-}
+        rules: [
+            "right($0, \"read\") <- resource($0), user_id($1), owner($1, $0)",
+        ],
+    },
+]
   checks: {
     "check if resource($0), operation(\"read\"), right($0, \"read\")",
 }
@@ -406,37 +392,38 @@ revocation ids:
 authorizer world:
 ```
 World {
-  facts: {
-    (
-        "operation(\"read\")",
-        {
+  facts: [
+    AuthorizerFactSet {
+        origin: {
             None,
         },
-    ),
-    (
-        "resource(\"file2\")",
-        {
-            None,
-        },
-    ),
-    (
-        "right(\"file1\", \"read\")",
-        {
+        facts: [
+            "operation(\"read\")",
+            "resource(\"file2\")",
+        ],
+    },
+    AuthorizerFactSet {
+        origin: {
             Some(
                 0,
             ),
         },
-    ),
-    (
-        "right(\"file2\", \"read\")",
-        {
+        facts: [
+            "right(\"file1\", \"read\")",
+        ],
+    },
+    AuthorizerFactSet {
+        origin: {
             Some(
                 2,
             ),
         },
-    ),
-}
-  rules: {}
+        facts: [
+            "right(\"file2\", \"read\")",
+        ],
+    },
+]
+  rules: []
   checks: {
     "check if resource($0), operation(\"read\"), right($0, \"read\")",
 }
@@ -490,27 +477,19 @@ revocation ids:
 authorizer world:
 ```
 World {
-  facts: {
-    (
-        "operation(\"read\")",
-        {
+  facts: [
+    AuthorizerFactSet {
+        origin: {
             None,
         },
-    ),
-    (
-        "resource(\"file1\")",
-        {
-            None,
-        },
-    ),
-    (
-        "time(2020-12-21T09:23:12Z)",
-        {
-            None,
-        },
-    ),
-}
-  rules: {}
+        facts: [
+            "operation(\"read\")",
+            "resource(\"file1\")",
+            "time(2020-12-21T09:23:12Z)",
+        ],
+    },
+]
+  rules: []
   checks: {
     "check if resource(\"file1\")",
     "check if time($time), $time <= 2018-12-20T00:00:00Z",
@@ -566,37 +545,38 @@ revocation ids:
 authorizer world:
 ```
 World {
-  facts: {
-    (
-        "operation(\"read\")",
-        {
+  facts: [
+    AuthorizerFactSet {
+        origin: {
             None,
         },
-    ),
-    (
-        "resource(\"file2\")",
-        {
-            None,
-        },
-    ),
-    (
-        "right(\"file1\", \"read\")",
-        {
+        facts: [
+            "operation(\"read\")",
+            "resource(\"file2\")",
+        ],
+    },
+    AuthorizerFactSet {
+        origin: {
             Some(
                 0,
             ),
         },
-    ),
-    (
-        "right(\"file2\", \"read\")",
-        {
+        facts: [
+            "right(\"file1\", \"read\")",
+        ],
+    },
+    AuthorizerFactSet {
+        origin: {
             Some(
                 1,
             ),
         },
-    ),
-}
-  rules: {}
+        facts: [
+            "right(\"file2\", \"read\")",
+        ],
+    },
+]
+  rules: []
   checks: {
     "check if right($0, $1), resource($0), operation($1)",
 }
@@ -641,29 +621,28 @@ revocation ids:
 authorizer world:
 ```
 World {
-  facts: {
-    (
-        "operation(\"read\")",
-        {
-            None,
-        },
-    ),
-    (
-        "resource(\"file2\")",
-        {
-            None,
-        },
-    ),
-    (
-        "right(\"file1\", \"read\")",
-        {
+  facts: [
+    AuthorizerFactSet {
+        origin: {
             Some(
                 0,
             ),
         },
-    ),
-}
-  rules: {}
+        facts: [
+            "right(\"file1\", \"read\")",
+        ],
+    },
+    AuthorizerFactSet {
+        origin: {
+            None,
+        },
+        facts: [
+            "operation(\"read\")",
+            "resource(\"file2\")",
+        ],
+    },
+]
+  rules: []
   checks: {
     "check if right($0, $1), resource($0), operation($1)",
 }
@@ -706,21 +685,18 @@ revocation ids:
 authorizer world:
 ```
 World {
-  facts: {
-    (
-        "operation(\"read\")",
-        {
+  facts: [
+    AuthorizerFactSet {
+        origin: {
             None,
         },
-    ),
-    (
-        "resource(\"file1\")",
-        {
-            None,
-        },
-    ),
-}
-  rules: {}
+        facts: [
+            "operation(\"read\")",
+            "resource(\"file1\")",
+        ],
+    },
+]
+  rules: []
   checks: {
     "check if resource(\"file1\")",
 }
@@ -747,21 +723,18 @@ revocation ids:
 authorizer world:
 ```
 World {
-  facts: {
-    (
-        "operation(\"read\")",
-        {
+  facts: [
+    AuthorizerFactSet {
+        origin: {
             None,
         },
-    ),
-    (
-        "resource(\"file2\")",
-        {
-            None,
-        },
-    ),
-}
-  rules: {}
+        facts: [
+            "operation(\"read\")",
+            "resource(\"file2\")",
+        ],
+    },
+]
+  rules: []
   checks: {
     "check if resource(\"file1\")",
 }
@@ -817,59 +790,50 @@ revocation ids:
 authorizer world:
 ```
 World {
-  facts: {
-    (
-        "resource(\"file1\")",
-        {
-            None,
-        },
-    ),
-    (
-        "right(\"file1\", \"read\")",
-        {
+  facts: [
+    AuthorizerFactSet {
+        origin: {
             Some(
                 0,
             ),
         },
-    ),
-    (
-        "right(\"file2\", \"read\")",
-        {
-            Some(
-                0,
-            ),
-        },
-    ),
-    (
-        "time(2020-12-21T09:23:12Z)",
-        {
+        facts: [
+            "right(\"file1\", \"read\")",
+            "right(\"file2\", \"read\")",
+        ],
+    },
+    AuthorizerFactSet {
+        origin: {
             None,
         },
-    ),
-    (
-        "valid_date(\"file1\")",
-        {
+        facts: [
+            "resource(\"file1\")",
+            "time(2020-12-21T09:23:12Z)",
+        ],
+    },
+    AuthorizerFactSet {
+        origin: {
             None,
             Some(
                 1,
             ),
         },
-    ),
-}
-  rules: {
-    (
-        "valid_date(\"file1\") <- time($0), resource(\"file1\"), $0 <= 2030-12-31T12:59:59Z",
-        Some(
+        facts: [
+            "valid_date(\"file1\")",
+        ],
+    },
+]
+  rules: [
+    AuthorizerRuleSet {
+        origin: Some(
             1,
         ),
-    ),
-    (
-        "valid_date($1) <- time($0), resource($1), $0 <= 1999-12-31T12:59:59Z, ![\"file1\"].contains($1)",
-        Some(
-            1,
-        ),
-    ),
-}
+        rules: [
+            "valid_date(\"file1\") <- time($0), resource(\"file1\"), $0 <= 2030-12-31T12:59:59Z",
+            "valid_date($1) <- time($0), resource($1), $0 <= 1999-12-31T12:59:59Z, ![\"file1\"].contains($1)",
+        ],
+    },
+]
   checks: {
     "check if valid_date($0), resource($0)",
 }
@@ -897,50 +861,39 @@ revocation ids:
 authorizer world:
 ```
 World {
-  facts: {
-    (
-        "resource(\"file2\")",
-        {
+  facts: [
+    AuthorizerFactSet {
+        origin: {
             None,
         },
-    ),
-    (
-        "right(\"file1\", \"read\")",
-        {
+        facts: [
+            "resource(\"file2\")",
+            "time(2020-12-21T09:23:12Z)",
+        ],
+    },
+    AuthorizerFactSet {
+        origin: {
             Some(
                 0,
             ),
         },
-    ),
-    (
-        "right(\"file2\", \"read\")",
-        {
-            Some(
-                0,
-            ),
-        },
-    ),
-    (
-        "time(2020-12-21T09:23:12Z)",
-        {
-            None,
-        },
-    ),
-}
-  rules: {
-    (
-        "valid_date(\"file1\") <- time($0), resource(\"file1\"), $0 <= 2030-12-31T12:59:59Z",
-        Some(
+        facts: [
+            "right(\"file1\", \"read\")",
+            "right(\"file2\", \"read\")",
+        ],
+    },
+]
+  rules: [
+    AuthorizerRuleSet {
+        origin: Some(
             1,
         ),
-    ),
-    (
-        "valid_date($1) <- time($0), resource($1), $0 <= 1999-12-31T12:59:59Z, ![\"file1\"].contains($1)",
-        Some(
-            1,
-        ),
-    ),
-}
+        rules: [
+            "valid_date(\"file1\") <- time($0), resource(\"file1\"), $0 <= 2030-12-31T12:59:59Z",
+            "valid_date($1) <- time($0), resource($1), $0 <= 1999-12-31T12:59:59Z, ![\"file1\"].contains($1)",
+        ],
+    },
+]
   checks: {
     "check if valid_date($0), resource($0)",
 }
@@ -982,15 +935,17 @@ revocation ids:
 authorizer world:
 ```
 World {
-  facts: {
-    (
-        "resource(\"file1\")",
-        {
+  facts: [
+    AuthorizerFactSet {
+        origin: {
             None,
         },
-    ),
-}
-  rules: {}
+        facts: [
+            "resource(\"file1\")",
+        ],
+    },
+]
+  rules: []
   checks: {
     "check if resource($0), $0.matches(\"file[0-9]+.txt\")",
 }
@@ -1016,15 +971,17 @@ revocation ids:
 authorizer world:
 ```
 World {
-  facts: {
-    (
-        "resource(\"file123.txt\")",
-        {
+  facts: [
+    AuthorizerFactSet {
+        origin: {
             None,
         },
-    ),
-}
-  rules: {}
+        facts: [
+            "resource(\"file123.txt\")",
+        ],
+    },
+]
+  rules: []
   checks: {
     "check if resource($0), $0.matches(\"file[0-9]+.txt\")",
 }
@@ -1066,17 +1023,19 @@ revocation ids:
 authorizer world:
 ```
 World {
-  facts: {
-    (
-        "must_be_present(\"hello\")",
-        {
+  facts: [
+    AuthorizerFactSet {
+        origin: {
             Some(
                 0,
             ),
         },
-    ),
-}
-  rules: {}
+        facts: [
+            "must_be_present(\"hello\")",
+        ],
+    },
+]
+  rules: []
   checks: {
     "check if must_be_present($0) or must_be_present($0)",
 }
@@ -1126,17 +1085,19 @@ revocation ids:
 authorizer world:
 ```
 World {
-  facts: {
-    (
-        "query(\"test\")",
-        {
+  facts: [
+    AuthorizerFactSet {
+        origin: {
             Some(
                 1,
             ),
         },
-    ),
-}
-  rules: {}
+        facts: [
+            "query(\"test\")",
+        ],
+    },
+]
+  rules: []
   checks: {
     "check if resource(\"hello\")",
 }
@@ -1214,8 +1175,8 @@ revocation ids:
 authorizer world:
 ```
 World {
-  facts: {}
-  rules: {}
+  facts: []
+  rules: []
   checks: {
     "check if !false",
     "check if !false && true",
@@ -1332,31 +1293,37 @@ revocation ids:
 authorizer world:
 ```
 World {
-  facts: {
-    (
-        "operation(\"read\")",
-        {
+  facts: [
+    AuthorizerFactSet {
+        origin: {
             None,
             Some(
                 1,
             ),
         },
-    ),
-    (
-        "operation(\"write\")",
-        {
+        facts: [
+            "operation(\"read\")",
+        ],
+    },
+    AuthorizerFactSet {
+        origin: {
             None,
         },
-    ),
-}
-  rules: {
-    (
-        "operation(\"read\") <- operation($any)",
-        Some(
+        facts: [
+            "operation(\"write\")",
+        ],
+    },
+]
+  rules: [
+    AuthorizerRuleSet {
+        origin: Some(
             1,
         ),
-    ),
-}
+        rules: [
+            "operation(\"read\") <- operation($any)",
+        ],
+    },
+]
   checks: {
     "check if operation(\"read\")",
 }
@@ -1411,45 +1378,30 @@ revocation ids:
 authorizer world:
 ```
 World {
-  facts: {
-    (
-        "operation(\"read\")",
-        {
+  facts: [
+    AuthorizerFactSet {
+        origin: {
             None,
         },
-    ),
-    (
-        "resource(\"file1\")",
-        {
-            None,
-        },
-    ),
-    (
-        "right(\"file1\", \"read\")",
-        {
+        facts: [
+            "operation(\"read\")",
+            "resource(\"file1\")",
+        ],
+    },
+    AuthorizerFactSet {
+        origin: {
             Some(
                 0,
             ),
         },
-    ),
-    (
-        "right(\"file1\", \"write\")",
-        {
-            Some(
-                0,
-            ),
-        },
-    ),
-    (
-        "right(\"file2\", \"read\")",
-        {
-            Some(
-                0,
-            ),
-        },
-    ),
-}
-  rules: {}
+        facts: [
+            "right(\"file1\", \"read\")",
+            "right(\"file1\", \"write\")",
+            "right(\"file2\", \"read\")",
+        ],
+    },
+]
+  rules: []
   checks: {
     "check if resource($0), operation(\"read\"), right($0, \"read\")",
 }
@@ -1491,17 +1443,19 @@ revocation ids:
 authorizer world:
 ```
 World {
-  facts: {
-    (
-        "ns::fact_123(\"hello é\t😁\")",
-        {
+  facts: [
+    AuthorizerFactSet {
+        origin: {
             Some(
                 0,
             ),
         },
-    ),
-}
-  rules: {}
+        facts: [
+            "ns::fact_123(\"hello é\t😁\")",
+        ],
+    },
+]
+  rules: []
   checks: {
     "check if ns::fact_123(\"hello é\t😁\")",
 }
@@ -1570,233 +1524,46 @@ revocation ids:
 authorizer world:
 ```
 World {
-  facts: {
-    (
-        "admin(13)",
-        {
+  facts: [
+    AuthorizerFactSet {
+        origin: {
             Some(
                 0,
             ),
         },
-    ),
-    (
-        "client(18)",
-        {
-            Some(
-                0,
-            ),
-        },
-    ),
-    (
-        "client_ip(19)",
-        {
-            Some(
-                0,
-            ),
-        },
-    ),
-    (
-        "cluster(23)",
-        {
-            Some(
-                0,
-            ),
-        },
-    ),
-    (
-        "domain(20)",
-        {
-            Some(
-                0,
-            ),
-        },
-    ),
-    (
-        "email(14)",
-        {
-            Some(
-                0,
-            ),
-        },
-    ),
-    (
-        "group(15)",
-        {
-            Some(
-                0,
-            ),
-        },
-    ),
-    (
-        "hostname(25)",
-        {
-            Some(
-                0,
-            ),
-        },
-    ),
-    (
-        "ip_address(17)",
-        {
-            Some(
-                0,
-            ),
-        },
-    ),
-    (
-        "member(16)",
-        {
-            Some(
-                0,
-            ),
-        },
-    ),
-    (
-        "namespace(9)",
-        {
-            Some(
-                0,
-            ),
-        },
-    ),
-    (
-        "node(24)",
-        {
-            Some(
-                0,
-            ),
-        },
-    ),
-    (
-        "nonce(26)",
-        {
-            Some(
-                0,
-            ),
-        },
-    ),
-    (
-        "operation(3)",
-        {
-            Some(
-                0,
-            ),
-        },
-    ),
-    (
-        "owner(7)",
-        {
-            Some(
-                0,
-            ),
-        },
-    ),
-    (
-        "path(21)",
-        {
-            Some(
-                0,
-            ),
-        },
-    ),
-    (
-        "query(27)",
-        {
-            Some(
-                0,
-            ),
-        },
-    ),
-    (
-        "read(0)",
-        {
-            Some(
-                0,
-            ),
-        },
-    ),
-    (
-        "resource(2)",
-        {
-            Some(
-                0,
-            ),
-        },
-    ),
-    (
-        "right(4)",
-        {
-            Some(
-                0,
-            ),
-        },
-    ),
-    (
-        "role(6)",
-        {
-            Some(
-                0,
-            ),
-        },
-    ),
-    (
-        "service(12)",
-        {
-            Some(
-                0,
-            ),
-        },
-    ),
-    (
-        "team(11)",
-        {
-            Some(
-                0,
-            ),
-        },
-    ),
-    (
-        "tenant(8)",
-        {
-            Some(
-                0,
-            ),
-        },
-    ),
-    (
-        "time(5)",
-        {
-            Some(
-                0,
-            ),
-        },
-    ),
-    (
-        "user(10)",
-        {
-            Some(
-                0,
-            ),
-        },
-    ),
-    (
-        "version(22)",
-        {
-            Some(
-                0,
-            ),
-        },
-    ),
-    (
-        "write(1)",
-        {
-            Some(
-                0,
-            ),
-        },
-    ),
-}
-  rules: {}
+        facts: [
+            "admin(13)",
+            "client(18)",
+            "client_ip(19)",
+            "cluster(23)",
+            "domain(20)",
+            "email(14)",
+            "group(15)",
+            "hostname(25)",
+            "ip_address(17)",
+            "member(16)",
+            "namespace(9)",
+            "node(24)",
+            "nonce(26)",
+            "operation(3)",
+            "owner(7)",
+            "path(21)",
+            "query(27)",
+            "read(0)",
+            "resource(2)",
+            "right(4)",
+            "role(6)",
+            "service(12)",
+            "team(11)",
+            "tenant(8)",
+            "time(5)",
+            "user(10)",
+            "version(22)",
+            "write(1)",
+        ],
+    },
+]
+  rules: []
   checks: {
     "check if read(0), write(1), resource(2), operation(3), right(4), time(5), role(6), owner(7), tenant(8), namespace(9), user(10), team(11), service(12), admin(13), email(14), group(15), member(16), ip_address(17), client(18), client_ip(19), domain(20), path(21), version(22), cluster(23), node(24), hostname(25), nonce(26), query(27)",
 }
@@ -1857,25 +1624,29 @@ revocation ids:
 authorizer world:
 ```
 World {
-  facts: {
-    (
-        "authority_fact(1)",
-        {
+  facts: [
+    AuthorizerFactSet {
+        origin: {
             Some(
                 0,
             ),
         },
-    ),
-    (
-        "block1_fact(1)",
-        {
+        facts: [
+            "authority_fact(1)",
+        ],
+    },
+    AuthorizerFactSet {
+        origin: {
             Some(
                 1,
             ),
         },
-    ),
-}
-  rules: {}
+        facts: [
+            "block1_fact(1)",
+        ],
+    },
+]
+  rules: []
   checks: {
     "check if authority_fact($var)",
     "check if block1_fact($var)",
@@ -1930,25 +1701,29 @@ revocation ids:
 authorizer world:
 ```
 World {
-  facts: {
-    (
-        "group(\"admin\")",
-        {
+  facts: [
+    AuthorizerFactSet {
+        origin: {
             Some(
                 1,
             ),
         },
-    ),
-    (
-        "right(\"read\")",
-        {
+        facts: [
+            "group(\"admin\")",
+        ],
+    },
+    AuthorizerFactSet {
+        origin: {
             Some(
                 0,
             ),
         },
-    ),
-}
-  rules: {}
+        facts: [
+            "right(\"read\")",
+        ],
+    },
+]
+  rules: []
   checks: {
     "check if group(\"admin\") trusting ed25519/acdd6d5b53bfee478bf689f8e012fe7988bf755e3d7c5152947abc149bc20189",
     "check if right(\"read\")",
@@ -1993,29 +1768,28 @@ revocation ids:
 authorizer world:
 ```
 World {
-  facts: {
-    (
-        "allowed_operations([\"A\", \"B\"])",
-        {
+  facts: [
+    AuthorizerFactSet {
+        origin: {
             Some(
                 0,
             ),
         },
-    ),
-    (
-        "operation(\"A\")",
-        {
+        facts: [
+            "allowed_operations([\"A\", \"B\"])",
+        ],
+    },
+    AuthorizerFactSet {
+        origin: {
             None,
         },
-    ),
-    (
-        "operation(\"B\")",
-        {
-            None,
-        },
-    ),
-}
-  rules: {}
+        facts: [
+            "operation(\"A\")",
+            "operation(\"B\")",
+        ],
+    },
+]
+  rules: []
   checks: {
     "check all operation($op), allowed_operations($allowed), $allowed.contains($op)",
 }
@@ -2042,29 +1816,28 @@ revocation ids:
 authorizer world:
 ```
 World {
-  facts: {
-    (
-        "allowed_operations([\"A\", \"B\"])",
-        {
+  facts: [
+    AuthorizerFactSet {
+        origin: {
             Some(
                 0,
             ),
         },
-    ),
-    (
-        "operation(\"A\")",
-        {
+        facts: [
+            "allowed_operations([\"A\", \"B\"])",
+        ],
+    },
+    AuthorizerFactSet {
+        origin: {
             None,
         },
-    ),
-    (
-        "operation(\"invalid\")",
-        {
-            None,
-        },
-    ),
-}
-  rules: {}
+        facts: [
+            "operation(\"A\")",
+            "operation(\"invalid\")",
+        ],
+    },
+]
+  rules: []
   checks: {
     "check all operation($op), allowed_operations($allowed), $allowed.contains($op)",
 }
@@ -2165,26 +1938,19 @@ revocation ids:
 authorizer world:
 ```
 World {
-  facts: {
-    (
-        "query(0)",
-        {
-            Some(
-                0,
-            ),
-        },
-    ),
-    (
-        "query(1)",
-        {
+  facts: [
+    AuthorizerFactSet {
+        origin: {
             Some(
                 1,
             ),
         },
-    ),
-    (
-        "query(1, 2)",
-        {
+        facts: [
+            "query(1)",
+        ],
+    },
+    AuthorizerFactSet {
+        origin: {
             Some(
                 1,
             ),
@@ -2192,40 +1958,61 @@ World {
                 2,
             ),
         },
-    ),
-    (
-        "query(2)",
-        {
-            Some(
-                2,
-            ),
-        },
-    ),
-    (
-        "query(3)",
-        {
+        facts: [
+            "query(1, 2)",
+        ],
+    },
+    AuthorizerFactSet {
+        origin: {
             Some(
                 3,
             ),
         },
-    ),
-    (
-        "query(4)",
-        {
+        facts: [
+            "query(3)",
+        ],
+    },
+    AuthorizerFactSet {
+        origin: {
+            Some(
+                0,
+            ),
+        },
+        facts: [
+            "query(0)",
+        ],
+    },
+    AuthorizerFactSet {
+        origin: {
+            Some(
+                2,
+            ),
+        },
+        facts: [
+            "query(2)",
+        ],
+    },
+    AuthorizerFactSet {
+        origin: {
             Some(
                 4,
             ),
         },
-    ),
-}
-  rules: {
-    (
-        "query(1, 2) <- query(1), query(2) trusting ed25519/a060270db7e9c9f06e8f9cc33a64e99f6596af12cb01c4b638df8afc7b642463",
-        Some(
+        facts: [
+            "query(4)",
+        ],
+    },
+]
+  rules: [
+    AuthorizerRuleSet {
+        origin: Some(
             1,
         ),
-    ),
-}
+        rules: [
+            "query(1, 2) <- query(1), query(2) trusting ed25519/a060270db7e9c9f06e8f9cc33a64e99f6596af12cb01c4b638df8afc7b642463",
+        ],
+    },
+]
   checks: {
     "check if query(1) trusting ed25519/acdd6d5b53bfee478bf689f8e012fe7988bf755e3d7c5152947abc149bc20189",
     "check if query(1, 2) trusting ed25519/acdd6d5b53bfee478bf689f8e012fe7988bf755e3d7c5152947abc149bc20189, ed25519/a060270db7e9c9f06e8f9cc33a64e99f6596af12cb01c4b638df8afc7b642463",
@@ -2275,8 +2062,8 @@ revocation ids:
 authorizer world:
 ```
 World {
-  facts: {}
-  rules: {}
+  facts: []
+  rules: []
   checks: {
     "check if true || -9223372036854775808 - 1 != 0",
     "check if true || 10000000000 * 10000000000 != 0",
@@ -2323,8 +2110,8 @@ revocation ids:
 authorizer world:
 ```
 World {
-  facts: {}
-  rules: {}
+  facts: []
+  rules: []
   checks: {
     "check if \"abcD12x\" != \"abcD12\"",
     "check if 1 != 3",

--- a/biscuit-auth/samples/samples.json
+++ b/biscuit-auth/samples/samples.json
@@ -2067,10 +2067,10 @@
               }
             ],
             "policies": [
-              "allow if true",
-              "deny if query(0) trusting ed25519/acdd6d5b53bfee478bf689f8e012fe7988bf755e3d7c5152947abc149bc20189",
+              "deny if query(3)",
               "deny if query(1, 2)",
-              "deny if query(3)"
+              "deny if query(0) trusting ed25519/acdd6d5b53bfee478bf689f8e012fe7988bf755e3d7c5152947abc149bc20189",
+              "allow if true"
             ]
           },
           "result": {

--- a/biscuit-auth/samples/samples.json
+++ b/biscuit-auth/samples/samples.json
@@ -49,7 +49,12 @@
             ],
             "rules": [],
             "checks": [
-              "check if resource($0), operation(\"read\"), right($0, \"read\")"
+              {
+                "origin": 1,
+                "checks": [
+                  "check if resource($0), operation(\"read\"), right($0, \"read\")"
+                ]
+              }
             ],
             "policies": [
               "allow if true"
@@ -319,6 +324,14 @@
             "facts": [
               {
                 "origin": [
+                  2
+                ],
+                "facts": [
+                  "owner(\"alice\", \"file2\")"
+                ]
+              },
+              {
+                "origin": [
                   null
                 ],
                 "facts": [
@@ -334,14 +347,6 @@
                   "owner(\"alice\", \"file1\")",
                   "user_id(\"alice\")"
                 ]
-              },
-              {
-                "origin": [
-                  2
-                ],
-                "facts": [
-                  "owner(\"alice\", \"file2\")"
-                ]
               }
             ],
             "rules": [
@@ -353,7 +358,12 @@
               }
             ],
             "checks": [
-              "check if resource($0), operation(\"read\"), right($0, \"read\")"
+              {
+                "origin": 1,
+                "checks": [
+                  "check if resource($0), operation(\"read\"), right($0, \"read\")"
+                ]
+              }
             ],
             "policies": [
               "allow if true"
@@ -423,19 +433,19 @@
             "facts": [
               {
                 "origin": [
-                  0
-                ],
-                "facts": [
-                  "right(\"file1\", \"read\")"
-                ]
-              },
-              {
-                "origin": [
                   null
                 ],
                 "facts": [
                   "operation(\"read\")",
                   "resource(\"file2\")"
+                ]
+              },
+              {
+                "origin": [
+                  0
+                ],
+                "facts": [
+                  "right(\"file1\", \"read\")"
                 ]
               },
               {
@@ -449,7 +459,12 @@
             ],
             "rules": [],
             "checks": [
-              "check if resource($0), operation(\"read\"), right($0, \"read\")"
+              {
+                "origin": 1,
+                "checks": [
+                  "check if resource($0), operation(\"read\"), right($0, \"read\")"
+                ]
+              }
             ],
             "policies": [
               "allow if true"
@@ -520,8 +535,13 @@
             ],
             "rules": [],
             "checks": [
-              "check if resource(\"file1\")",
-              "check if time($time), $time <= 2018-12-20T00:00:00Z"
+              {
+                "origin": 1,
+                "checks": [
+                  "check if resource(\"file1\")",
+                  "check if time($time), $time <= 2018-12-20T00:00:00Z"
+                ]
+              }
             ],
             "policies": [
               "allow if true"
@@ -582,14 +602,6 @@
             "facts": [
               {
                 "origin": [
-                  1
-                ],
-                "facts": [
-                  "right(\"file2\", \"read\")"
-                ]
-              },
-              {
-                "origin": [
                   0
                 ],
                 "facts": [
@@ -604,11 +616,24 @@
                   "operation(\"read\")",
                   "resource(\"file2\")"
                 ]
+              },
+              {
+                "origin": [
+                  1
+                ],
+                "facts": [
+                  "right(\"file2\", \"read\")"
+                ]
               }
             ],
             "rules": [],
             "checks": [
-              "check if right($0, $1), resource($0), operation($1)"
+              {
+                "origin": 18446744073709551615,
+                "checks": [
+                  "check if right($0, $1), resource($0), operation($1)"
+                ]
+              }
             ],
             "policies": [
               "allow if true"
@@ -660,25 +685,30 @@
             "facts": [
               {
                 "origin": [
+                  0
+                ],
+                "facts": [
+                  "right(\"file1\", \"read\")"
+                ]
+              },
+              {
+                "origin": [
                   null
                 ],
                 "facts": [
                   "operation(\"read\")",
                   "resource(\"file2\")"
                 ]
-              },
-              {
-                "origin": [
-                  0
-                ],
-                "facts": [
-                  "right(\"file1\", \"read\")"
-                ]
               }
             ],
             "rules": [],
             "checks": [
-              "check if right($0, $1), resource($0), operation($1)"
+              {
+                "origin": 18446744073709551615,
+                "checks": [
+                  "check if right($0, $1), resource($0), operation($1)"
+                ]
+              }
             ],
             "policies": [
               "allow if true"
@@ -739,7 +769,12 @@
             ],
             "rules": [],
             "checks": [
-              "check if resource(\"file1\")"
+              {
+                "origin": 0,
+                "checks": [
+                  "check if resource(\"file1\")"
+                ]
+              }
             ],
             "policies": [
               "allow if true"
@@ -768,7 +803,12 @@
             ],
             "rules": [],
             "checks": [
-              "check if resource(\"file1\")"
+              {
+                "origin": 0,
+                "checks": [
+                  "check if resource(\"file1\")"
+                ]
+              }
             ],
             "policies": [
               "allow if true"
@@ -831,15 +871,6 @@
             "facts": [
               {
                 "origin": [
-                  null
-                ],
-                "facts": [
-                  "resource(\"file1\")",
-                  "time(2020-12-21T09:23:12Z)"
-                ]
-              },
-              {
-                "origin": [
                   null,
                   1
                 ],
@@ -855,6 +886,15 @@
                   "right(\"file1\", \"read\")",
                   "right(\"file2\", \"read\")"
                 ]
+              },
+              {
+                "origin": [
+                  null
+                ],
+                "facts": [
+                  "resource(\"file1\")",
+                  "time(2020-12-21T09:23:12Z)"
+                ]
               }
             ],
             "rules": [
@@ -867,7 +907,12 @@
               }
             ],
             "checks": [
-              "check if valid_date($0), resource($0)"
+              {
+                "origin": 1,
+                "checks": [
+                  "check if valid_date($0), resource($0)"
+                ]
+              }
             ],
             "policies": [
               "allow if true"
@@ -914,7 +959,12 @@
               }
             ],
             "checks": [
-              "check if valid_date($0), resource($0)"
+              {
+                "origin": 1,
+                "checks": [
+                  "check if valid_date($0), resource($0)"
+                ]
+              }
             ],
             "policies": [
               "allow if true"
@@ -977,7 +1027,12 @@
             ],
             "rules": [],
             "checks": [
-              "check if resource($0), $0.matches(\"file[0-9]+.txt\")"
+              {
+                "origin": 0,
+                "checks": [
+                  "check if resource($0), $0.matches(\"file[0-9]+.txt\")"
+                ]
+              }
             ],
             "policies": [
               "allow if true"
@@ -1022,7 +1077,12 @@
             ],
             "rules": [],
             "checks": [
-              "check if resource($0), $0.matches(\"file[0-9]+.txt\")"
+              {
+                "origin": 0,
+                "checks": [
+                  "check if resource($0), $0.matches(\"file[0-9]+.txt\")"
+                ]
+              }
             ],
             "policies": [
               "allow if true"
@@ -1067,7 +1127,12 @@
             ],
             "rules": [],
             "checks": [
-              "check if must_be_present($0) or must_be_present($0)"
+              {
+                "origin": 18446744073709551615,
+                "checks": [
+                  "check if must_be_present($0) or must_be_present($0)"
+                ]
+              }
             ],
             "policies": [
               "allow if true"
@@ -1119,7 +1184,12 @@
             ],
             "rules": [],
             "checks": [
-              "check if resource(\"hello\")"
+              {
+                "origin": 0,
+                "checks": [
+                  "check if resource(\"hello\")"
+                ]
+              }
             ],
             "policies": [
               "allow if true"
@@ -1183,44 +1253,50 @@
             "facts": [],
             "rules": [],
             "checks": [
-              "check if !false",
-              "check if !false && true",
-              "check if \"aaabde\" == \"aaa\" + \"b\" + \"de\"",
-              "check if \"aaabde\".contains(\"abd\")",
-              "check if \"aaabde\".matches(\"a*c?.e\")",
-              "check if \"abcD12\" == \"abcD12\"",
-              "check if \"hello world\".starts_with(\"hello\") && \"hello world\".ends_with(\"world\")",
-              "check if (true || false) && true",
-              "check if 1 + 2 * 3 - 4 / 2 == 5",
-              "check if 1 < 2",
-              "check if 1 <= 1",
-              "check if 1 <= 2",
-              "check if 2 > 1",
-              "check if 2 >= 1",
-              "check if 2 >= 2",
-              "check if 2019-12-04T09:46:41Z < 2020-12-04T09:46:41Z",
-              "check if 2019-12-04T09:46:41Z <= 2020-12-04T09:46:41Z",
-              "check if 2020-12-04T09:46:41Z == 2020-12-04T09:46:41Z",
-              "check if 2020-12-04T09:46:41Z > 2019-12-04T09:46:41Z",
-              "check if 2020-12-04T09:46:41Z >= 2019-12-04T09:46:41Z",
-              "check if 2020-12-04T09:46:41Z >= 2020-12-04T09:46:41Z",
-              "check if 3 == 3",
-              "check if [\"abc\", \"def\"].contains(\"abc\")",
-              "check if [1, 2, 3].intersection([1, 2]).contains(1)",
-              "check if [1, 2, 3].intersection([1, 2]).length() == 2",
-              "check if [1, 2] == [1, 2]",
-              "check if [1, 2].contains(2)",
-              "check if [1, 2].contains([2])",
-              "check if [1, 2].intersection([2, 3]) == [2]",
-              "check if [1, 2].union([2, 3]) == [1, 2, 3]",
-              "check if [2019-12-04T09:46:41Z, 2020-12-04T09:46:41Z].contains(2020-12-04T09:46:41Z)",
-              "check if [false, true].contains(true)",
-              "check if [hex:12ab, hex:34de].contains(hex:34de)",
-              "check if false == false",
-              "check if false || true",
-              "check if hex:12ab == hex:12ab",
-              "check if true",
-              "check if true == true"
+              {
+                "origin": 0,
+                "checks": [
+                  "check if !false",
+                  "check if !false && true",
+                  "check if \"aaabde\" == \"aaa\" + \"b\" + \"de\"",
+                  "check if \"aaabde\".contains(\"abd\")",
+                  "check if \"aaabde\".matches(\"a*c?.e\")",
+                  "check if \"abcD12\" == \"abcD12\"",
+                  "check if \"hello world\".starts_with(\"hello\") && \"hello world\".ends_with(\"world\")",
+                  "check if (true || false) && true",
+                  "check if 1 + 2 * 3 - 4 / 2 == 5",
+                  "check if 1 < 2",
+                  "check if 1 <= 1",
+                  "check if 1 <= 2",
+                  "check if 2 > 1",
+                  "check if 2 >= 1",
+                  "check if 2 >= 2",
+                  "check if 2019-12-04T09:46:41Z < 2020-12-04T09:46:41Z",
+                  "check if 2019-12-04T09:46:41Z <= 2020-12-04T09:46:41Z",
+                  "check if 2020-12-04T09:46:41Z == 2020-12-04T09:46:41Z",
+                  "check if 2020-12-04T09:46:41Z > 2019-12-04T09:46:41Z",
+                  "check if 2020-12-04T09:46:41Z >= 2019-12-04T09:46:41Z",
+                  "check if 2020-12-04T09:46:41Z >= 2020-12-04T09:46:41Z",
+                  "check if 2020-12-04T09:46:41Z >= 2020-12-04T09:46:41Z",
+                  "check if 3 == 3",
+                  "check if [\"abc\", \"def\"].contains(\"abc\")",
+                  "check if [1, 2, 3].intersection([1, 2]).contains(1)",
+                  "check if [1, 2, 3].intersection([1, 2]).length() == 2",
+                  "check if [1, 2] == [1, 2]",
+                  "check if [1, 2].contains(2)",
+                  "check if [1, 2].contains([2])",
+                  "check if [1, 2].intersection([2, 3]) == [2]",
+                  "check if [1, 2].union([2, 3]) == [1, 2, 3]",
+                  "check if [2019-12-04T09:46:41Z, 2020-12-04T09:46:41Z].contains(2020-12-04T09:46:41Z)",
+                  "check if [false, true].contains(true)",
+                  "check if [hex:12ab, hex:34de].contains(hex:34de)",
+                  "check if false == false",
+                  "check if false || true",
+                  "check if hex:12ab == hex:12ab",
+                  "check if true",
+                  "check if true == true"
+                ]
+              }
             ],
             "policies": [
               "allow if true"
@@ -1303,19 +1379,19 @@
             "facts": [
               {
                 "origin": [
+                  null
+                ],
+                "facts": [
+                  "operation(\"write\")"
+                ]
+              },
+              {
+                "origin": [
                   null,
                   1
                 ],
                 "facts": [
                   "operation(\"read\")"
-                ]
-              },
-              {
-                "origin": [
-                  null
-                ],
-                "facts": [
-                  "operation(\"write\")"
                 ]
               }
             ],
@@ -1328,7 +1404,12 @@
               }
             ],
             "checks": [
-              "check if operation(\"read\")"
+              {
+                "origin": 0,
+                "checks": [
+                  "check if operation(\"read\")"
+                ]
+              }
             ],
             "policies": [
               "allow if true"
@@ -1390,6 +1471,15 @@
             "facts": [
               {
                 "origin": [
+                  null
+                ],
+                "facts": [
+                  "operation(\"read\")",
+                  "resource(\"file1\")"
+                ]
+              },
+              {
+                "origin": [
                   0
                 ],
                 "facts": [
@@ -1397,20 +1487,16 @@
                   "right(\"file1\", \"write\")",
                   "right(\"file2\", \"read\")"
                 ]
-              },
-              {
-                "origin": [
-                  null
-                ],
-                "facts": [
-                  "operation(\"read\")",
-                  "resource(\"file1\")"
-                ]
               }
             ],
             "rules": [],
             "checks": [
-              "check if resource($0), operation(\"read\"), right($0, \"read\")"
+              {
+                "origin": 1,
+                "checks": [
+                  "check if resource($0), operation(\"read\"), right($0, \"read\")"
+                ]
+              }
             ],
             "policies": [
               "allow if true"
@@ -1456,7 +1542,12 @@
             ],
             "rules": [],
             "checks": [
-              "check if ns::fact_123(\"hello é\t😁\")"
+              {
+                "origin": 18446744073709551615,
+                "checks": [
+                  "check if ns::fact_123(\"hello é\t😁\")"
+                ]
+              }
             ],
             "policies": [
               "allow if true"
@@ -1525,7 +1616,12 @@
             ],
             "rules": [],
             "checks": [
-              "check if read(0), write(1), resource(2), operation(3), right(4), time(5), role(6), owner(7), tenant(8), namespace(9), user(10), team(11), service(12), admin(13), email(14), group(15), member(16), ip_address(17), client(18), client_ip(19), domain(20), path(21), version(22), cluster(23), node(24), hostname(25), nonce(26), query(27)"
+              {
+                "origin": 18446744073709551615,
+                "checks": [
+                  "check if read(0), write(1), resource(2), operation(3), right(4), time(5), role(6), owner(7), tenant(8), namespace(9), user(10), team(11), service(12), admin(13), email(14), group(15), member(16), ip_address(17), client(18), client_ip(19), domain(20), path(21), version(22), cluster(23), node(24), hostname(25), nonce(26), query(27)"
+                ]
+              }
             ],
             "policies": [
               "allow if true"
@@ -1593,8 +1689,13 @@
             ],
             "rules": [],
             "checks": [
-              "check if authority_fact($var)",
-              "check if block1_fact($var)"
+              {
+                "origin": 2,
+                "checks": [
+                  "check if authority_fact($var)",
+                  "check if block1_fact($var)"
+                ]
+              }
             ],
             "policies": [
               "allow if true"
@@ -1671,8 +1772,18 @@
             ],
             "rules": [],
             "checks": [
-              "check if group(\"admin\") trusting ed25519/acdd6d5b53bfee478bf689f8e012fe7988bf755e3d7c5152947abc149bc20189",
-              "check if right(\"read\")"
+              {
+                "origin": 0,
+                "checks": [
+                  "check if group(\"admin\") trusting ed25519/acdd6d5b53bfee478bf689f8e012fe7988bf755e3d7c5152947abc149bc20189"
+                ]
+              },
+              {
+                "origin": 1,
+                "checks": [
+                  "check if right(\"read\")"
+                ]
+              }
             ],
             "policies": [
               "allow if true"
@@ -1730,7 +1841,12 @@
             ],
             "rules": [],
             "checks": [
-              "check all operation($op), allowed_operations($allowed), $allowed.contains($op)"
+              {
+                "origin": 0,
+                "checks": [
+                  "check all operation($op), allowed_operations($allowed), $allowed.contains($op)"
+                ]
+              }
             ],
             "policies": [
               "allow if true"
@@ -1767,7 +1883,12 @@
             ],
             "rules": [],
             "checks": [
-              "check all operation($op), allowed_operations($allowed), $allowed.contains($op)"
+              {
+                "origin": 0,
+                "checks": [
+                  "check all operation($op), allowed_operations($allowed), $allowed.contains($op)"
+                ]
+              }
             ],
             "policies": [
               "allow if true"
@@ -1847,18 +1968,18 @@
             "facts": [
               {
                 "origin": [
-                  2
-                ],
-                "facts": [
-                  "query(2)"
-                ]
-              },
-              {
-                "origin": [
                   3
                 ],
                 "facts": [
                   "query(3)"
+                ]
+              },
+              {
+                "origin": [
+                  1
+                ],
+                "facts": [
+                  "query(1)"
                 ]
               },
               {
@@ -1880,10 +2001,10 @@
               },
               {
                 "origin": [
-                  1
+                  2
                 ],
                 "facts": [
-                  "query(1)"
+                  "query(2)"
                 ]
               },
               {
@@ -1904,12 +2025,46 @@
               }
             ],
             "checks": [
-              "check if query(1) trusting ed25519/acdd6d5b53bfee478bf689f8e012fe7988bf755e3d7c5152947abc149bc20189",
-              "check if query(1, 2) trusting ed25519/acdd6d5b53bfee478bf689f8e012fe7988bf755e3d7c5152947abc149bc20189, ed25519/a060270db7e9c9f06e8f9cc33a64e99f6596af12cb01c4b638df8afc7b642463",
-              "check if query(2) trusting ed25519/a060270db7e9c9f06e8f9cc33a64e99f6596af12cb01c4b638df8afc7b642463",
-              "check if query(2), query(3) trusting ed25519/a060270db7e9c9f06e8f9cc33a64e99f6596af12cb01c4b638df8afc7b642463",
-              "check if query(4) trusting ed25519/f98da8c1cf907856431bfc3dc87531e0eaadba90f919edc232405b85877ef136",
-              "check if true trusting previous, ed25519/acdd6d5b53bfee478bf689f8e012fe7988bf755e3d7c5152947abc149bc20189"
+              {
+                "origin": 0,
+                "checks": [
+                  "check if true trusting previous, ed25519/acdd6d5b53bfee478bf689f8e012fe7988bf755e3d7c5152947abc149bc20189"
+                ]
+              },
+              {
+                "origin": 1,
+                "checks": [
+                  "check if query(1) trusting ed25519/acdd6d5b53bfee478bf689f8e012fe7988bf755e3d7c5152947abc149bc20189",
+                  "check if query(2), query(3) trusting ed25519/a060270db7e9c9f06e8f9cc33a64e99f6596af12cb01c4b638df8afc7b642463"
+                ]
+              },
+              {
+                "origin": 2,
+                "checks": [
+                  "check if query(1) trusting ed25519/acdd6d5b53bfee478bf689f8e012fe7988bf755e3d7c5152947abc149bc20189",
+                  "check if query(2), query(3) trusting ed25519/a060270db7e9c9f06e8f9cc33a64e99f6596af12cb01c4b638df8afc7b642463"
+                ]
+              },
+              {
+                "origin": 3,
+                "checks": [
+                  "check if query(1) trusting ed25519/acdd6d5b53bfee478bf689f8e012fe7988bf755e3d7c5152947abc149bc20189",
+                  "check if query(2), query(3) trusting ed25519/a060270db7e9c9f06e8f9cc33a64e99f6596af12cb01c4b638df8afc7b642463"
+                ]
+              },
+              {
+                "origin": 4,
+                "checks": [
+                  "check if query(2) trusting ed25519/a060270db7e9c9f06e8f9cc33a64e99f6596af12cb01c4b638df8afc7b642463",
+                  "check if query(4) trusting ed25519/f98da8c1cf907856431bfc3dc87531e0eaadba90f919edc232405b85877ef136"
+                ]
+              },
+              {
+                "origin": 18446744073709551615,
+                "checks": [
+                  "check if query(1, 2) trusting ed25519/acdd6d5b53bfee478bf689f8e012fe7988bf755e3d7c5152947abc149bc20189, ed25519/a060270db7e9c9f06e8f9cc33a64e99f6596af12cb01c4b638df8afc7b642463"
+                ]
+              }
             ],
             "policies": [
               "allow if true",
@@ -1949,9 +2104,14 @@
             "facts": [],
             "rules": [],
             "checks": [
-              "check if true || -9223372036854775808 - 1 != 0",
-              "check if true || 10000000000 * 10000000000 != 0",
-              "check if true || 9223372036854775807 + 1 != 0"
+              {
+                "origin": 0,
+                "checks": [
+                  "check if true || -9223372036854775808 - 1 != 0",
+                  "check if true || 10000000000 * 10000000000 != 0",
+                  "check if true || 9223372036854775807 + 1 != 0"
+                ]
+              }
             ],
             "policies": [
               "allow if true"
@@ -1989,12 +2149,17 @@
             "facts": [],
             "rules": [],
             "checks": [
-              "check if \"abcD12x\" != \"abcD12\"",
-              "check if 1 != 3",
-              "check if 1 | 2 ^ 3 == 0",
-              "check if 2022-12-04T09:46:41Z != 2020-12-04T09:46:41Z",
-              "check if [1, 4] != [1, 2]",
-              "check if hex:12abcd != hex:12ab"
+              {
+                "origin": 0,
+                "checks": [
+                  "check if \"abcD12x\" != \"abcD12\"",
+                  "check if 1 != 3",
+                  "check if 1 | 2 ^ 3 == 0",
+                  "check if 2022-12-04T09:46:41Z != 2020-12-04T09:46:41Z",
+                  "check if [1, 4] != [1, 2]",
+                  "check if hex:12abcd != hex:12ab"
+                ]
+              }
             ],
             "policies": [
               "allow if true"

--- a/biscuit-auth/samples/samples.json
+++ b/biscuit-auth/samples/samples.json
@@ -32,25 +32,19 @@
                 "origin": [
                   null
                 ],
-                "fact": "resource(\"file1\")"
+                "facts": [
+                  "resource(\"file1\")"
+                ]
               },
               {
                 "origin": [
                   0
                 ],
-                "fact": "right(\"file1\", \"read\")"
-              },
-              {
-                "origin": [
-                  0
-                ],
-                "fact": "right(\"file1\", \"write\")"
-              },
-              {
-                "origin": [
-                  0
-                ],
-                "fact": "right(\"file2\", \"read\")"
+                "facts": [
+                  "right(\"file1\", \"read\")",
+                  "right(\"file1\", \"write\")",
+                  "right(\"file2\", \"read\")"
+                ]
               }
             ],
             "rules": [],
@@ -327,37 +321,35 @@
                 "origin": [
                   null
                 ],
-                "fact": "operation(\"read\")"
-              },
-              {
-                "origin": [
-                  null
-                ],
-                "fact": "resource(\"file2\")"
-              },
-              {
-                "origin": [
-                  0
-                ],
-                "fact": "owner(\"alice\", \"file1\")"
+                "facts": [
+                  "operation(\"read\")",
+                  "resource(\"file2\")"
+                ]
               },
               {
                 "origin": [
                   0
                 ],
-                "fact": "user_id(\"alice\")"
+                "facts": [
+                  "owner(\"alice\", \"file1\")",
+                  "user_id(\"alice\")"
+                ]
               },
               {
                 "origin": [
                   2
                 ],
-                "fact": "owner(\"alice\", \"file2\")"
+                "facts": [
+                  "owner(\"alice\", \"file2\")"
+                ]
               }
             ],
             "rules": [
               {
                 "origin": 1,
-                "rule": "right($0, \"read\") <- resource($0), user_id($1), owner($1, $0)"
+                "rules": [
+                  "right($0, \"read\") <- resource($0), user_id($1), owner($1, $0)"
+                ]
               }
             ],
             "checks": [
@@ -431,27 +423,28 @@
             "facts": [
               {
                 "origin": [
-                  null
-                ],
-                "fact": "operation(\"read\")"
-              },
-              {
-                "origin": [
-                  null
-                ],
-                "fact": "resource(\"file2\")"
-              },
-              {
-                "origin": [
                   0
                 ],
-                "fact": "right(\"file1\", \"read\")"
+                "facts": [
+                  "right(\"file1\", \"read\")"
+                ]
+              },
+              {
+                "origin": [
+                  null
+                ],
+                "facts": [
+                  "operation(\"read\")",
+                  "resource(\"file2\")"
+                ]
               },
               {
                 "origin": [
                   2
                 ],
-                "fact": "right(\"file2\", \"read\")"
+                "facts": [
+                  "right(\"file2\", \"read\")"
+                ]
               }
             ],
             "rules": [],
@@ -518,19 +511,11 @@
                 "origin": [
                   null
                 ],
-                "fact": "operation(\"read\")"
-              },
-              {
-                "origin": [
-                  null
-                ],
-                "fact": "resource(\"file1\")"
-              },
-              {
-                "origin": [
-                  null
-                ],
-                "fact": "time(2020-12-21T09:23:12Z)"
+                "facts": [
+                  "operation(\"read\")",
+                  "resource(\"file1\")",
+                  "time(2020-12-21T09:23:12Z)"
+                ]
               }
             ],
             "rules": [],
@@ -597,27 +582,28 @@
             "facts": [
               {
                 "origin": [
-                  null
+                  1
                 ],
-                "fact": "operation(\"read\")"
-              },
-              {
-                "origin": [
-                  null
-                ],
-                "fact": "resource(\"file2\")"
+                "facts": [
+                  "right(\"file2\", \"read\")"
+                ]
               },
               {
                 "origin": [
                   0
                 ],
-                "fact": "right(\"file1\", \"read\")"
+                "facts": [
+                  "right(\"file1\", \"read\")"
+                ]
               },
               {
                 "origin": [
-                  1
+                  null
                 ],
-                "fact": "right(\"file2\", \"read\")"
+                "facts": [
+                  "operation(\"read\")",
+                  "resource(\"file2\")"
+                ]
               }
             ],
             "rules": [],
@@ -676,19 +662,18 @@
                 "origin": [
                   null
                 ],
-                "fact": "operation(\"read\")"
-              },
-              {
-                "origin": [
-                  null
-                ],
-                "fact": "resource(\"file2\")"
+                "facts": [
+                  "operation(\"read\")",
+                  "resource(\"file2\")"
+                ]
               },
               {
                 "origin": [
                   0
                 ],
-                "fact": "right(\"file1\", \"read\")"
+                "facts": [
+                  "right(\"file1\", \"read\")"
+                ]
               }
             ],
             "rules": [],
@@ -746,13 +731,10 @@
                 "origin": [
                   null
                 ],
-                "fact": "operation(\"read\")"
-              },
-              {
-                "origin": [
-                  null
-                ],
-                "fact": "resource(\"file1\")"
+                "facts": [
+                  "operation(\"read\")",
+                  "resource(\"file1\")"
+                ]
               }
             ],
             "rules": [],
@@ -778,13 +760,10 @@
                 "origin": [
                   null
                 ],
-                "fact": "operation(\"read\")"
-              },
-              {
-                "origin": [
-                  null
-                ],
-                "fact": "resource(\"file2\")"
+                "facts": [
+                  "operation(\"read\")",
+                  "resource(\"file2\")"
+                ]
               }
             ],
             "rules": [],
@@ -854,42 +833,37 @@
                 "origin": [
                   null
                 ],
-                "fact": "resource(\"file1\")"
-              },
-              {
-                "origin": [
-                  null
-                ],
-                "fact": "time(2020-12-21T09:23:12Z)"
+                "facts": [
+                  "resource(\"file1\")",
+                  "time(2020-12-21T09:23:12Z)"
+                ]
               },
               {
                 "origin": [
                   null,
                   1
                 ],
-                "fact": "valid_date(\"file1\")"
+                "facts": [
+                  "valid_date(\"file1\")"
+                ]
               },
               {
                 "origin": [
                   0
                 ],
-                "fact": "right(\"file1\", \"read\")"
-              },
-              {
-                "origin": [
-                  0
-                ],
-                "fact": "right(\"file2\", \"read\")"
+                "facts": [
+                  "right(\"file1\", \"read\")",
+                  "right(\"file2\", \"read\")"
+                ]
               }
             ],
             "rules": [
               {
                 "origin": 1,
-                "rule": "valid_date(\"file1\") <- time($0), resource(\"file1\"), $0 <= 2030-12-31T12:59:59Z"
-              },
-              {
-                "origin": 1,
-                "rule": "valid_date($1) <- time($0), resource($1), $0 <= 1999-12-31T12:59:59Z, ![\"file1\"].contains($1)"
+                "rules": [
+                  "valid_date(\"file1\") <- time($0), resource(\"file1\"), $0 <= 2030-12-31T12:59:59Z",
+                  "valid_date($1) <- time($0), resource($1), $0 <= 1999-12-31T12:59:59Z, ![\"file1\"].contains($1)"
+                ]
               }
             ],
             "checks": [
@@ -915,35 +889,28 @@
                 "origin": [
                   null
                 ],
-                "fact": "resource(\"file2\")"
-              },
-              {
-                "origin": [
-                  null
-                ],
-                "fact": "time(2020-12-21T09:23:12Z)"
-              },
-              {
-                "origin": [
-                  0
-                ],
-                "fact": "right(\"file1\", \"read\")"
+                "facts": [
+                  "resource(\"file2\")",
+                  "time(2020-12-21T09:23:12Z)"
+                ]
               },
               {
                 "origin": [
                   0
                 ],
-                "fact": "right(\"file2\", \"read\")"
+                "facts": [
+                  "right(\"file1\", \"read\")",
+                  "right(\"file2\", \"read\")"
+                ]
               }
             ],
             "rules": [
               {
                 "origin": 1,
-                "rule": "valid_date(\"file1\") <- time($0), resource(\"file1\"), $0 <= 2030-12-31T12:59:59Z"
-              },
-              {
-                "origin": 1,
-                "rule": "valid_date($1) <- time($0), resource($1), $0 <= 1999-12-31T12:59:59Z, ![\"file1\"].contains($1)"
+                "rules": [
+                  "valid_date(\"file1\") <- time($0), resource(\"file1\"), $0 <= 2030-12-31T12:59:59Z",
+                  "valid_date($1) <- time($0), resource($1), $0 <= 1999-12-31T12:59:59Z, ![\"file1\"].contains($1)"
+                ]
               }
             ],
             "checks": [
@@ -1003,7 +970,9 @@
                 "origin": [
                   null
                 ],
-                "fact": "resource(\"file1\")"
+                "facts": [
+                  "resource(\"file1\")"
+                ]
               }
             ],
             "rules": [],
@@ -1046,7 +1015,9 @@
                 "origin": [
                   null
                 ],
-                "fact": "resource(\"file123.txt\")"
+                "facts": [
+                  "resource(\"file123.txt\")"
+                ]
               }
             ],
             "rules": [],
@@ -1089,7 +1060,9 @@
                 "origin": [
                   0
                 ],
-                "fact": "must_be_present(\"hello\")"
+                "facts": [
+                  "must_be_present(\"hello\")"
+                ]
               }
             ],
             "rules": [],
@@ -1139,7 +1112,9 @@
                 "origin": [
                   1
                 ],
-                "fact": "query(\"test\")"
+                "facts": [
+                  "query(\"test\")"
+                ]
               }
             ],
             "rules": [],
@@ -1328,22 +1303,28 @@
             "facts": [
               {
                 "origin": [
-                  null
-                ],
-                "fact": "operation(\"write\")"
-              },
-              {
-                "origin": [
                   null,
                   1
                 ],
-                "fact": "operation(\"read\")"
+                "facts": [
+                  "operation(\"read\")"
+                ]
+              },
+              {
+                "origin": [
+                  null
+                ],
+                "facts": [
+                  "operation(\"write\")"
+                ]
               }
             ],
             "rules": [
               {
                 "origin": 1,
-                "rule": "operation(\"read\") <- operation($any)"
+                "rules": [
+                  "operation(\"read\") <- operation($any)"
+                ]
               }
             ],
             "checks": [
@@ -1409,33 +1390,22 @@
             "facts": [
               {
                 "origin": [
+                  0
+                ],
+                "facts": [
+                  "right(\"file1\", \"read\")",
+                  "right(\"file1\", \"write\")",
+                  "right(\"file2\", \"read\")"
+                ]
+              },
+              {
+                "origin": [
                   null
                 ],
-                "fact": "operation(\"read\")"
-              },
-              {
-                "origin": [
-                  null
-                ],
-                "fact": "resource(\"file1\")"
-              },
-              {
-                "origin": [
-                  0
-                ],
-                "fact": "right(\"file1\", \"read\")"
-              },
-              {
-                "origin": [
-                  0
-                ],
-                "fact": "right(\"file1\", \"write\")"
-              },
-              {
-                "origin": [
-                  0
-                ],
-                "fact": "right(\"file2\", \"read\")"
+                "facts": [
+                  "operation(\"read\")",
+                  "resource(\"file1\")"
+                ]
               }
             ],
             "rules": [],
@@ -1479,7 +1449,9 @@
                 "origin": [
                   0
                 ],
-                "fact": "ns::fact_123(\"hello é\t😁\")"
+                "facts": [
+                  "ns::fact_123(\"hello é\t😁\")"
+                ]
               }
             ],
             "rules": [],
@@ -1519,169 +1491,36 @@
                 "origin": [
                   0
                 ],
-                "fact": "admin(13)"
-              },
-              {
-                "origin": [
-                  0
-                ],
-                "fact": "client(18)"
-              },
-              {
-                "origin": [
-                  0
-                ],
-                "fact": "client_ip(19)"
-              },
-              {
-                "origin": [
-                  0
-                ],
-                "fact": "cluster(23)"
-              },
-              {
-                "origin": [
-                  0
-                ],
-                "fact": "domain(20)"
-              },
-              {
-                "origin": [
-                  0
-                ],
-                "fact": "email(14)"
-              },
-              {
-                "origin": [
-                  0
-                ],
-                "fact": "group(15)"
-              },
-              {
-                "origin": [
-                  0
-                ],
-                "fact": "hostname(25)"
-              },
-              {
-                "origin": [
-                  0
-                ],
-                "fact": "ip_address(17)"
-              },
-              {
-                "origin": [
-                  0
-                ],
-                "fact": "member(16)"
-              },
-              {
-                "origin": [
-                  0
-                ],
-                "fact": "namespace(9)"
-              },
-              {
-                "origin": [
-                  0
-                ],
-                "fact": "node(24)"
-              },
-              {
-                "origin": [
-                  0
-                ],
-                "fact": "nonce(26)"
-              },
-              {
-                "origin": [
-                  0
-                ],
-                "fact": "operation(3)"
-              },
-              {
-                "origin": [
-                  0
-                ],
-                "fact": "owner(7)"
-              },
-              {
-                "origin": [
-                  0
-                ],
-                "fact": "path(21)"
-              },
-              {
-                "origin": [
-                  0
-                ],
-                "fact": "query(27)"
-              },
-              {
-                "origin": [
-                  0
-                ],
-                "fact": "read(0)"
-              },
-              {
-                "origin": [
-                  0
-                ],
-                "fact": "resource(2)"
-              },
-              {
-                "origin": [
-                  0
-                ],
-                "fact": "right(4)"
-              },
-              {
-                "origin": [
-                  0
-                ],
-                "fact": "role(6)"
-              },
-              {
-                "origin": [
-                  0
-                ],
-                "fact": "service(12)"
-              },
-              {
-                "origin": [
-                  0
-                ],
-                "fact": "team(11)"
-              },
-              {
-                "origin": [
-                  0
-                ],
-                "fact": "tenant(8)"
-              },
-              {
-                "origin": [
-                  0
-                ],
-                "fact": "time(5)"
-              },
-              {
-                "origin": [
-                  0
-                ],
-                "fact": "user(10)"
-              },
-              {
-                "origin": [
-                  0
-                ],
-                "fact": "version(22)"
-              },
-              {
-                "origin": [
-                  0
-                ],
-                "fact": "write(1)"
+                "facts": [
+                  "admin(13)",
+                  "client(18)",
+                  "client_ip(19)",
+                  "cluster(23)",
+                  "domain(20)",
+                  "email(14)",
+                  "group(15)",
+                  "hostname(25)",
+                  "ip_address(17)",
+                  "member(16)",
+                  "namespace(9)",
+                  "node(24)",
+                  "nonce(26)",
+                  "operation(3)",
+                  "owner(7)",
+                  "path(21)",
+                  "query(27)",
+                  "read(0)",
+                  "resource(2)",
+                  "right(4)",
+                  "role(6)",
+                  "service(12)",
+                  "team(11)",
+                  "tenant(8)",
+                  "time(5)",
+                  "user(10)",
+                  "version(22)",
+                  "write(1)"
+                ]
               }
             ],
             "rules": [],
@@ -1739,13 +1578,17 @@
                 "origin": [
                   0
                 ],
-                "fact": "authority_fact(1)"
+                "facts": [
+                  "authority_fact(1)"
+                ]
               },
               {
                 "origin": [
                   1
                 ],
-                "fact": "block1_fact(1)"
+                "facts": [
+                  "block1_fact(1)"
+                ]
               }
             ],
             "rules": [],
@@ -1811,15 +1654,19 @@
             "facts": [
               {
                 "origin": [
-                  0
+                  1
                 ],
-                "fact": "right(\"read\")"
+                "facts": [
+                  "group(\"admin\")"
+                ]
               },
               {
                 "origin": [
-                  1
+                  0
                 ],
-                "fact": "group(\"admin\")"
+                "facts": [
+                  "right(\"read\")"
+                ]
               }
             ],
             "rules": [],
@@ -1865,21 +1712,20 @@
             "facts": [
               {
                 "origin": [
-                  null
-                ],
-                "fact": "operation(\"A\")"
-              },
-              {
-                "origin": [
-                  null
-                ],
-                "fact": "operation(\"B\")"
-              },
-              {
-                "origin": [
                   0
                 ],
-                "fact": "allowed_operations([\"A\", \"B\"])"
+                "facts": [
+                  "allowed_operations([\"A\", \"B\"])"
+                ]
+              },
+              {
+                "origin": [
+                  null
+                ],
+                "facts": [
+                  "operation(\"A\")",
+                  "operation(\"B\")"
+                ]
               }
             ],
             "rules": [],
@@ -1905,19 +1751,18 @@
                 "origin": [
                   null
                 ],
-                "fact": "operation(\"A\")"
-              },
-              {
-                "origin": [
-                  null
-                ],
-                "fact": "operation(\"invalid\")"
+                "facts": [
+                  "operation(\"A\")",
+                  "operation(\"invalid\")"
+                ]
               },
               {
                 "origin": [
                   0
                 ],
-                "fact": "allowed_operations([\"A\", \"B\"])"
+                "facts": [
+                  "allowed_operations([\"A\", \"B\"])"
+                ]
               }
             ],
             "rules": [],
@@ -2002,46 +1847,60 @@
             "facts": [
               {
                 "origin": [
-                  0
+                  2
                 ],
-                "fact": "query(0)"
+                "facts": [
+                  "query(2)"
+                ]
               },
               {
                 "origin": [
-                  1
+                  3
                 ],
-                "fact": "query(1)"
+                "facts": [
+                  "query(3)"
+                ]
               },
               {
                 "origin": [
                   1,
                   2
                 ],
-                "fact": "query(1, 2)"
+                "facts": [
+                  "query(1, 2)"
+                ]
               },
               {
                 "origin": [
-                  2
+                  0
                 ],
-                "fact": "query(2)"
+                "facts": [
+                  "query(0)"
+                ]
               },
               {
                 "origin": [
-                  3
+                  1
                 ],
-                "fact": "query(3)"
+                "facts": [
+                  "query(1)"
+                ]
               },
               {
                 "origin": [
                   4
                 ],
-                "fact": "query(4)"
+                "facts": [
+                  "query(4)"
+                ]
               }
             ],
             "rules": [
               {
                 "origin": 1,
-                "rule": "query(1, 2) <- query(1), query(2) trusting ed25519/a060270db7e9c9f06e8f9cc33a64e99f6596af12cb01c4b638df8afc7b642463"
+                "rules": [
+                  "query(1, 2) <- query(1), query(2) trusting ed25519/a060270db7e9c9f06e8f9cc33a64e99f6596af12cb01c4b638df8afc7b642463"
+                ]
               }
             ],
             "checks": [

--- a/biscuit-auth/samples/samples.json
+++ b/biscuit-auth/samples/samples.json
@@ -324,14 +324,6 @@
             "facts": [
               {
                 "origin": [
-                  2
-                ],
-                "facts": [
-                  "owner(\"alice\", \"file2\")"
-                ]
-              },
-              {
-                "origin": [
                   null
                 ],
                 "facts": [
@@ -346,6 +338,14 @@
                 "facts": [
                   "owner(\"alice\", \"file1\")",
                   "user_id(\"alice\")"
+                ]
+              },
+              {
+                "origin": [
+                  2
+                ],
+                "facts": [
+                  "owner(\"alice\", \"file2\")"
                 ]
               }
             ],
@@ -602,19 +602,19 @@
             "facts": [
               {
                 "origin": [
-                  0
-                ],
-                "facts": [
-                  "right(\"file1\", \"read\")"
-                ]
-              },
-              {
-                "origin": [
                   null
                 ],
                 "facts": [
                   "operation(\"read\")",
                   "resource(\"file2\")"
+                ]
+              },
+              {
+                "origin": [
+                  0
+                ],
+                "facts": [
+                  "right(\"file1\", \"read\")"
                 ]
               },
               {
@@ -685,19 +685,19 @@
             "facts": [
               {
                 "origin": [
-                  0
-                ],
-                "facts": [
-                  "right(\"file1\", \"read\")"
-                ]
-              },
-              {
-                "origin": [
                   null
                 ],
                 "facts": [
                   "operation(\"read\")",
                   "resource(\"file2\")"
+                ]
+              },
+              {
+                "origin": [
+                  0
+                ],
+                "facts": [
+                  "right(\"file1\", \"read\")"
                 ]
               }
             ],
@@ -871,6 +871,15 @@
             "facts": [
               {
                 "origin": [
+                  null
+                ],
+                "facts": [
+                  "resource(\"file1\")",
+                  "time(2020-12-21T09:23:12Z)"
+                ]
+              },
+              {
+                "origin": [
                   null,
                   1
                 ],
@@ -885,15 +894,6 @@
                 "facts": [
                   "right(\"file1\", \"read\")",
                   "right(\"file2\", \"read\")"
-                ]
-              },
-              {
-                "origin": [
-                  null
-                ],
-                "facts": [
-                  "resource(\"file1\")",
-                  "time(2020-12-21T09:23:12Z)"
                 ]
               }
             ],
@@ -1755,18 +1755,18 @@
             "facts": [
               {
                 "origin": [
-                  1
-                ],
-                "facts": [
-                  "group(\"admin\")"
-                ]
-              },
-              {
-                "origin": [
                   0
                 ],
                 "facts": [
                   "right(\"read\")"
+                ]
+              },
+              {
+                "origin": [
+                  1
+                ],
+                "facts": [
+                  "group(\"admin\")"
                 ]
               }
             ],
@@ -1823,19 +1823,19 @@
             "facts": [
               {
                 "origin": [
-                  0
-                ],
-                "facts": [
-                  "allowed_operations([\"A\", \"B\"])"
-                ]
-              },
-              {
-                "origin": [
                   null
                 ],
                 "facts": [
                   "operation(\"A\")",
                   "operation(\"B\")"
+                ]
+              },
+              {
+                "origin": [
+                  0
+                ],
+                "facts": [
+                  "allowed_operations([\"A\", \"B\"])"
                 ]
               }
             ],
@@ -1968,10 +1968,10 @@
             "facts": [
               {
                 "origin": [
-                  3
+                  0
                 ],
                 "facts": [
-                  "query(3)"
+                  "query(0)"
                 ]
               },
               {
@@ -1993,18 +1993,18 @@
               },
               {
                 "origin": [
-                  0
-                ],
-                "facts": [
-                  "query(0)"
-                ]
-              },
-              {
-                "origin": [
                   2
                 ],
                 "facts": [
                   "query(2)"
+                ]
+              },
+              {
+                "origin": [
+                  3
+                ],
+                "facts": [
+                  "query(3)"
                 ]
               },
               {

--- a/biscuit-auth/samples/samples.json
+++ b/biscuit-auth/samples/samples.json
@@ -28,30 +28,30 @@
         "": {
           "world": {
             "facts": [
-              [
-                "resource(\"file1\")",
-                [
+              {
+                "origin": [
                   null
-                ]
-              ],
-              [
-                "right(\"file1\", \"read\")",
-                [
+                ],
+                "fact": "resource(\"file1\")"
+              },
+              {
+                "origin": [
                   0
-                ]
-              ],
-              [
-                "right(\"file1\", \"write\")",
-                [
+                ],
+                "fact": "right(\"file1\", \"read\")"
+              },
+              {
+                "origin": [
                   0
-                ]
-              ],
-              [
-                "right(\"file2\", \"read\")",
-                [
+                ],
+                "fact": "right(\"file1\", \"write\")"
+              },
+              {
+                "origin": [
                   0
-                ]
-              ]
+                ],
+                "fact": "right(\"file2\", \"read\")"
+              }
             ],
             "rules": [],
             "checks": [
@@ -323,42 +323,42 @@
         "": {
           "world": {
             "facts": [
-              [
-                "operation(\"read\")",
-                [
+              {
+                "origin": [
                   null
-                ]
-              ],
-              [
-                "owner(\"alice\", \"file1\")",
-                [
+                ],
+                "fact": "operation(\"read\")"
+              },
+              {
+                "origin": [
+                  null
+                ],
+                "fact": "resource(\"file2\")"
+              },
+              {
+                "origin": [
                   0
-                ]
-              ],
-              [
-                "owner(\"alice\", \"file2\")",
-                [
+                ],
+                "fact": "owner(\"alice\", \"file1\")"
+              },
+              {
+                "origin": [
+                  0
+                ],
+                "fact": "user_id(\"alice\")"
+              },
+              {
+                "origin": [
                   2
-                ]
-              ],
-              [
-                "resource(\"file2\")",
-                [
-                  null
-                ]
-              ],
-              [
-                "user_id(\"alice\")",
-                [
-                  0
-                ]
-              ]
+                ],
+                "fact": "owner(\"alice\", \"file2\")"
+              }
             ],
             "rules": [
-              [
-                "right($0, \"read\") <- resource($0), user_id($1), owner($1, $0)",
-                1
-              ]
+              {
+                "origin": 1,
+                "rule": "right($0, \"read\") <- resource($0), user_id($1), owner($1, $0)"
+              }
             ],
             "checks": [
               "check if resource($0), operation(\"read\"), right($0, \"read\")"
@@ -429,30 +429,30 @@
         "": {
           "world": {
             "facts": [
-              [
-                "operation(\"read\")",
-                [
+              {
+                "origin": [
                   null
-                ]
-              ],
-              [
-                "resource(\"file2\")",
-                [
+                ],
+                "fact": "operation(\"read\")"
+              },
+              {
+                "origin": [
                   null
-                ]
-              ],
-              [
-                "right(\"file1\", \"read\")",
-                [
+                ],
+                "fact": "resource(\"file2\")"
+              },
+              {
+                "origin": [
                   0
-                ]
-              ],
-              [
-                "right(\"file2\", \"read\")",
-                [
+                ],
+                "fact": "right(\"file1\", \"read\")"
+              },
+              {
+                "origin": [
                   2
-                ]
-              ]
+                ],
+                "fact": "right(\"file2\", \"read\")"
+              }
             ],
             "rules": [],
             "checks": [
@@ -514,24 +514,24 @@
         "": {
           "world": {
             "facts": [
-              [
-                "operation(\"read\")",
-                [
+              {
+                "origin": [
                   null
-                ]
-              ],
-              [
-                "resource(\"file1\")",
-                [
+                ],
+                "fact": "operation(\"read\")"
+              },
+              {
+                "origin": [
                   null
-                ]
-              ],
-              [
-                "time(2020-12-21T09:23:12Z)",
-                [
+                ],
+                "fact": "resource(\"file1\")"
+              },
+              {
+                "origin": [
                   null
-                ]
-              ]
+                ],
+                "fact": "time(2020-12-21T09:23:12Z)"
+              }
             ],
             "rules": [],
             "checks": [
@@ -595,30 +595,30 @@
         "": {
           "world": {
             "facts": [
-              [
-                "operation(\"read\")",
-                [
+              {
+                "origin": [
                   null
-                ]
-              ],
-              [
-                "resource(\"file2\")",
-                [
+                ],
+                "fact": "operation(\"read\")"
+              },
+              {
+                "origin": [
                   null
-                ]
-              ],
-              [
-                "right(\"file1\", \"read\")",
-                [
+                ],
+                "fact": "resource(\"file2\")"
+              },
+              {
+                "origin": [
                   0
-                ]
-              ],
-              [
-                "right(\"file2\", \"read\")",
-                [
+                ],
+                "fact": "right(\"file1\", \"read\")"
+              },
+              {
+                "origin": [
                   1
-                ]
-              ]
+                ],
+                "fact": "right(\"file2\", \"read\")"
+              }
             ],
             "rules": [],
             "checks": [
@@ -672,24 +672,24 @@
         "": {
           "world": {
             "facts": [
-              [
-                "operation(\"read\")",
-                [
+              {
+                "origin": [
                   null
-                ]
-              ],
-              [
-                "resource(\"file2\")",
-                [
+                ],
+                "fact": "operation(\"read\")"
+              },
+              {
+                "origin": [
                   null
-                ]
-              ],
-              [
-                "right(\"file1\", \"read\")",
-                [
+                ],
+                "fact": "resource(\"file2\")"
+              },
+              {
+                "origin": [
                   0
-                ]
-              ]
+                ],
+                "fact": "right(\"file1\", \"read\")"
+              }
             ],
             "rules": [],
             "checks": [
@@ -742,18 +742,18 @@
         "file1": {
           "world": {
             "facts": [
-              [
-                "operation(\"read\")",
-                [
+              {
+                "origin": [
                   null
-                ]
-              ],
-              [
-                "resource(\"file1\")",
-                [
+                ],
+                "fact": "operation(\"read\")"
+              },
+              {
+                "origin": [
                   null
-                ]
-              ]
+                ],
+                "fact": "resource(\"file1\")"
+              }
             ],
             "rules": [],
             "checks": [
@@ -774,18 +774,18 @@
         "file2": {
           "world": {
             "facts": [
-              [
-                "operation(\"read\")",
-                [
+              {
+                "origin": [
                   null
-                ]
-              ],
-              [
-                "resource(\"file2\")",
-                [
+                ],
+                "fact": "operation(\"read\")"
+              },
+              {
+                "origin": [
                   null
-                ]
-              ]
+                ],
+                "fact": "resource(\"file2\")"
+              }
             ],
             "rules": [],
             "checks": [
@@ -850,47 +850,47 @@
         "file1": {
           "world": {
             "facts": [
-              [
-                "resource(\"file1\")",
-                [
+              {
+                "origin": [
                   null
-                ]
-              ],
-              [
-                "right(\"file1\", \"read\")",
-                [
-                  0
-                ]
-              ],
-              [
-                "right(\"file2\", \"read\")",
-                [
-                  0
-                ]
-              ],
-              [
-                "time(2020-12-21T09:23:12Z)",
-                [
+                ],
+                "fact": "resource(\"file1\")"
+              },
+              {
+                "origin": [
                   null
-                ]
-              ],
-              [
-                "valid_date(\"file1\")",
-                [
+                ],
+                "fact": "time(2020-12-21T09:23:12Z)"
+              },
+              {
+                "origin": [
                   null,
                   1
-                ]
-              ]
+                ],
+                "fact": "valid_date(\"file1\")"
+              },
+              {
+                "origin": [
+                  0
+                ],
+                "fact": "right(\"file1\", \"read\")"
+              },
+              {
+                "origin": [
+                  0
+                ],
+                "fact": "right(\"file2\", \"read\")"
+              }
             ],
             "rules": [
-              [
-                "valid_date(\"file1\") <- time($0), resource(\"file1\"), $0 <= 2030-12-31T12:59:59Z",
-                1
-              ],
-              [
-                "valid_date($1) <- time($0), resource($1), $0 <= 1999-12-31T12:59:59Z, ![\"file1\"].contains($1)",
-                1
-              ]
+              {
+                "origin": 1,
+                "rule": "valid_date(\"file1\") <- time($0), resource(\"file1\"), $0 <= 2030-12-31T12:59:59Z"
+              },
+              {
+                "origin": 1,
+                "rule": "valid_date($1) <- time($0), resource($1), $0 <= 1999-12-31T12:59:59Z, ![\"file1\"].contains($1)"
+              }
             ],
             "checks": [
               "check if valid_date($0), resource($0)"
@@ -911,40 +911,40 @@
         "file2": {
           "world": {
             "facts": [
-              [
-                "resource(\"file2\")",
-                [
+              {
+                "origin": [
                   null
-                ]
-              ],
-              [
-                "right(\"file1\", \"read\")",
-                [
-                  0
-                ]
-              ],
-              [
-                "right(\"file2\", \"read\")",
-                [
-                  0
-                ]
-              ],
-              [
-                "time(2020-12-21T09:23:12Z)",
-                [
+                ],
+                "fact": "resource(\"file2\")"
+              },
+              {
+                "origin": [
                   null
-                ]
-              ]
+                ],
+                "fact": "time(2020-12-21T09:23:12Z)"
+              },
+              {
+                "origin": [
+                  0
+                ],
+                "fact": "right(\"file1\", \"read\")"
+              },
+              {
+                "origin": [
+                  0
+                ],
+                "fact": "right(\"file2\", \"read\")"
+              }
             ],
             "rules": [
-              [
-                "valid_date(\"file1\") <- time($0), resource(\"file1\"), $0 <= 2030-12-31T12:59:59Z",
-                1
-              ],
-              [
-                "valid_date($1) <- time($0), resource($1), $0 <= 1999-12-31T12:59:59Z, ![\"file1\"].contains($1)",
-                1
-              ]
+              {
+                "origin": 1,
+                "rule": "valid_date(\"file1\") <- time($0), resource(\"file1\"), $0 <= 2030-12-31T12:59:59Z"
+              },
+              {
+                "origin": 1,
+                "rule": "valid_date($1) <- time($0), resource($1), $0 <= 1999-12-31T12:59:59Z, ![\"file1\"].contains($1)"
+              }
             ],
             "checks": [
               "check if valid_date($0), resource($0)"
@@ -999,12 +999,12 @@
         "file1": {
           "world": {
             "facts": [
-              [
-                "resource(\"file1\")",
-                [
+              {
+                "origin": [
                   null
-                ]
-              ]
+                ],
+                "fact": "resource(\"file1\")"
+              }
             ],
             "rules": [],
             "checks": [
@@ -1042,12 +1042,12 @@
         "file123": {
           "world": {
             "facts": [
-              [
-                "resource(\"file123.txt\")",
-                [
+              {
+                "origin": [
                   null
-                ]
-              ]
+                ],
+                "fact": "resource(\"file123.txt\")"
+              }
             ],
             "rules": [],
             "checks": [
@@ -1085,12 +1085,12 @@
         "": {
           "world": {
             "facts": [
-              [
-                "must_be_present(\"hello\")",
-                [
+              {
+                "origin": [
                   0
-                ]
-              ]
+                ],
+                "fact": "must_be_present(\"hello\")"
+              }
             ],
             "rules": [],
             "checks": [
@@ -1135,12 +1135,12 @@
         "": {
           "world": {
             "facts": [
-              [
-                "query(\"test\")",
-                [
+              {
+                "origin": [
                   1
-                ]
-              ]
+                ],
+                "fact": "query(\"test\")"
+              }
             ],
             "rules": [],
             "checks": [
@@ -1326,25 +1326,25 @@
         "": {
           "world": {
             "facts": [
-              [
-                "operation(\"read\")",
-                [
+              {
+                "origin": [
+                  null
+                ],
+                "fact": "operation(\"write\")"
+              },
+              {
+                "origin": [
                   null,
                   1
-                ]
-              ],
-              [
-                "operation(\"write\")",
-                [
-                  null
-                ]
-              ]
+                ],
+                "fact": "operation(\"read\")"
+              }
             ],
             "rules": [
-              [
-                "operation(\"read\") <- operation($any)",
-                1
-              ]
+              {
+                "origin": 1,
+                "rule": "operation(\"read\") <- operation($any)"
+              }
             ],
             "checks": [
               "check if operation(\"read\")"
@@ -1407,36 +1407,36 @@
         "": {
           "world": {
             "facts": [
-              [
-                "operation(\"read\")",
-                [
+              {
+                "origin": [
                   null
-                ]
-              ],
-              [
-                "resource(\"file1\")",
-                [
+                ],
+                "fact": "operation(\"read\")"
+              },
+              {
+                "origin": [
                   null
-                ]
-              ],
-              [
-                "right(\"file1\", \"read\")",
-                [
+                ],
+                "fact": "resource(\"file1\")"
+              },
+              {
+                "origin": [
                   0
-                ]
-              ],
-              [
-                "right(\"file1\", \"write\")",
-                [
+                ],
+                "fact": "right(\"file1\", \"read\")"
+              },
+              {
+                "origin": [
                   0
-                ]
-              ],
-              [
-                "right(\"file2\", \"read\")",
-                [
+                ],
+                "fact": "right(\"file1\", \"write\")"
+              },
+              {
+                "origin": [
                   0
-                ]
-              ]
+                ],
+                "fact": "right(\"file2\", \"read\")"
+              }
             ],
             "rules": [],
             "checks": [
@@ -1475,12 +1475,12 @@
         "": {
           "world": {
             "facts": [
-              [
-                "ns::fact_123(\"hello é\t😁\")",
-                [
+              {
+                "origin": [
                   0
-                ]
-              ]
+                ],
+                "fact": "ns::fact_123(\"hello é\t😁\")"
+              }
             ],
             "rules": [],
             "checks": [
@@ -1515,174 +1515,174 @@
         "": {
           "world": {
             "facts": [
-              [
-                "admin(13)",
-                [
+              {
+                "origin": [
                   0
-                ]
-              ],
-              [
-                "client(18)",
-                [
+                ],
+                "fact": "admin(13)"
+              },
+              {
+                "origin": [
                   0
-                ]
-              ],
-              [
-                "client_ip(19)",
-                [
+                ],
+                "fact": "client(18)"
+              },
+              {
+                "origin": [
                   0
-                ]
-              ],
-              [
-                "cluster(23)",
-                [
+                ],
+                "fact": "client_ip(19)"
+              },
+              {
+                "origin": [
                   0
-                ]
-              ],
-              [
-                "domain(20)",
-                [
+                ],
+                "fact": "cluster(23)"
+              },
+              {
+                "origin": [
                   0
-                ]
-              ],
-              [
-                "email(14)",
-                [
+                ],
+                "fact": "domain(20)"
+              },
+              {
+                "origin": [
                   0
-                ]
-              ],
-              [
-                "group(15)",
-                [
+                ],
+                "fact": "email(14)"
+              },
+              {
+                "origin": [
                   0
-                ]
-              ],
-              [
-                "hostname(25)",
-                [
+                ],
+                "fact": "group(15)"
+              },
+              {
+                "origin": [
                   0
-                ]
-              ],
-              [
-                "ip_address(17)",
-                [
+                ],
+                "fact": "hostname(25)"
+              },
+              {
+                "origin": [
                   0
-                ]
-              ],
-              [
-                "member(16)",
-                [
+                ],
+                "fact": "ip_address(17)"
+              },
+              {
+                "origin": [
                   0
-                ]
-              ],
-              [
-                "namespace(9)",
-                [
+                ],
+                "fact": "member(16)"
+              },
+              {
+                "origin": [
                   0
-                ]
-              ],
-              [
-                "node(24)",
-                [
+                ],
+                "fact": "namespace(9)"
+              },
+              {
+                "origin": [
                   0
-                ]
-              ],
-              [
-                "nonce(26)",
-                [
+                ],
+                "fact": "node(24)"
+              },
+              {
+                "origin": [
                   0
-                ]
-              ],
-              [
-                "operation(3)",
-                [
+                ],
+                "fact": "nonce(26)"
+              },
+              {
+                "origin": [
                   0
-                ]
-              ],
-              [
-                "owner(7)",
-                [
+                ],
+                "fact": "operation(3)"
+              },
+              {
+                "origin": [
                   0
-                ]
-              ],
-              [
-                "path(21)",
-                [
+                ],
+                "fact": "owner(7)"
+              },
+              {
+                "origin": [
                   0
-                ]
-              ],
-              [
-                "query(27)",
-                [
+                ],
+                "fact": "path(21)"
+              },
+              {
+                "origin": [
                   0
-                ]
-              ],
-              [
-                "read(0)",
-                [
+                ],
+                "fact": "query(27)"
+              },
+              {
+                "origin": [
                   0
-                ]
-              ],
-              [
-                "resource(2)",
-                [
+                ],
+                "fact": "read(0)"
+              },
+              {
+                "origin": [
                   0
-                ]
-              ],
-              [
-                "right(4)",
-                [
+                ],
+                "fact": "resource(2)"
+              },
+              {
+                "origin": [
                   0
-                ]
-              ],
-              [
-                "role(6)",
-                [
+                ],
+                "fact": "right(4)"
+              },
+              {
+                "origin": [
                   0
-                ]
-              ],
-              [
-                "service(12)",
-                [
+                ],
+                "fact": "role(6)"
+              },
+              {
+                "origin": [
                   0
-                ]
-              ],
-              [
-                "team(11)",
-                [
+                ],
+                "fact": "service(12)"
+              },
+              {
+                "origin": [
                   0
-                ]
-              ],
-              [
-                "tenant(8)",
-                [
+                ],
+                "fact": "team(11)"
+              },
+              {
+                "origin": [
                   0
-                ]
-              ],
-              [
-                "time(5)",
-                [
+                ],
+                "fact": "tenant(8)"
+              },
+              {
+                "origin": [
                   0
-                ]
-              ],
-              [
-                "user(10)",
-                [
+                ],
+                "fact": "time(5)"
+              },
+              {
+                "origin": [
                   0
-                ]
-              ],
-              [
-                "version(22)",
-                [
+                ],
+                "fact": "user(10)"
+              },
+              {
+                "origin": [
                   0
-                ]
-              ],
-              [
-                "write(1)",
-                [
+                ],
+                "fact": "version(22)"
+              },
+              {
+                "origin": [
                   0
-                ]
-              ]
+                ],
+                "fact": "write(1)"
+              }
             ],
             "rules": [],
             "checks": [
@@ -1735,18 +1735,18 @@
         "": {
           "world": {
             "facts": [
-              [
-                "authority_fact(1)",
-                [
+              {
+                "origin": [
                   0
-                ]
-              ],
-              [
-                "block1_fact(1)",
-                [
+                ],
+                "fact": "authority_fact(1)"
+              },
+              {
+                "origin": [
                   1
-                ]
-              ]
+                ],
+                "fact": "block1_fact(1)"
+              }
             ],
             "rules": [],
             "checks": [
@@ -1809,18 +1809,18 @@
         "": {
           "world": {
             "facts": [
-              [
-                "group(\"admin\")",
-                [
-                  1
-                ]
-              ],
-              [
-                "right(\"read\")",
-                [
+              {
+                "origin": [
                   0
-                ]
-              ]
+                ],
+                "fact": "right(\"read\")"
+              },
+              {
+                "origin": [
+                  1
+                ],
+                "fact": "group(\"admin\")"
+              }
             ],
             "rules": [],
             "checks": [
@@ -1863,24 +1863,24 @@
         "A, B": {
           "world": {
             "facts": [
-              [
-                "allowed_operations([\"A\", \"B\"])",
-                [
+              {
+                "origin": [
+                  null
+                ],
+                "fact": "operation(\"A\")"
+              },
+              {
+                "origin": [
+                  null
+                ],
+                "fact": "operation(\"B\")"
+              },
+              {
+                "origin": [
                   0
-                ]
-              ],
-              [
-                "operation(\"A\")",
-                [
-                  null
-                ]
-              ],
-              [
-                "operation(\"B\")",
-                [
-                  null
-                ]
-              ]
+                ],
+                "fact": "allowed_operations([\"A\", \"B\"])"
+              }
             ],
             "rules": [],
             "checks": [
@@ -1901,24 +1901,24 @@
         "A, invalid": {
           "world": {
             "facts": [
-              [
-                "allowed_operations([\"A\", \"B\"])",
-                [
+              {
+                "origin": [
+                  null
+                ],
+                "fact": "operation(\"A\")"
+              },
+              {
+                "origin": [
+                  null
+                ],
+                "fact": "operation(\"invalid\")"
+              },
+              {
+                "origin": [
                   0
-                ]
-              ],
-              [
-                "operation(\"A\")",
-                [
-                  null
-                ]
-              ],
-              [
-                "operation(\"invalid\")",
-                [
-                  null
-                ]
-              ]
+                ],
+                "fact": "allowed_operations([\"A\", \"B\"])"
+              }
             ],
             "rules": [],
             "checks": [
@@ -2000,49 +2000,49 @@
         "": {
           "world": {
             "facts": [
-              [
-                "query(0)",
-                [
+              {
+                "origin": [
                   0
-                ]
-              ],
-              [
-                "query(1)",
-                [
+                ],
+                "fact": "query(0)"
+              },
+              {
+                "origin": [
                   1
-                ]
-              ],
-              [
-                "query(1, 2)",
-                [
+                ],
+                "fact": "query(1)"
+              },
+              {
+                "origin": [
                   1,
                   2
-                ]
-              ],
-              [
-                "query(2)",
-                [
+                ],
+                "fact": "query(1, 2)"
+              },
+              {
+                "origin": [
                   2
-                ]
-              ],
-              [
-                "query(3)",
-                [
+                ],
+                "fact": "query(2)"
+              },
+              {
+                "origin": [
                   3
-                ]
-              ],
-              [
-                "query(4)",
-                [
+                ],
+                "fact": "query(3)"
+              },
+              {
+                "origin": [
                   4
-                ]
-              ]
+                ],
+                "fact": "query(4)"
+              }
             ],
             "rules": [
-              [
-                "query(1, 2) <- query(1), query(2) trusting ed25519/a060270db7e9c9f06e8f9cc33a64e99f6596af12cb01c4b638df8afc7b642463",
-                1
-              ]
+              {
+                "origin": 1,
+                "rule": "query(1, 2) <- query(1), query(2) trusting ed25519/a060270db7e9c9f06e8f9cc33a64e99f6596af12cb01c4b638df8afc7b642463"
+              }
             ],
             "checks": [
               "check if query(1) trusting ed25519/acdd6d5b53bfee478bf689f8e012fe7988bf755e3d7c5152947abc149bc20189",


### PR DESCRIPTION
* use objects instead of tuples because tuples are serialized as arrays in JSON
* instead of having a list of objects containing each a fact and its origin, let's have a map of origin -> list of facts
* sort facts, rules, checks etc should be sorted (sorting strings, not objects, to keep it simple), because we use sets everywhere, and their order can be random