### PR TITLE
ci(capi): Add MUSL Support + SHA256 checksums

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,30 +17,77 @@ jobs:
     strategy:
       matrix:
         include:
-          # deactivated for now, the x86 workers are more expensive
-          # - os: macos-latest-large
-          #   target_arch: x86_64-apple-darwin
+          - os: macos-13
+            target_arch: x86_64-apple-darwin
+            arch: x86_64-macos
           - os: macos-latest
             target_arch: aarch64-apple-darwin
+            arch: arm64-macos
           - os: ubuntu-latest
             target_arch: x86_64-unknown-linux-gnu
+            arch: x86_64-linux
+          - os: ubuntu-latest
+            target_arch: x86_64-unknown-linux-musl
+            arch: x86_64-linux-musl
+            use_musl: true
 
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
+      - name: Install musl tools
+        if: matrix.use_musl
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           target: ${{ matrix.target_arch }}
-      - name: Install cargo-c
-        run: cargo install cargo-c --version 0.10.5+cargo-0.83.0
+      - name: Install cargo-c (macOS)
+        if: startsWith(matrix.os, 'macos')
+        env:
+          LINK: https://github.com/lu-zero/cargo-c/releases/download
+          CARGO_C_FILE: cargo-c-macos.zip
+          CARGO_C_VERSION: v0.10.5
+        run: |
+          curl -L $LINK/$CARGO_C_VERSION/$CARGO_C_FILE -o cargo-c-macos.zip
+          unzip cargo-c-macos.zip -d ~/.cargo/bin
+      - name: Install cargo-c (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        env:
+          LINK: https://github.com/lu-zero/cargo-c/releases/download
+          CARGO_C_FILE: cargo-c-x86_64-unknown-linux-musl.tar.gz
+          CARGO_C_VERSION: v0.10.5
+        run: |
+          curl -L $LINK/$CARGO_C_VERSION/$CARGO_C_FILE | tar xz -C ~/.cargo/bin
       - name: Run cargo-c tests
         run: cargo ctest --release --features="capi"
         if: matrix.os == 'ubuntu-latest' && matrix.target_arch == 'x86_64-unknown-linux-gnu'
-      - name: Build C-API
-        run: cargo cinstall --release --prefix=/usr --destdir=./build --features="capi"
+
+      - name: Build C-API (Linux)
+        if: matrix.os == 'ubuntu-latest' && !matrix.use_musl
+        run: cargo cinstall --release --target ${{ matrix.target_arch }} --prefix=/usr --destdir=./build --features="capi"
+      - name: Build C-API (musl)
+        if: matrix.use_musl
+        run: |
+          cargo cinstall --target ${{ matrix.target_arch }} --release --prefix=/usr --destdir=./build --features="capi"
+      - name: Build C-API (macOS)
+        if: startsWith(matrix.os, 'macos')
+        run: |
+          cargo cinstall --target ${{ matrix.target_arch }} --release --prefix=/usr --destdir=./build --features="capi"
+
       - name: Compress
-        run: tar cvzf biscuit_capi-${{github.ref_name}}-${{matrix.target_arch}}.tar.gz -C build/ .
+        run: tar cvzf biscuit-auth-${{github.ref_name}}-${{matrix.arch}}.tar.gz -C build/ .
+
+      - name: Generate checksum
+        run: |
+          if [[ "$RUNNER_OS" == "Linux" ]]; then
+            sha256sum "biscuit-auth-${{github.ref_name}}-${{matrix.arch}}.tar.gz" > "biscuit-auth-${{github.ref_name}}-${{matrix.arch}}.tar.gz.sha256"
+          else
+            shasum -a 256 "biscuit-auth-${{github.ref_name}}-${{matrix.arch}}.tar.gz" > "biscuit-auth-${{github.ref_name}}-${{matrix.arch}}.tar.gz.sha256"
+          fi
       - name: Release
         uses: softprops/action-gh-release@v1
         with:
-          files: biscuit_capi-${{github.ref_name}}-${{matrix.target_arch}}.tar.gz
+          files: |
+            biscuit-auth-${{github.ref_name}}-${{matrix.arch}}.tar.gz
+            biscuit-auth-${{github.ref_name}}-${{matrix.arch}}.tar.gz.sha256

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,7 +43,12 @@ jobs:
         uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Install cargo-c
-        run: cargo install cargo-c --version 0.10.5+cargo-0.83.0
+        env:
+          LINK: https://github.com/lu-zero/cargo-c/releases/download
+          CARGO_C_FILE: cargo-c-x86_64-unknown-linux-musl.tar.gz
+          CARGO_C_VERSION: v0.10.5
+        run: |
+          curl -L $LINK/$CARGO_C_VERSION/$CARGO_C_FILE | tar xz -C ~/.cargo/bin
       - name: Run cargo-c tests
         run: cargo ctest --features="capi" --release
 


### PR DESCRIPTION
- Add MUSL target
- Add SHA256 checksums
- rename release files to `biscuit-auth-capi-X.X.X-arch.tar.gz`
- download directly `cargo-c` instead of compiling
- Re-activate macos x86 build
