### PR TITLE
Add pem/der loaders to PublicKey

### DIFF
--- a/biscuit-auth/Cargo.toml
+++ b/biscuit-auth/Cargo.toml
@@ -25,7 +25,7 @@ bwk = ["chrono", "serde"]
 docsrs = []
 uuid = ["dep:uuid"]
 # used to expose pem/der loaders for keypairs
-pem = ["ed25519-dalek/pem"]
+pem = ["ed25519-dalek/pem", "ed25519-dalek/pkcs8"]
 
 [dependencies]
 rand_core = "^0.6"

--- a/biscuit-auth/src/crypto/mod.rs
+++ b/biscuit-auth/src/crypto/mod.rs
@@ -12,6 +12,8 @@ use crate::{error::Format, format::schema};
 use super::error;
 #[cfg(feature = "pem")]
 use ed25519_dalek::pkcs8::DecodePrivateKey;
+#[cfg(feature = "pem")]
+use ed25519_dalek::pkcs8::DecodePublicKey;
 use ed25519_dalek::*;
 
 use nom::Finish;
@@ -168,6 +170,20 @@ impl PublicKey {
             algorithm: schema::public_key::Algorithm::Ed25519 as i32,
             key: self.to_bytes().to_vec(),
         }
+    }
+
+    #[cfg(feature = "pem")]
+    pub fn from_public_key_der(bytes: &[u8]) -> Result<Self, error::Format> {
+        let verification_key = ed25519_dalek::VerifyingKey::from_public_key_der(bytes)
+            .map_err(|e| error::Format::InvalidKey(e.to_string()))?;
+        Ok(PublicKey(verification_key))
+    }
+
+    #[cfg(feature = "pem")]
+    pub fn from_public_key_pem(pem: &str) -> Result<Self, error::Format> {
+        let verification_key = ed25519_dalek::VerifyingKey::from_public_key_pem(pem)
+            .map_err(|e| error::Format::InvalidKey(e.to_string()))?;
+        Ok(PublicKey(verification_key))
     }
 
     pub fn print(&self) -> String {

--- a/biscuit-parser/Cargo.toml
+++ b/biscuit-parser/Cargo.toml
@@ -21,5 +21,6 @@ time = {version = "0.3.7", features = ["formatting", "parsing"]}
 
 [features]
 datalog-macro = []
+pem = []
 # used by biscuit-wasm to serialize errors to JSON
 serde-error = ["serde"]


### PR DESCRIPTION
Similar to #204 
It seems like the previous feature gate does not work correctly - cargo does not detect the `pem` feature unless it is also available in the biscuit-parser crate. 

I assume something similar happened with the `datalog-macro`, so I've added an empty `pem` feature to biscuit-parser.