### PR TITLE
remove pkcs8 file loading functions

### DIFF
--- a/biscuit-auth/src/crypto/mod.rs
+++ b/biscuit-auth/src/crypto/mod.rs
@@ -16,8 +16,6 @@ use ed25519_dalek::*;
 
 use nom::Finish;
 use rand_core::{CryptoRng, RngCore};
-#[cfg(feature = "pem")]
-use std::path::Path;
 use std::{convert::TryInto, fmt::Display, hash::Hash, ops::Drop, str::FromStr};
 use zeroize::Zeroize;
 
@@ -54,20 +52,6 @@ impl KeyPair {
     #[cfg(feature = "pem")]
     pub fn from_private_key_pem(str: &str) -> Result<Self, error::Format> {
         let kp = SigningKey::from_pkcs8_pem(str)
-            .map_err(|e| error::Format::InvalidKey(e.to_string()))?;
-        Ok(KeyPair { kp })
-    }
-
-    #[cfg(feature = "pem")]
-    pub fn from_private_key_der_file(path: impl AsRef<Path>) -> Result<Self, error::Format> {
-        let kp = SigningKey::read_pkcs8_der_file(path)
-            .map_err(|e| error::Format::InvalidKey(e.to_string()))?;
-        Ok(KeyPair { kp })
-    }
-
-    #[cfg(feature = "pem")]
-    pub fn from_private_key_pem_file(path: impl AsRef<Path>) -> Result<Self, error::Format> {
-        let kp = SigningKey::read_pkcs8_pem_file(path)
             .map_err(|e| error::Format::InvalidKey(e.to_string()))?;
         Ok(KeyPair { kp })
     }


### PR DESCRIPTION
We made a mistake when merging https://github.com/biscuit-auth/biscuit-rust/pull/204, that feature can't compile right now, because it needs the `std` feature active on the e25519 crate. That features requires `std::fs`, which may not work easily in other target platforms like web assembly.
It is reasonably easy to load a file manually in rust and pass a buffer, so I propose we remove those functions entirely.

cc @baranyildirim 