### PR TITLE
Bump proc-macro-error

### DIFF
--- a/biscuit-auth/src/lib.rs
+++ b/biscuit-auth/src/lib.rs
@@ -241,9 +241,9 @@ mod capi;
 #[cfg(cargo_c)]
 pub use capi::*;
 
-#[cfg(bwk)]
+#[cfg(feature = "bwk")]
 mod bwk;
-#[cfg(bwk)]
+#[cfg(feature = "bwk")]
 pub use bwk::*;
 
 mod time;

--- a/biscuit-quote/Cargo.toml
+++ b/biscuit-quote/Cargo.toml
@@ -14,7 +14,7 @@ biscuit-parser = { path = "../biscuit-parser", features = ["datalog-macro"], ver
 proc-macro2 = "1"
 quote = "1.0.14"
 syn = { version = "1.0.85", features = ["full", "extra-traits"] }
-proc-macro-error = "1.0"
+proc-macro-error2 = "2.0"
 
 [dev-dependencies]
 hex = "0.4.3"

--- a/biscuit-quote/src/lib.rs
+++ b/biscuit-quote/src/lib.rs
@@ -6,7 +6,7 @@ use biscuit_parser::{
     parser::{parse_block_source, parse_source},
 };
 use proc_macro2::{Span, TokenStream};
-use proc_macro_error::{abort_call_site, proc_macro_error};
+use proc_macro_error2::{abort_call_site, proc_macro_error};
 use quote::{quote, ToTokens};
 use std::collections::{HashMap, HashSet};
 use syn::{


### PR DESCRIPTION
Following https://rustsec.org/advisories/RUSTSEC-2024-0370

A second commit fixes the feature gate for bwk.