### PR TITLE
Expose PEM/DER decoder functions in KeyPair

### DIFF
--- a/biscuit-auth/Cargo.toml
+++ b/biscuit-auth/Cargo.toml
@@ -39,7 +39,7 @@ rand = { version = "0.8" }
 inline-c = { version = "0.1", optional = true }
 wasm-bindgen = { version = "0.2", optional = true }
 base64 = "0.13.0"
-ed25519-dalek = { version = "2.0.0", features = ["rand_core", "zeroize"] }
+ed25519-dalek = { version = "2.0.0", features = ["rand_core", "zeroize", "pem"] }
 serde = { version = "1.0.132", optional = true, features = ["derive"] }
 getrandom = { version = "0.1.16" }
 time = { version = "0.3.7", features = ["formatting", "parsing"] }

--- a/biscuit-auth/Cargo.toml
+++ b/biscuit-auth/Cargo.toml
@@ -24,6 +24,8 @@ datalog-macro = ["biscuit-quote"]
 bwk = ["chrono", "serde"]
 docsrs = []
 uuid = ["dep:uuid"]
+# used to expose pem/der loaders for keypairs
+pem = ["ed25519-dalek/pem"]
 
 [dependencies]
 rand_core = "^0.6"
@@ -39,7 +41,7 @@ rand = { version = "0.8" }
 inline-c = { version = "0.1", optional = true }
 wasm-bindgen = { version = "0.2", optional = true }
 base64 = "0.13.0"
-ed25519-dalek = { version = "2.0.0", features = ["rand_core", "zeroize", "pem"] }
+ed25519-dalek = { version = "2.0.0", features = ["rand_core", "zeroize"] }
 serde = { version = "1.0.132", optional = true, features = ["derive"] }
 getrandom = { version = "0.1.16" }
 time = { version = "0.3.7", features = ["formatting", "parsing"] }

--- a/biscuit-auth/src/crypto/mod.rs
+++ b/biscuit-auth/src/crypto/mod.rs
@@ -10,7 +10,10 @@
 use crate::{error::Format, format::schema};
 
 use super::error;
-use ed25519_dalek::{pkcs8::DecodePrivateKey, *};
+#[cfg(feature = "pem")]
+use ed25519_dalek::pkcs8::DecodePrivateKey;
+use ed25519_dalek::*;
+
 use nom::Finish;
 use rand_core::{CryptoRng, RngCore};
 use std::{convert::TryInto, fmt::Display, hash::Hash, ops::Drop, path::Path, str::FromStr};
@@ -39,24 +42,28 @@ impl KeyPair {
         }
     }
 
+    #[cfg(feature = "pem")]
     pub fn from_private_key_der(bytes: &[u8]) -> Result<Self, error::Format> {
         let kp = SigningKey::from_pkcs8_der(bytes)
             .map_err(|e| error::Format::InvalidKey(e.to_string()))?;
         Ok(KeyPair { kp })
     }
 
+    #[cfg(feature = "pem")]
     pub fn from_private_key_pem(str: &str) -> Result<Self, error::Format> {
         let kp = SigningKey::from_pkcs8_pem(str)
             .map_err(|e| error::Format::InvalidKey(e.to_string()))?;
         Ok(KeyPair { kp })
     }
 
+    #[cfg(feature = "pem")]
     pub fn from_private_key_der_file(path: impl AsRef<Path>) -> Result<Self, error::Format> {
         let kp = SigningKey::read_pkcs8_der_file(path)
             .map_err(|e| error::Format::InvalidKey(e.to_string()))?;
         Ok(KeyPair { kp })
     }
 
+    #[cfg(feature = "pem")]
     pub fn from_private_key_pem_file(path: impl AsRef<Path>) -> Result<Self, error::Format> {
         let kp = SigningKey::read_pkcs8_pem_file(path)
             .map_err(|e| error::Format::InvalidKey(e.to_string()))?;

--- a/biscuit-auth/src/crypto/mod.rs
+++ b/biscuit-auth/src/crypto/mod.rs
@@ -10,10 +10,10 @@
 use crate::{error::Format, format::schema};
 
 use super::error;
-use ed25519_dalek::*;
+use ed25519_dalek::{pkcs8::DecodePrivateKey, *};
 use nom::Finish;
 use rand_core::{CryptoRng, RngCore};
-use std::{convert::TryInto, fmt::Display, hash::Hash, ops::Drop, str::FromStr};
+use std::{convert::TryInto, fmt::Display, hash::Hash, ops::Drop, path::Path, str::FromStr};
 use zeroize::Zeroize;
 
 /// pair of cryptographic keys used to sign a token's block
@@ -37,6 +37,30 @@ impl KeyPair {
         KeyPair {
             kp: ed25519_dalek::SigningKey::from_bytes(&key.0),
         }
+    }
+
+    pub fn from_private_key_der(bytes: &[u8]) -> Result<Self, error::Format> {
+        let kp = SigningKey::from_pkcs8_der(bytes)
+            .map_err(|e| error::Format::InvalidKey(e.to_string()))?;
+        Ok(KeyPair { kp })
+    }
+
+    pub fn from_private_key_pem(str: &str) -> Result<Self, error::Format> {
+        let kp = SigningKey::from_pkcs8_pem(str)
+            .map_err(|e| error::Format::InvalidKey(e.to_string()))?;
+        Ok(KeyPair { kp })
+    }
+
+    pub fn from_private_key_der_file(path: impl AsRef<Path>) -> Result<Self, error::Format> {
+        let kp = SigningKey::read_pkcs8_der_file(path)
+            .map_err(|e| error::Format::InvalidKey(e.to_string()))?;
+        Ok(KeyPair { kp })
+    }
+
+    pub fn from_private_key_pem_file(path: impl AsRef<Path>) -> Result<Self, error::Format> {
+        let kp = SigningKey::read_pkcs8_pem_file(path)
+            .map_err(|e| error::Format::InvalidKey(e.to_string()))?;
+        Ok(KeyPair { kp })
     }
 
     pub fn private(&self) -> PrivateKey {


### PR DESCRIPTION
To make it easier to loader KeyPairs, expose PEM and DER loaders from the `ed25519_dalek` crate.
PEM and DER are common formats for a key pair, so this should make loading a KeyPair easier.