### PR TITLE
fix(ci): Fix CAPI build on macos

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos-13
+          - os: macos-latest
             target_arch: x86_64-apple-darwin
             arch: x86_64-macos
           - os: macos-latest
@@ -29,13 +29,12 @@ jobs:
           - os: ubuntu-latest
             target_arch: x86_64-unknown-linux-musl
             arch: x86_64-linux-musl
-            use_musl: true
 
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
       - name: Install musl tools
-        if: matrix.use_musl
+        if: matrix.os == 'ubuntu-latest' && matrix.target_arch == 'x86_64-unknown-linux-musl'
         run: |
           sudo apt-get update
           sudo apt-get install -y musl-tools
@@ -43,7 +42,7 @@ jobs:
         with:
           target: ${{ matrix.target_arch }}
       - name: Install cargo-c (macOS)
-        if: startsWith(matrix.os, 'macos')
+        if: matrix.os == 'macos-latest'
         env:
           LINK: https://github.com/lu-zero/cargo-c/releases/download
           CARGO_C_FILE: cargo-c-macos.zip
@@ -64,14 +63,14 @@ jobs:
         if: matrix.os == 'ubuntu-latest' && matrix.target_arch == 'x86_64-unknown-linux-gnu'
 
       - name: Build C-API (Linux)
-        if: matrix.os == 'ubuntu-latest' && !matrix.use_musl
+        if: matrix.os == 'ubuntu-latest' && matrix.target_arch == 'x86_64-unknown-linux-gnu'
         run: cargo cinstall --release --target ${{ matrix.target_arch }} --prefix=/usr --destdir=./build --features="capi"
       - name: Build C-API (musl)
-        if: matrix.use_musl
+        if: matrix.os == 'ubuntu-latest' && matrix.target_arch == 'x86_64-unknown-linux-musl'
         run: |
           cargo cinstall --target ${{ matrix.target_arch }} --release --prefix=/usr --destdir=./build --features="capi"
       - name: Build C-API (macOS)
-        if: startsWith(matrix.os, 'macos')
+        if: matrix.os == 'macos-latest'
         run: |
           cargo cinstall --target ${{ matrix.target_arch }} --release --prefix=/usr --destdir=./build --features="capi"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,9 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
+  build-capi:
     runs-on: ${{ matrix.os }}
+    name: Build C-API (${{ matrix.arch }})
     strategy:
       matrix:
         include:
@@ -64,15 +65,15 @@ jobs:
 
       - name: Build C-API (Linux)
         if: matrix.os == 'ubuntu-latest' && matrix.target_arch == 'x86_64-unknown-linux-gnu'
-        run: cargo cinstall --release --target ${{ matrix.target_arch }} --prefix=/usr --destdir=./build --features="capi"
+        run: cargo cinstall --release --target ${{ matrix.target_arch }} --prefix=/usr --destdir=./build
       - name: Build C-API (musl)
         if: matrix.os == 'ubuntu-latest' && matrix.target_arch == 'x86_64-unknown-linux-musl'
         run: |
-          cargo cinstall --target ${{ matrix.target_arch }} --release --prefix=/usr --destdir=./build --features="capi"
+          cargo cinstall --target ${{ matrix.target_arch }} --release --prefix=/usr --destdir=./build
       - name: Build C-API (macOS)
         if: matrix.os == 'macos-latest'
         run: |
-          cargo cinstall --target ${{ matrix.target_arch }} --release --prefix=/usr --destdir=./build --features="capi"
+          cargo cinstall --target ${{ matrix.target_arch }} --release --prefix=/usr --destdir=./build
 
       - name: Compress
         run: tar cvzf biscuit-auth-${{github.ref_name}}-${{matrix.arch}}.tar.gz -C build/ .
@@ -85,7 +86,7 @@ jobs:
             shasum -a 256 "biscuit-auth-${{github.ref_name}}-${{matrix.arch}}.tar.gz" > "biscuit-auth-${{github.ref_name}}-${{matrix.arch}}.tar.gz.sha256"
           fi
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: |
             biscuit-auth-${{github.ref_name}}-${{matrix.arch}}.tar.gz

--- a/biscuit-capi/Cargo.toml
+++ b/biscuit-capi/Cargo.toml
@@ -14,12 +14,14 @@ biscuit-auth = { version = "5.0.0", path = "../biscuit-auth", features = [
     "datalog-macro",
     "serde-error",
 ] }
-inline-c = { version = "0.1", optional = true }
+libc = { version = "0.2", optional = true }
 rand = "0.8"
 
 [features]
-default = []
-capi = ["inline-c"]
+capi = ["libc"]
+
+[dev-dependencies]
+inline-c = "0.1"
 
 [package.metadata.capi.library]
 # Used as the library name and defaults to the crate name. This might get


### PR DESCRIPTION
## Purpose

- The build on macos-13 wasn't working because the pre-built `cargo-c` bins for macOS is only built for macos-arm architecture. We're now building both macOS arch on `macos-latest`
- I've spotted a bug where `inline-c` was always built in the release (see: https://github.com/biscuit-auth/biscuit-rust/actions/runs/11653423212/job/32445931933#step:6:94). We're now marking `inline-c` as a dev dependency and explicit requiring `libc` for `capi` build.
- Reworked the name of the CI jobs for ease of debugging: 
![CleanShot 2024-11-10 at 14 51 52](https://github.com/user-attachments/assets/099370a5-4524-467b-9103-efcc4e2e5aed)

I've tested the release workflow on my fork: https://github.com/ptondereau/biscuit-rust/actions/runs/11765631797 and https://github.com/ptondereau/biscuit-rust/releases/tag/capi-5.0.0
