### PR TITLE
authorizer builder

### DIFF
--- a/biscuit-auth/benches/token.rs
+++ b/biscuit-auth/benches/token.rs
@@ -16,11 +16,11 @@ fn create_block_1(b: &mut Bencher) {
     let root = KeyPair::new_with_rng(Algorithm::Ed25519, &mut rng);
 
     let token = Biscuit::builder()
-        .add_fact(fact("right", &[string("file1"), string("read")]))
+        .fact(fact("right", &[string("file1"), string("read")]))
         .unwrap()
-        .add_fact(fact("right", &[string("file2"), string("read")]))
+        .fact(fact("right", &[string("file2"), string("read")]))
         .unwrap()
-        .add_fact(fact("right", &[string("file1"), string("write")]))
+        .fact(fact("right", &[string("file1"), string("write")]))
         .unwrap()
         .build_with_rng(&root, SymbolTable::default(), &mut rng)
         .unwrap();
@@ -30,11 +30,11 @@ fn create_block_1(b: &mut Bencher) {
     assert_eq!(b.bytes, 206);
     b.iter(|| {
         let token = Biscuit::builder()
-            .add_fact(fact("right", &[string("file1"), string("read")]))
+            .fact(fact("right", &[string("file1"), string("read")]))
             .unwrap()
-            .add_fact(fact("right", &[string("file2"), string("read")]))
+            .fact(fact("right", &[string("file2"), string("read")]))
             .unwrap()
-            .add_fact(fact("right", &[string("file1"), string("write")]))
+            .fact(fact("right", &[string("file1"), string("write")]))
             .unwrap()
             .build_with_rng(&root, SymbolTable::default(), &mut rng)
             .unwrap();
@@ -48,11 +48,11 @@ fn append_block_2(b: &mut Bencher) {
     let keypair2 = KeyPair::new_with_rng(Algorithm::Ed25519, &mut rng);
 
     let token = Biscuit::builder()
-        .add_fact(fact("right", &[string("file1"), string("read")]))
+        .fact(fact("right", &[string("file1"), string("read")]))
         .unwrap()
-        .add_fact(fact("right", &[string("file2"), string("read")]))
+        .fact(fact("right", &[string("file2"), string("read")]))
         .unwrap()
-        .add_fact(fact("right", &[string("file1"), string("write")]))
+        .fact(fact("right", &[string("file1"), string("write")]))
         .unwrap()
         .build_with_rng(&root, SymbolTable::default(), &mut rng)
         .unwrap();
@@ -87,11 +87,11 @@ fn append_block_5(b: &mut Bencher) {
     let keypair5 = KeyPair::new_with_rng(Algorithm::Ed25519, &mut rng);
 
     let token = Biscuit::builder()
-        .add_fact(fact("right", &[string("file1"), string("read")]))
+        .fact(fact("right", &[string("file1"), string("read")]))
         .unwrap()
-        .add_fact(fact("right", &[string("file2"), string("read")]))
+        .fact(fact("right", &[string("file2"), string("read")]))
         .unwrap()
-        .add_fact(fact("right", &[string("file1"), string("write")]))
+        .fact(fact("right", &[string("file1"), string("write")]))
         .unwrap()
         .build_with_rng(&root, SymbolTable::default(), &mut rng)
         .unwrap();
@@ -145,11 +145,11 @@ fn unverified_append_block_2(b: &mut Bencher) {
     let keypair2 = KeyPair::new_with_rng(Algorithm::Ed25519, &mut rng);
 
     let token = Biscuit::builder()
-        .add_fact(fact("right", &[string("file1"), string("read")]))
+        .fact(fact("right", &[string("file1"), string("read")]))
         .unwrap()
-        .add_fact(fact("right", &[string("file2"), string("read")]))
+        .fact(fact("right", &[string("file2"), string("read")]))
         .unwrap()
-        .add_fact(fact("right", &[string("file1"), string("write")]))
+        .fact(fact("right", &[string("file1"), string("write")]))
         .unwrap()
         .build_with_rng(&root, SymbolTable::default(), &mut rng)
         .unwrap();
@@ -184,11 +184,11 @@ fn unverified_append_block_5(b: &mut Bencher) {
     let keypair5 = KeyPair::new_with_rng(Algorithm::Ed25519, &mut rng);
 
     let token = Biscuit::builder()
-        .add_fact(fact("right", &[string("file1"), string("read")]))
+        .fact(fact("right", &[string("file1"), string("read")]))
         .unwrap()
-        .add_fact(fact("right", &[string("file2"), string("read")]))
+        .fact(fact("right", &[string("file2"), string("read")]))
         .unwrap()
-        .add_fact(fact("right", &[string("file1"), string("write")]))
+        .fact(fact("right", &[string("file1"), string("write")]))
         .unwrap()
         .build_with_rng(&root, SymbolTable::default(), &mut rng)
         .unwrap();
@@ -243,11 +243,11 @@ fn verify_block_2(b: &mut Bencher) {
 
     let data = {
         let token = Biscuit::builder()
-            .add_fact(fact("right", &[string("file1"), string("read")]))
+            .fact(fact("right", &[string("file1"), string("read")]))
             .unwrap()
-            .add_fact(fact("right", &[string("file2"), string("read")]))
+            .fact(fact("right", &[string("file2"), string("read")]))
             .unwrap()
-            .add_fact(fact("right", &[string("file1"), string("write")]))
+            .fact(fact("right", &[string("file1"), string("write")]))
             .unwrap()
             .build_with_rng(&root, SymbolTable::default(), &mut rng)
             .unwrap();
@@ -263,12 +263,12 @@ fn verify_block_2(b: &mut Bencher) {
 
     let token = Biscuit::from(&data, &root.public()).unwrap();
     let mut verifier = AuthorizerBuilder::new()
-        .add_token(&token)
-        .add_fact("resource(\"file1\")")
+        .token(&token)
+        .fact("resource(\"file1\")")
         .unwrap()
-        .add_fact("operation(\"read\")")
+        .fact("operation(\"read\")")
         .unwrap()
-        .add_allow_all()
+        .allow_all()
         .build()
         .unwrap();
     verifier
@@ -281,12 +281,12 @@ fn verify_block_2(b: &mut Bencher) {
     b.iter(|| {
         let token = Biscuit::from(&data, &root.public()).unwrap();
         let mut verifier = AuthorizerBuilder::new()
-            .add_token(&token)
-            .add_fact("resource(\"file1\")")
+            .token(&token)
+            .fact("resource(\"file1\")")
             .unwrap()
-            .add_fact("operation(\"read\")")
+            .fact("operation(\"read\")")
             .unwrap()
-            .add_allow_all()
+            .allow_all()
             .build()
             .unwrap();
         verifier
@@ -308,11 +308,11 @@ fn verify_block_5(b: &mut Bencher) {
 
     let data = {
         let token = Biscuit::builder()
-            .add_fact(fact("right", &[string("file1"), string("read")]))
+            .fact(fact("right", &[string("file1"), string("read")]))
             .unwrap()
-            .add_fact(fact("right", &[string("file2"), string("read")]))
+            .fact(fact("right", &[string("file2"), string("read")]))
             .unwrap()
-            .add_fact(fact("right", &[string("file1"), string("write")]))
+            .fact(fact("right", &[string("file1"), string("write")]))
             .unwrap()
             .build_with_rng(&root, SymbolTable::default(), &mut rng)
             .unwrap();
@@ -352,12 +352,12 @@ fn verify_block_5(b: &mut Bencher) {
 
     let token = Biscuit::from(&data, &root.public()).unwrap();
     let mut verifier = AuthorizerBuilder::new()
-        .add_token(&token)
-        .add_fact("resource(\"file1\")")
+        .token(&token)
+        .fact("resource(\"file1\")")
         .unwrap()
-        .add_fact("operation(\"read\")")
+        .fact("operation(\"read\")")
         .unwrap()
-        .add_allow_all()
+        .allow_all()
         .build()
         .unwrap();
     verifier
@@ -371,12 +371,12 @@ fn verify_block_5(b: &mut Bencher) {
     b.iter(|| {
         let token = Biscuit::from(&data, &root.public()).unwrap();
         let mut verifier = AuthorizerBuilder::new()
-            .add_token(&token)
-            .add_fact("resource(\"file1\")")
+            .token(&token)
+            .fact("resource(\"file1\")")
             .unwrap()
-            .add_fact("operation(\"read\")")
+            .fact("operation(\"read\")")
             .unwrap()
-            .add_allow_all()
+            .allow_all()
             .build()
             .unwrap();
         verifier
@@ -395,11 +395,11 @@ fn check_signature_2(b: &mut Bencher) {
 
     let data = {
         let token = Biscuit::builder()
-            .add_fact(fact("right", &[string("file1"), string("read")]))
+            .fact(fact("right", &[string("file1"), string("read")]))
             .unwrap()
-            .add_fact(fact("right", &[string("file2"), string("read")]))
+            .fact(fact("right", &[string("file2"), string("read")]))
             .unwrap()
-            .add_fact(fact("right", &[string("file1"), string("write")]))
+            .fact(fact("right", &[string("file1"), string("write")]))
             .unwrap()
             .build_with_rng(&root, SymbolTable::default(), &mut rng)
             .unwrap();
@@ -415,12 +415,12 @@ fn check_signature_2(b: &mut Bencher) {
 
     let token = Biscuit::from(&data, &root.public()).unwrap();
     let mut verifier = AuthorizerBuilder::new()
-        .add_token(&token)
-        .add_fact("resource(\"file1\")")
+        .token(&token)
+        .fact("resource(\"file1\")")
         .unwrap()
-        .add_fact("operation(\"read\")")
+        .fact("operation(\"read\")")
         .unwrap()
-        .add_allow_all()
+        .allow_all()
         .build()
         .unwrap();
     verifier
@@ -446,11 +446,11 @@ fn check_signature_5(b: &mut Bencher) {
 
     let data = {
         let token = Biscuit::builder()
-            .add_fact(fact("right", &[string("file1"), string("read")]))
+            .fact(fact("right", &[string("file1"), string("read")]))
             .unwrap()
-            .add_fact(fact("right", &[string("file2"), string("read")]))
+            .fact(fact("right", &[string("file2"), string("read")]))
             .unwrap()
-            .add_fact(fact("right", &[string("file1"), string("write")]))
+            .fact(fact("right", &[string("file1"), string("write")]))
             .unwrap()
             .build_with_rng(&root, SymbolTable::default(), &mut rng)
             .unwrap();
@@ -489,12 +489,12 @@ fn check_signature_5(b: &mut Bencher) {
 
     let token = Biscuit::from(&data, &root.public()).unwrap();
     let mut verifier = AuthorizerBuilder::new()
-        .add_token(&token)
-        .add_fact("resource(\"file1\")")
+        .token(&token)
+        .fact("resource(\"file1\")")
         .unwrap()
-        .add_fact("operation(\"read\")")
+        .fact("operation(\"read\")")
         .unwrap()
-        .add_allow_all()
+        .allow_all()
         .build()
         .unwrap();
     verifier
@@ -517,11 +517,11 @@ fn checks_block_2(b: &mut Bencher) {
 
     let data = {
         let token = Biscuit::builder()
-            .add_fact(fact("right", &[string("file1"), string("read")]))
+            .fact(fact("right", &[string("file1"), string("read")]))
             .unwrap()
-            .add_fact(fact("right", &[string("file2"), string("read")]))
+            .fact(fact("right", &[string("file2"), string("read")]))
             .unwrap()
-            .add_fact(fact("right", &[string("file1"), string("write")]))
+            .fact(fact("right", &[string("file1"), string("write")]))
             .unwrap()
             .build_with_rng(&root, SymbolTable::default(), &mut rng)
             .unwrap();
@@ -537,12 +537,12 @@ fn checks_block_2(b: &mut Bencher) {
 
     let token = Biscuit::from(&data, &root.public()).unwrap();
     let mut verifier = AuthorizerBuilder::new()
-        .add_token(&token)
-        .add_fact("resource(\"file1\")")
+        .token(&token)
+        .fact("resource(\"file1\")")
         .unwrap()
-        .add_fact("operation(\"read\")")
+        .fact("operation(\"read\")")
         .unwrap()
-        .add_allow_all()
+        .allow_all()
         .build()
         .unwrap();
     verifier
@@ -556,12 +556,12 @@ fn checks_block_2(b: &mut Bencher) {
     b.bytes = data.len() as u64;
     b.iter(|| {
         let mut verifier = AuthorizerBuilder::new()
-            .add_token(&token)
-            .add_fact("resource(\"file1\")")
+            .token(&token)
+            .fact("resource(\"file1\")")
             .unwrap()
-            .add_fact("operation(\"read\")")
+            .fact("operation(\"read\")")
             .unwrap()
-            .add_allow_all()
+            .allow_all()
             .build()
             .unwrap();
         verifier
@@ -580,11 +580,11 @@ fn checks_block_create_verifier2(b: &mut Bencher) {
 
     let data = {
         let token = Biscuit::builder()
-            .add_fact(fact("right", &[string("file1"), string("read")]))
+            .fact(fact("right", &[string("file1"), string("read")]))
             .unwrap()
-            .add_fact(fact("right", &[string("file2"), string("read")]))
+            .fact(fact("right", &[string("file2"), string("read")]))
             .unwrap()
-            .add_fact(fact("right", &[string("file1"), string("write")]))
+            .fact(fact("right", &[string("file1"), string("write")]))
             .unwrap()
             .build_with_rng(&root, SymbolTable::default(), &mut rng)
             .unwrap();
@@ -600,12 +600,12 @@ fn checks_block_create_verifier2(b: &mut Bencher) {
 
     let token = Biscuit::from(&data, &root.public()).unwrap();
     let mut verifier = AuthorizerBuilder::new()
-        .add_token(&token)
-        .add_fact("resource(\"file1\")")
+        .token(&token)
+        .fact("resource(\"file1\")")
         .unwrap()
-        .add_fact("operation(\"read\")")
+        .fact("operation(\"read\")")
         .unwrap()
-        .add_allow_all()
+        .allow_all()
         .build()
         .unwrap();
     verifier
@@ -629,11 +629,11 @@ fn checks_block_verify_only2(b: &mut Bencher) {
 
     let data = {
         let token = Biscuit::builder()
-            .add_fact(fact("right", &[string("file1"), string("read")]))
+            .fact(fact("right", &[string("file1"), string("read")]))
             .unwrap()
-            .add_fact(fact("right", &[string("file2"), string("read")]))
+            .fact(fact("right", &[string("file2"), string("read")]))
             .unwrap()
-            .add_fact(fact("right", &[string("file1"), string("write")]))
+            .fact(fact("right", &[string("file1"), string("write")]))
             .unwrap()
             .build_with_rng(&root, SymbolTable::default(), &mut rng)
             .unwrap();
@@ -649,12 +649,12 @@ fn checks_block_verify_only2(b: &mut Bencher) {
 
     let token = Biscuit::from(&data, &root.public()).unwrap();
     let mut verifier = AuthorizerBuilder::new()
-        .add_token(&token)
-        .add_fact("resource(\"file1\")")
+        .token(&token)
+        .fact("resource(\"file1\")")
         .unwrap()
-        .add_fact("operation(\"read\")")
+        .fact("operation(\"read\")")
         .unwrap()
-        .add_allow_all()
+        .allow_all()
         .build()
         .unwrap();
     verifier
@@ -667,12 +667,12 @@ fn checks_block_verify_only2(b: &mut Bencher) {
     let token = Biscuit::from(&data, &root.public()).unwrap();
     b.iter(|| {
         let mut verifier = AuthorizerBuilder::new()
-            .add_token(&token)
-            .add_fact("resource(\"file1\")")
+            .token(&token)
+            .fact("resource(\"file1\")")
             .unwrap()
-            .add_fact("operation(\"read\")")
+            .fact("operation(\"read\")")
             .unwrap()
-            .add_allow_all()
+            .allow_all()
             .build()
             .unwrap();
         verifier

--- a/biscuit-auth/benches/token.rs
+++ b/biscuit-auth/benches/token.rs
@@ -243,10 +243,12 @@ fn verify_block_2(b: &mut Bencher) {
     };
 
     let token = Biscuit::from(&data, &root.public()).unwrap();
-    let mut verifier = token.authorizer().unwrap();
-    verifier.add_fact("resource(\"file1\")");
-    verifier.add_fact("operation(\"read\")");
-    verifier.add_allow_all();
+    let mut builder = AuthorizerBuilder::new();
+    builder.add_token(&token);
+    builder.add_fact("resource(\"file1\")");
+    builder.add_fact("operation(\"read\")");
+    builder.add_allow_all();
+    let mut verifier = builder.build().unwrap();
     verifier
         .authorize_with_limits(AuthorizerLimits {
             max_time: Duration::from_secs(10),
@@ -256,10 +258,12 @@ fn verify_block_2(b: &mut Bencher) {
     b.bytes = data.len() as u64;
     b.iter(|| {
         let token = Biscuit::from(&data, &root.public()).unwrap();
-        let mut verifier = token.authorizer().unwrap();
-        verifier.add_fact("resource(\"file1\")");
-        verifier.add_fact("operation(\"read\")");
-        verifier.add_allow_all();
+        let mut builder = AuthorizerBuilder::new();
+        builder.add_token(&token);
+        builder.add_fact("resource(\"file1\")");
+        builder.add_fact("operation(\"read\")");
+        builder.add_allow_all();
+        let mut verifier = builder.build().unwrap();
         verifier
             .authorize_with_limits(AuthorizerLimits {
                 max_time: Duration::from_secs(10),
@@ -321,10 +325,12 @@ fn verify_block_5(b: &mut Bencher) {
     };
 
     let token = Biscuit::from(&data, &root.public()).unwrap();
-    let mut verifier = token.authorizer().unwrap();
-    verifier.add_fact("resource(\"file1\")");
-    verifier.add_fact("operation(\"read\")");
-    verifier.add_allow_all();
+    let mut builder = AuthorizerBuilder::new();
+    builder.add_token(&token);
+    builder.add_fact("resource(\"file1\")");
+    builder.add_fact("operation(\"read\")");
+    builder.add_allow_all();
+    let mut verifier = builder.build().unwrap();
     verifier
         .authorize_with_limits(AuthorizerLimits {
             max_time: Duration::from_secs(10),
@@ -335,10 +341,12 @@ fn verify_block_5(b: &mut Bencher) {
     b.bytes = data.len() as u64;
     b.iter(|| {
         let token = Biscuit::from(&data, &root.public()).unwrap();
-        let mut verifier = token.authorizer().unwrap();
-        verifier.add_fact("resource(\"file1\")");
-        verifier.add_fact("operation(\"read\")");
-        verifier.add_allow_all();
+        let mut builder = AuthorizerBuilder::new();
+        builder.add_token(&token);
+        builder.add_fact("resource(\"file1\")");
+        builder.add_fact("operation(\"read\")");
+        builder.add_allow_all();
+        let mut verifier = builder.build().unwrap();
         verifier
             .authorize_with_limits(AuthorizerLimits {
                 max_time: Duration::from_secs(10),
@@ -373,10 +381,12 @@ fn check_signature_2(b: &mut Bencher) {
     };
 
     let token = Biscuit::from(&data, &root.public()).unwrap();
-    let mut verifier = token.authorizer().unwrap();
-    verifier.add_fact("resource(\"file1\")");
-    verifier.add_fact("operation(\"read\")");
-    verifier.add_allow_all();
+    let mut builder = AuthorizerBuilder::new();
+    builder.add_token(&token);
+    builder.add_fact("resource(\"file1\")");
+    builder.add_fact("operation(\"read\")");
+    builder.add_allow_all();
+    let mut verifier = builder.build().unwrap();
     verifier
         .authorize_with_limits(AuthorizerLimits {
             max_time: Duration::from_secs(10),
@@ -441,10 +451,12 @@ fn check_signature_5(b: &mut Bencher) {
     };
 
     let token = Biscuit::from(&data, &root.public()).unwrap();
-    let mut verifier = token.authorizer().unwrap();
-    verifier.add_fact("resource(\"file1\")");
-    verifier.add_fact("operation(\"read\")");
-    verifier.add_allow_all();
+    let mut builder = AuthorizerBuilder::new();
+    builder.add_token(&token);
+    builder.add_fact("resource(\"file1\")");
+    builder.add_fact("operation(\"read\")");
+    builder.add_allow_all();
+    let mut verifier = builder.build().unwrap();
     verifier
         .authorize_with_limits(AuthorizerLimits {
             max_time: Duration::from_secs(10),
@@ -483,10 +495,12 @@ fn checks_block_2(b: &mut Bencher) {
     };
 
     let token = Biscuit::from(&data, &root.public()).unwrap();
-    let mut verifier = token.authorizer().unwrap();
-    verifier.add_fact("resource(\"file1\")");
-    verifier.add_fact("operation(\"read\")");
-    verifier.add_allow_all();
+    let mut builder = AuthorizerBuilder::new();
+    builder.add_token(&token);
+    builder.add_fact("resource(\"file1\")");
+    builder.add_fact("operation(\"read\")");
+    builder.add_allow_all();
+    let mut verifier = builder.build().unwrap();
     verifier
         .authorize_with_limits(AuthorizerLimits {
             max_time: Duration::from_secs(10),
@@ -497,10 +511,12 @@ fn checks_block_2(b: &mut Bencher) {
     let token = Biscuit::from(&data, &root.public()).unwrap();
     b.bytes = data.len() as u64;
     b.iter(|| {
-        let mut verifier = token.authorizer().unwrap();
-        verifier.add_fact("resource(\"file1\")");
-        verifier.add_fact("operation(\"read\")");
-        verifier.add_allow_all();
+        let mut builder = AuthorizerBuilder::new();
+        builder.add_token(&token);
+        builder.add_fact("resource(\"file1\")");
+        builder.add_fact("operation(\"read\")");
+        builder.add_allow_all();
+        let mut verifier = builder.build().unwrap();
         verifier
             .authorize_with_limits(AuthorizerLimits {
                 max_time: Duration::from_secs(10),
@@ -535,10 +551,12 @@ fn checks_block_create_verifier2(b: &mut Bencher) {
     };
 
     let token = Biscuit::from(&data, &root.public()).unwrap();
-    let mut verifier = token.authorizer().unwrap();
-    verifier.add_fact("resource(\"file1\")");
-    verifier.add_fact("operation(\"read\")");
-    verifier.add_allow_all();
+    let mut builder = AuthorizerBuilder::new();
+    builder.add_token(&token);
+    builder.add_fact("resource(\"file1\")");
+    builder.add_fact("operation(\"read\")");
+    builder.add_allow_all();
+    let mut verifier = builder.build().unwrap();
     verifier
         .authorize_with_limits(AuthorizerLimits {
             max_time: Duration::from_secs(10),
@@ -578,10 +596,12 @@ fn checks_block_verify_only2(b: &mut Bencher) {
     };
 
     let token = Biscuit::from(&data, &root.public()).unwrap();
-    let mut verifier = token.authorizer().unwrap();
-    verifier.add_fact("resource(\"file1\")");
-    verifier.add_fact("operation(\"read\")");
-    verifier.add_allow_all();
+    let mut builder = AuthorizerBuilder::new();
+    builder.add_token(&token);
+    builder.add_fact("resource(\"file1\")");
+    builder.add_fact("operation(\"read\")");
+    builder.add_allow_all();
+    let mut verifier = builder.build().unwrap();
     verifier
         .authorize_with_limits(AuthorizerLimits {
             max_time: Duration::from_secs(10),
@@ -591,10 +611,12 @@ fn checks_block_verify_only2(b: &mut Bencher) {
 
     let token = Biscuit::from(&data, &root.public()).unwrap();
     b.iter(|| {
-        let mut verifier = token.authorizer().unwrap();
-        verifier.add_fact("resource(\"file1\")");
-        verifier.add_fact("operation(\"read\")");
-        verifier.add_allow_all();
+        let mut builder = AuthorizerBuilder::new();
+        builder.add_token(&token);
+        builder.add_fact("resource(\"file1\")");
+        builder.add_fact("operation(\"read\")");
+        builder.add_allow_all();
+        let mut verifier = builder.build().unwrap();
         verifier
             .authorize_with_limits(AuthorizerLimits {
                 max_time: Duration::from_secs(10),

--- a/biscuit-auth/benches/token.rs
+++ b/biscuit-auth/benches/token.rs
@@ -263,13 +263,12 @@ fn verify_block_2(b: &mut Bencher) {
 
     let token = Biscuit::from(&data, &root.public()).unwrap();
     let mut verifier = AuthorizerBuilder::new()
-        .token(&token)
         .fact("resource(\"file1\")")
         .unwrap()
         .fact("operation(\"read\")")
         .unwrap()
         .allow_all()
-        .build()
+        .build(&token)
         .unwrap();
     verifier
         .authorize_with_limits(AuthorizerLimits {
@@ -281,13 +280,12 @@ fn verify_block_2(b: &mut Bencher) {
     b.iter(|| {
         let token = Biscuit::from(&data, &root.public()).unwrap();
         let mut verifier = AuthorizerBuilder::new()
-            .token(&token)
             .fact("resource(\"file1\")")
             .unwrap()
             .fact("operation(\"read\")")
             .unwrap()
             .allow_all()
-            .build()
+            .build(&token)
             .unwrap();
         verifier
             .authorize_with_limits(AuthorizerLimits {
@@ -352,13 +350,12 @@ fn verify_block_5(b: &mut Bencher) {
 
     let token = Biscuit::from(&data, &root.public()).unwrap();
     let mut verifier = AuthorizerBuilder::new()
-        .token(&token)
         .fact("resource(\"file1\")")
         .unwrap()
         .fact("operation(\"read\")")
         .unwrap()
         .allow_all()
-        .build()
+        .build(&token)
         .unwrap();
     verifier
         .authorize_with_limits(AuthorizerLimits {
@@ -371,13 +368,12 @@ fn verify_block_5(b: &mut Bencher) {
     b.iter(|| {
         let token = Biscuit::from(&data, &root.public()).unwrap();
         let mut verifier = AuthorizerBuilder::new()
-            .token(&token)
             .fact("resource(\"file1\")")
             .unwrap()
             .fact("operation(\"read\")")
             .unwrap()
             .allow_all()
-            .build()
+            .build(&token)
             .unwrap();
         verifier
             .authorize_with_limits(AuthorizerLimits {
@@ -415,13 +411,12 @@ fn check_signature_2(b: &mut Bencher) {
 
     let token = Biscuit::from(&data, &root.public()).unwrap();
     let mut verifier = AuthorizerBuilder::new()
-        .token(&token)
         .fact("resource(\"file1\")")
         .unwrap()
         .fact("operation(\"read\")")
         .unwrap()
         .allow_all()
-        .build()
+        .build(&token)
         .unwrap();
     verifier
         .authorize_with_limits(AuthorizerLimits {
@@ -489,13 +484,12 @@ fn check_signature_5(b: &mut Bencher) {
 
     let token = Biscuit::from(&data, &root.public()).unwrap();
     let mut verifier = AuthorizerBuilder::new()
-        .token(&token)
         .fact("resource(\"file1\")")
         .unwrap()
         .fact("operation(\"read\")")
         .unwrap()
         .allow_all()
-        .build()
+        .build(&token)
         .unwrap();
     verifier
         .authorize_with_limits(AuthorizerLimits {
@@ -537,13 +531,12 @@ fn checks_block_2(b: &mut Bencher) {
 
     let token = Biscuit::from(&data, &root.public()).unwrap();
     let mut verifier = AuthorizerBuilder::new()
-        .token(&token)
         .fact("resource(\"file1\")")
         .unwrap()
         .fact("operation(\"read\")")
         .unwrap()
         .allow_all()
-        .build()
+        .build(&token)
         .unwrap();
     verifier
         .authorize_with_limits(AuthorizerLimits {
@@ -556,13 +549,12 @@ fn checks_block_2(b: &mut Bencher) {
     b.bytes = data.len() as u64;
     b.iter(|| {
         let mut verifier = AuthorizerBuilder::new()
-            .token(&token)
             .fact("resource(\"file1\")")
             .unwrap()
             .fact("operation(\"read\")")
             .unwrap()
             .allow_all()
-            .build()
+            .build(&token)
             .unwrap();
         verifier
             .authorize_with_limits(AuthorizerLimits {
@@ -600,13 +592,12 @@ fn checks_block_create_verifier2(b: &mut Bencher) {
 
     let token = Biscuit::from(&data, &root.public()).unwrap();
     let mut verifier = AuthorizerBuilder::new()
-        .token(&token)
         .fact("resource(\"file1\")")
         .unwrap()
         .fact("operation(\"read\")")
         .unwrap()
         .allow_all()
-        .build()
+        .build(&token)
         .unwrap();
     verifier
         .authorize_with_limits(AuthorizerLimits {
@@ -649,13 +640,12 @@ fn checks_block_verify_only2(b: &mut Bencher) {
 
     let token = Biscuit::from(&data, &root.public()).unwrap();
     let mut verifier = AuthorizerBuilder::new()
-        .token(&token)
         .fact("resource(\"file1\")")
         .unwrap()
         .fact("operation(\"read\")")
         .unwrap()
         .allow_all()
-        .build()
+        .build(&token)
         .unwrap();
     verifier
         .authorize_with_limits(AuthorizerLimits {
@@ -667,13 +657,12 @@ fn checks_block_verify_only2(b: &mut Bencher) {
     let token = Biscuit::from(&data, &root.public()).unwrap();
     b.iter(|| {
         let mut verifier = AuthorizerBuilder::new()
-            .token(&token)
             .fact("resource(\"file1\")")
             .unwrap()
             .fact("operation(\"read\")")
             .unwrap()
             .allow_all()
-            .build()
+            .build(&token)
             .unwrap();
         verifier
             .authorize_with_limits(AuthorizerLimits {

--- a/biscuit-auth/benches/token.rs
+++ b/biscuit-auth/benches/token.rs
@@ -262,12 +262,15 @@ fn verify_block_2(b: &mut Bencher) {
     };
 
     let token = Biscuit::from(&data, &root.public()).unwrap();
-    let mut builder = AuthorizerBuilder::new();
-    builder.add_token(&token);
-    builder.add_fact("resource(\"file1\")");
-    builder.add_fact("operation(\"read\")");
-    builder.add_allow_all();
-    let mut verifier = builder.build().unwrap();
+    let mut verifier = AuthorizerBuilder::new()
+        .add_token(&token)
+        .add_fact("resource(\"file1\")")
+        .unwrap()
+        .add_fact("operation(\"read\")")
+        .unwrap()
+        .add_allow_all()
+        .build()
+        .unwrap();
     verifier
         .authorize_with_limits(AuthorizerLimits {
             max_time: Duration::from_secs(10),
@@ -277,12 +280,15 @@ fn verify_block_2(b: &mut Bencher) {
     b.bytes = data.len() as u64;
     b.iter(|| {
         let token = Biscuit::from(&data, &root.public()).unwrap();
-        let mut builder = AuthorizerBuilder::new();
-        builder.add_token(&token);
-        builder.add_fact("resource(\"file1\")");
-        builder.add_fact("operation(\"read\")");
-        builder.add_allow_all();
-        let mut verifier = builder.build().unwrap();
+        let mut verifier = AuthorizerBuilder::new()
+            .add_token(&token)
+            .add_fact("resource(\"file1\")")
+            .unwrap()
+            .add_fact("operation(\"read\")")
+            .unwrap()
+            .add_allow_all()
+            .build()
+            .unwrap();
         verifier
             .authorize_with_limits(AuthorizerLimits {
                 max_time: Duration::from_secs(10),
@@ -345,12 +351,15 @@ fn verify_block_5(b: &mut Bencher) {
     };
 
     let token = Biscuit::from(&data, &root.public()).unwrap();
-    let mut builder = AuthorizerBuilder::new();
-    builder.add_token(&token);
-    builder.add_fact("resource(\"file1\")");
-    builder.add_fact("operation(\"read\")");
-    builder.add_allow_all();
-    let mut verifier = builder.build().unwrap();
+    let mut verifier = AuthorizerBuilder::new()
+        .add_token(&token)
+        .add_fact("resource(\"file1\")")
+        .unwrap()
+        .add_fact("operation(\"read\")")
+        .unwrap()
+        .add_allow_all()
+        .build()
+        .unwrap();
     verifier
         .authorize_with_limits(AuthorizerLimits {
             max_time: Duration::from_secs(10),
@@ -361,12 +370,15 @@ fn verify_block_5(b: &mut Bencher) {
     b.bytes = data.len() as u64;
     b.iter(|| {
         let token = Biscuit::from(&data, &root.public()).unwrap();
-        let mut builder = AuthorizerBuilder::new();
-        builder.add_token(&token);
-        builder.add_fact("resource(\"file1\")");
-        builder.add_fact("operation(\"read\")");
-        builder.add_allow_all();
-        let mut verifier = builder.build().unwrap();
+        let mut verifier = AuthorizerBuilder::new()
+            .add_token(&token)
+            .add_fact("resource(\"file1\")")
+            .unwrap()
+            .add_fact("operation(\"read\")")
+            .unwrap()
+            .add_allow_all()
+            .build()
+            .unwrap();
         verifier
             .authorize_with_limits(AuthorizerLimits {
                 max_time: Duration::from_secs(10),
@@ -402,12 +414,15 @@ fn check_signature_2(b: &mut Bencher) {
     };
 
     let token = Biscuit::from(&data, &root.public()).unwrap();
-    let mut builder = AuthorizerBuilder::new();
-    builder.add_token(&token);
-    builder.add_fact("resource(\"file1\")");
-    builder.add_fact("operation(\"read\")");
-    builder.add_allow_all();
-    let mut verifier = builder.build().unwrap();
+    let mut verifier = AuthorizerBuilder::new()
+        .add_token(&token)
+        .add_fact("resource(\"file1\")")
+        .unwrap()
+        .add_fact("operation(\"read\")")
+        .unwrap()
+        .add_allow_all()
+        .build()
+        .unwrap();
     verifier
         .authorize_with_limits(AuthorizerLimits {
             max_time: Duration::from_secs(10),
@@ -473,12 +488,15 @@ fn check_signature_5(b: &mut Bencher) {
     };
 
     let token = Biscuit::from(&data, &root.public()).unwrap();
-    let mut builder = AuthorizerBuilder::new();
-    builder.add_token(&token);
-    builder.add_fact("resource(\"file1\")");
-    builder.add_fact("operation(\"read\")");
-    builder.add_allow_all();
-    let mut verifier = builder.build().unwrap();
+    let mut verifier = AuthorizerBuilder::new()
+        .add_token(&token)
+        .add_fact("resource(\"file1\")")
+        .unwrap()
+        .add_fact("operation(\"read\")")
+        .unwrap()
+        .add_allow_all()
+        .build()
+        .unwrap();
     verifier
         .authorize_with_limits(AuthorizerLimits {
             max_time: Duration::from_secs(10),
@@ -518,12 +536,15 @@ fn checks_block_2(b: &mut Bencher) {
     };
 
     let token = Biscuit::from(&data, &root.public()).unwrap();
-    let mut builder = AuthorizerBuilder::new();
-    builder.add_token(&token);
-    builder.add_fact("resource(\"file1\")");
-    builder.add_fact("operation(\"read\")");
-    builder.add_allow_all();
-    let mut verifier = builder.build().unwrap();
+    let mut verifier = AuthorizerBuilder::new()
+        .add_token(&token)
+        .add_fact("resource(\"file1\")")
+        .unwrap()
+        .add_fact("operation(\"read\")")
+        .unwrap()
+        .add_allow_all()
+        .build()
+        .unwrap();
     verifier
         .authorize_with_limits(AuthorizerLimits {
             max_time: Duration::from_secs(10),
@@ -534,12 +555,15 @@ fn checks_block_2(b: &mut Bencher) {
     let token = Biscuit::from(&data, &root.public()).unwrap();
     b.bytes = data.len() as u64;
     b.iter(|| {
-        let mut builder = AuthorizerBuilder::new();
-        builder.add_token(&token);
-        builder.add_fact("resource(\"file1\")");
-        builder.add_fact("operation(\"read\")");
-        builder.add_allow_all();
-        let mut verifier = builder.build().unwrap();
+        let mut verifier = AuthorizerBuilder::new()
+            .add_token(&token)
+            .add_fact("resource(\"file1\")")
+            .unwrap()
+            .add_fact("operation(\"read\")")
+            .unwrap()
+            .add_allow_all()
+            .build()
+            .unwrap();
         verifier
             .authorize_with_limits(AuthorizerLimits {
                 max_time: Duration::from_secs(10),
@@ -575,12 +599,15 @@ fn checks_block_create_verifier2(b: &mut Bencher) {
     };
 
     let token = Biscuit::from(&data, &root.public()).unwrap();
-    let mut builder = AuthorizerBuilder::new();
-    builder.add_token(&token);
-    builder.add_fact("resource(\"file1\")");
-    builder.add_fact("operation(\"read\")");
-    builder.add_allow_all();
-    let mut verifier = builder.build().unwrap();
+    let mut verifier = AuthorizerBuilder::new()
+        .add_token(&token)
+        .add_fact("resource(\"file1\")")
+        .unwrap()
+        .add_fact("operation(\"read\")")
+        .unwrap()
+        .add_allow_all()
+        .build()
+        .unwrap();
     verifier
         .authorize_with_limits(AuthorizerLimits {
             max_time: Duration::from_secs(10),
@@ -621,12 +648,15 @@ fn checks_block_verify_only2(b: &mut Bencher) {
     };
 
     let token = Biscuit::from(&data, &root.public()).unwrap();
-    let mut builder = AuthorizerBuilder::new();
-    builder.add_token(&token);
-    builder.add_fact("resource(\"file1\")");
-    builder.add_fact("operation(\"read\")");
-    builder.add_allow_all();
-    let mut verifier = builder.build().unwrap();
+    let mut verifier = AuthorizerBuilder::new()
+        .add_token(&token)
+        .add_fact("resource(\"file1\")")
+        .unwrap()
+        .add_fact("operation(\"read\")")
+        .unwrap()
+        .add_allow_all()
+        .build()
+        .unwrap();
     verifier
         .authorize_with_limits(AuthorizerLimits {
             max_time: Duration::from_secs(10),
@@ -636,12 +666,15 @@ fn checks_block_verify_only2(b: &mut Bencher) {
 
     let token = Biscuit::from(&data, &root.public()).unwrap();
     b.iter(|| {
-        let mut builder = AuthorizerBuilder::new();
-        builder.add_token(&token);
-        builder.add_fact("resource(\"file1\")");
-        builder.add_fact("operation(\"read\")");
-        builder.add_allow_all();
-        let mut verifier = builder.build().unwrap();
+        let mut verifier = AuthorizerBuilder::new()
+            .add_token(&token)
+            .add_fact("resource(\"file1\")")
+            .unwrap()
+            .add_fact("operation(\"read\")")
+            .unwrap()
+            .add_allow_all()
+            .build()
+            .unwrap();
         verifier
             .authorize_with_limits(AuthorizerLimits {
                 max_time: Duration::from_secs(10),

--- a/biscuit-auth/benches/token.rs
+++ b/biscuit-auth/benches/token.rs
@@ -3,8 +3,10 @@ extern crate biscuit_auth as biscuit;
 use std::time::Duration;
 
 use biscuit::{
-    builder::*, builder_ext::BuilderExt, datalog::SymbolTable, AuthorizerLimits, Biscuit, KeyPair,
-    UnverifiedBiscuit,
+    builder::*,
+    builder_ext::{AuthorizerExt, BuilderExt},
+    datalog::SymbolTable,
+    AuthorizerLimits, Biscuit, KeyPair, UnverifiedBiscuit,
 };
 use codspeed_bencher_compat::{benchmark_group, benchmark_main, Bencher};
 use rand::rngs::OsRng;
@@ -244,7 +246,7 @@ fn verify_block_2(b: &mut Bencher) {
     let mut verifier = token.authorizer().unwrap();
     verifier.add_fact("resource(\"file1\")");
     verifier.add_fact("operation(\"read\")");
-    verifier.allow();
+    verifier.add_allow_all();
     verifier
         .authorize_with_limits(AuthorizerLimits {
             max_time: Duration::from_secs(10),
@@ -257,7 +259,7 @@ fn verify_block_2(b: &mut Bencher) {
         let mut verifier = token.authorizer().unwrap();
         verifier.add_fact("resource(\"file1\")");
         verifier.add_fact("operation(\"read\")");
-        verifier.allow();
+        verifier.add_allow_all();
         verifier
             .authorize_with_limits(AuthorizerLimits {
                 max_time: Duration::from_secs(10),
@@ -322,7 +324,7 @@ fn verify_block_5(b: &mut Bencher) {
     let mut verifier = token.authorizer().unwrap();
     verifier.add_fact("resource(\"file1\")");
     verifier.add_fact("operation(\"read\")");
-    verifier.allow();
+    verifier.add_allow_all();
     verifier
         .authorize_with_limits(AuthorizerLimits {
             max_time: Duration::from_secs(10),
@@ -336,7 +338,7 @@ fn verify_block_5(b: &mut Bencher) {
         let mut verifier = token.authorizer().unwrap();
         verifier.add_fact("resource(\"file1\")");
         verifier.add_fact("operation(\"read\")");
-        verifier.allow();
+        verifier.add_allow_all();
         verifier
             .authorize_with_limits(AuthorizerLimits {
                 max_time: Duration::from_secs(10),
@@ -374,7 +376,7 @@ fn check_signature_2(b: &mut Bencher) {
     let mut verifier = token.authorizer().unwrap();
     verifier.add_fact("resource(\"file1\")");
     verifier.add_fact("operation(\"read\")");
-    verifier.allow();
+    verifier.add_allow_all();
     verifier
         .authorize_with_limits(AuthorizerLimits {
             max_time: Duration::from_secs(10),
@@ -442,7 +444,7 @@ fn check_signature_5(b: &mut Bencher) {
     let mut verifier = token.authorizer().unwrap();
     verifier.add_fact("resource(\"file1\")");
     verifier.add_fact("operation(\"read\")");
-    verifier.allow();
+    verifier.add_allow_all();
     verifier
         .authorize_with_limits(AuthorizerLimits {
             max_time: Duration::from_secs(10),
@@ -484,7 +486,7 @@ fn checks_block_2(b: &mut Bencher) {
     let mut verifier = token.authorizer().unwrap();
     verifier.add_fact("resource(\"file1\")");
     verifier.add_fact("operation(\"read\")");
-    verifier.allow();
+    verifier.add_allow_all();
     verifier
         .authorize_with_limits(AuthorizerLimits {
             max_time: Duration::from_secs(10),
@@ -498,7 +500,7 @@ fn checks_block_2(b: &mut Bencher) {
         let mut verifier = token.authorizer().unwrap();
         verifier.add_fact("resource(\"file1\")");
         verifier.add_fact("operation(\"read\")");
-        verifier.allow();
+        verifier.add_allow_all();
         verifier
             .authorize_with_limits(AuthorizerLimits {
                 max_time: Duration::from_secs(10),
@@ -536,7 +538,7 @@ fn checks_block_create_verifier2(b: &mut Bencher) {
     let mut verifier = token.authorizer().unwrap();
     verifier.add_fact("resource(\"file1\")");
     verifier.add_fact("operation(\"read\")");
-    verifier.allow();
+    verifier.add_allow_all();
     verifier
         .authorize_with_limits(AuthorizerLimits {
             max_time: Duration::from_secs(10),
@@ -579,7 +581,7 @@ fn checks_block_verify_only2(b: &mut Bencher) {
     let mut verifier = token.authorizer().unwrap();
     verifier.add_fact("resource(\"file1\")");
     verifier.add_fact("operation(\"read\")");
-    verifier.allow();
+    verifier.add_allow_all();
     verifier
         .authorize_with_limits(AuthorizerLimits {
             max_time: Duration::from_secs(10),
@@ -592,7 +594,7 @@ fn checks_block_verify_only2(b: &mut Bencher) {
         let mut verifier = token.authorizer().unwrap();
         verifier.add_fact("resource(\"file1\")");
         verifier.add_fact("operation(\"read\")");
-        verifier.allow();
+        verifier.add_allow_all();
         verifier
             .authorize_with_limits(AuthorizerLimits {
                 max_time: Duration::from_secs(10),

--- a/biscuit-auth/examples/testcases.rs
+++ b/biscuit-auth/examples/testcases.rs
@@ -343,13 +343,13 @@ fn validate_token_with_limits_and_external_functions(
         revocation_ids.push(hex::encode(&bytes));
     }
 
-    let mut builder = AuthorizerBuilder::new();
-    builder.set_extern_funcs(extern_funcs);
-    builder.add_code(authorizer_code).unwrap();
+    let builder = AuthorizerBuilder::new()
+        .set_extern_funcs(extern_funcs)
+        .add_code(authorizer_code)
+        .unwrap();
     let authorizer_code = builder.dump_code();
-    builder.add_token(&token);
 
-    let mut authorizer = match builder.build() {
+    let mut authorizer = match builder.add_token(&token).build() {
         Ok(v) => v,
         Err(e) => {
             return Validation {

--- a/biscuit-auth/examples/testcases.rs
+++ b/biscuit-auth/examples/testcases.rs
@@ -345,11 +345,11 @@ fn validate_token_with_limits_and_external_functions(
 
     let builder = AuthorizerBuilder::new()
         .set_extern_funcs(extern_funcs)
-        .add_code(authorizer_code)
+        .code(authorizer_code)
         .unwrap();
     let authorizer_code = builder.dump_code();
 
-    let mut authorizer = match builder.add_token(&token).build() {
+    let mut authorizer = match builder.token(&token).build() {
         Ok(v) => v,
         Err(e) => {
             return Validation {
@@ -879,7 +879,7 @@ fn scoped_rules(target: &str, root: &KeyPair, test: bool) -> TestResult {
         .unwrap();
 
     let block3 = BlockBuilder::new()
-        .add_fact(r#"owner("alice", "file2")"#)
+        .fact(r#"owner("alice", "file2")"#)
         .unwrap();
 
     let keypair3 = KeyPair::new_with_rng(Algorithm::Ed25519, &mut rng);
@@ -1411,7 +1411,7 @@ fn unbound_variables_in_rule(target: &str, root: &KeyPair, test: bool) -> TestRe
 
     let block2 = BlockBuilder::new()
         // this one does not go through the parser because it checks for unused variables
-        .add_rule(rule(
+        .rule(rule(
             "operation",
             &[var("unbound"), string("read")],
             &[pred("operation", &[var("any1"), var("any2")])],

--- a/biscuit-auth/examples/testcases.rs
+++ b/biscuit-auth/examples/testcases.rs
@@ -349,7 +349,7 @@ fn validate_token_with_limits_and_external_functions(
         .unwrap();
     let authorizer_code = builder.dump_code();
 
-    let mut authorizer = match builder.token(&token).build() {
+    let mut authorizer = match builder.build(&token) {
         Ok(v) => v,
         Err(e) => {
             return Validation {

--- a/biscuit-auth/examples/third_party.rs
+++ b/biscuit-auth/examples/third_party.rs
@@ -13,7 +13,7 @@ fn main() {
     let external_pub = hex::encode(external.public().to_bytes());
 
     let biscuit1 = Biscuit::builder()
-        .add_check(
+        .check(
             format!("check if external_fact(\"hello\") trusting ed25519/{external_pub}").as_str(),
         )
         .unwrap()
@@ -26,7 +26,7 @@ fn main() {
 
     let req = biscuit_auth::ThirdPartyRequest::deserialize(&serialized_req).unwrap();
     let builder = BlockBuilder::new()
-        .add_fact("external_fact(\"hello\")")
+        .fact("external_fact(\"hello\")")
         .unwrap();
     let res = req.create_block(&external.private(), builder).unwrap();
 
@@ -35,8 +35,8 @@ fn main() {
     println!("biscuit2: {}", biscuit2);
 
     let mut authorizer = AuthorizerBuilder::new()
-        .add_token(&biscuit1)
-        .add_allow_all()
+        .token(&biscuit1)
+        .allow_all()
         .build()
         .unwrap();
 
@@ -44,8 +44,8 @@ fn main() {
     println!("world:\n{}", authorizer.print_world());
 
     let mut authorizer = AuthorizerBuilder::new()
-        .add_token(&biscuit2)
-        .add_allow_all()
+        .token(&biscuit2)
+        .allow_all()
         .build()
         .unwrap();
 

--- a/biscuit-auth/examples/third_party.rs
+++ b/biscuit-auth/examples/third_party.rs
@@ -34,18 +34,20 @@ fn main() {
 
     println!("biscuit2: {}", biscuit2);
 
-    let mut builder = AuthorizerBuilder::new();
-    builder.add_token(&biscuit1);
-    builder.add_allow_all();
-    let mut authorizer = builder.build().unwrap();
+    let mut authorizer = AuthorizerBuilder::new()
+        .add_token(&biscuit1)
+        .add_allow_all()
+        .build()
+        .unwrap();
 
     println!("authorize biscuit1:\n{:?}", authorizer.authorize());
     println!("world:\n{}", authorizer.print_world());
 
-    let mut builder = AuthorizerBuilder::new();
-    builder.add_token(&biscuit2);
-    builder.add_allow_all();
-    let mut authorizer = builder.build().unwrap();
+    let mut authorizer = AuthorizerBuilder::new()
+        .add_token(&biscuit2)
+        .add_allow_all()
+        .build()
+        .unwrap();
 
     println!("authorize biscuit2:\n{:?}", authorizer.authorize());
     println!("world:\n{}", authorizer.print_world());

--- a/biscuit-auth/examples/third_party.rs
+++ b/biscuit-auth/examples/third_party.rs
@@ -1,5 +1,8 @@
 use biscuit_auth::{
-    builder::Algorithm, builder::BlockBuilder, datalog::SymbolTable, Biscuit, KeyPair,
+    builder::{Algorithm, BlockBuilder},
+    builder_ext::AuthorizerExt,
+    datalog::SymbolTable,
+    Biscuit, KeyPair,
 };
 use rand::{prelude::StdRng, SeedableRng};
 
@@ -36,12 +39,12 @@ fn main() {
     println!("biscuit2: {}", biscuit2);
 
     let mut authorizer = biscuit1.authorizer().unwrap();
-    authorizer.allow().unwrap();
+    authorizer.add_allow_all();
     println!("authorize biscuit1:\n{:?}", authorizer.authorize());
     println!("world:\n{}", authorizer.print_world());
 
     let mut authorizer = biscuit2.authorizer().unwrap();
-    authorizer.allow().unwrap();
+    authorizer.add_allow_all();
     println!("authorize biscuit2:\n{:?}", authorizer.authorize());
     println!("world:\n{}", authorizer.print_world());
 }

--- a/biscuit-auth/examples/third_party.rs
+++ b/biscuit-auth/examples/third_party.rs
@@ -1,5 +1,5 @@
 use biscuit_auth::{
-    builder::{Algorithm, BlockBuilder},
+    builder::{Algorithm, AuthorizerBuilder, BlockBuilder},
     builder_ext::AuthorizerExt,
     datalog::SymbolTable,
     Biscuit, KeyPair,
@@ -38,13 +38,19 @@ fn main() {
 
     println!("biscuit2: {}", biscuit2);
 
-    let mut authorizer = biscuit1.authorizer().unwrap();
-    authorizer.add_allow_all();
+    let mut builder = AuthorizerBuilder::new();
+    builder.add_token(&biscuit1);
+    builder.add_allow_all();
+    let mut authorizer = builder.build().unwrap();
+
     println!("authorize biscuit1:\n{:?}", authorizer.authorize());
     println!("world:\n{}", authorizer.print_world());
 
-    let mut authorizer = biscuit2.authorizer().unwrap();
-    authorizer.add_allow_all();
+    let mut builder = AuthorizerBuilder::new();
+    builder.add_token(&biscuit2);
+    builder.add_allow_all();
+    let mut authorizer = builder.build().unwrap();
+
     println!("authorize biscuit2:\n{:?}", authorizer.authorize());
     println!("world:\n{}", authorizer.print_world());
 }

--- a/biscuit-auth/examples/third_party.rs
+++ b/biscuit-auth/examples/third_party.rs
@@ -35,18 +35,16 @@ fn main() {
     println!("biscuit2: {}", biscuit2);
 
     let mut authorizer = AuthorizerBuilder::new()
-        .token(&biscuit1)
         .allow_all()
-        .build()
+        .build(&biscuit1)
         .unwrap();
 
     println!("authorize biscuit1:\n{:?}", authorizer.authorize());
     println!("world:\n{}", authorizer.print_world());
 
     let mut authorizer = AuthorizerBuilder::new()
-        .token(&biscuit2)
         .allow_all()
-        .build()
+        .build(&biscuit2)
         .unwrap();
 
     println!("authorize biscuit2:\n{:?}", authorizer.authorize());

--- a/biscuit-auth/examples/verifying_printer.rs
+++ b/biscuit-auth/examples/verifying_printer.rs
@@ -26,8 +26,8 @@ fn main() {
     println!("token:\n{}", token);
 
     let mut authorizer = AuthorizerBuilder::new()
-        .add_token(&token)
-        .add_allow_all()
+        .token(&token)
+        .allow_all()
         .build()
         .unwrap();
 

--- a/biscuit-auth/examples/verifying_printer.rs
+++ b/biscuit-auth/examples/verifying_printer.rs
@@ -1,4 +1,4 @@
-use biscuit_auth::PublicKey;
+use biscuit_auth::{builder_ext::AuthorizerExt, PublicKey};
 
 fn main() {
     let mut args = std::env::args();
@@ -26,7 +26,7 @@ fn main() {
     println!("token:\n{}", token);
 
     let mut authorizer = token.authorizer().unwrap();
-    authorizer.allow().unwrap();
+    authorizer.add_allow_all();
 
     println!("authorizer result: {:?}", authorizer.authorize());
     println!("authorizer world:\n{}", authorizer.print_world());

--- a/biscuit-auth/examples/verifying_printer.rs
+++ b/biscuit-auth/examples/verifying_printer.rs
@@ -25,11 +25,7 @@ fn main() {
     }
     println!("token:\n{}", token);
 
-    let mut authorizer = AuthorizerBuilder::new()
-        .token(&token)
-        .allow_all()
-        .build()
-        .unwrap();
+    let mut authorizer = AuthorizerBuilder::new().allow_all().build(&token).unwrap();
 
     println!("authorizer result: {:?}", authorizer.authorize());
     println!("authorizer world:\n{}", authorizer.print_world());

--- a/biscuit-auth/examples/verifying_printer.rs
+++ b/biscuit-auth/examples/verifying_printer.rs
@@ -25,10 +25,11 @@ fn main() {
     }
     println!("token:\n{}", token);
 
-    let mut builder = AuthorizerBuilder::new();
-    builder.add_token(&token);
-    builder.add_allow_all();
-    let mut authorizer = builder.build().unwrap();
+    let mut authorizer = AuthorizerBuilder::new()
+        .add_token(&token)
+        .add_allow_all()
+        .build()
+        .unwrap();
 
     println!("authorizer result: {:?}", authorizer.authorize());
     println!("authorizer world:\n{}", authorizer.print_world());

--- a/biscuit-auth/examples/verifying_printer.rs
+++ b/biscuit-auth/examples/verifying_printer.rs
@@ -1,4 +1,4 @@
-use biscuit_auth::{builder_ext::AuthorizerExt, PublicKey};
+use biscuit_auth::{builder::AuthorizerBuilder, builder_ext::AuthorizerExt, PublicKey};
 
 fn main() {
     let mut args = std::env::args();
@@ -25,8 +25,10 @@ fn main() {
     }
     println!("token:\n{}", token);
 
-    let mut authorizer = token.authorizer().unwrap();
-    authorizer.add_allow_all();
+    let mut builder = AuthorizerBuilder::new();
+    builder.add_token(&token);
+    builder.add_allow_all();
+    let mut authorizer = builder.build().unwrap();
 
     println!("authorizer result: {:?}", authorizer.authorize());
     println!("authorizer world:\n{}", authorizer.print_world());

--- a/biscuit-auth/src/datalog/mod.rs
+++ b/biscuit-auth/src/datalog/mod.rs
@@ -783,7 +783,7 @@ impl FactSet {
     pub fn iterator<'a>(
         &'a self,
         block_ids: &'a TrustedOrigins,
-    ) -> impl Iterator<Item = (&Origin, &Fact)> + Clone {
+    ) -> impl Iterator<Item = (&'a Origin, &'a Fact)> + Clone {
         self.inner
             .iter()
             .filter_map(move |(ids, facts)| {

--- a/biscuit-auth/src/lib.rs
+++ b/biscuit-auth/src/lib.rs
@@ -88,7 +88,7 @@
 //!   // - one for /a/file1.txt and a write operation
 //!   // - one for /a/file2.txt and a read operation
 //!
-//!   let v1 = authorizer!(r#"
+//!   let mut v1 = authorizer!(r#"
 //!      resource("/a/file1.txt");
 //!      operation("read");
 //!      
@@ -101,26 +101,32 @@
 //!      // explicit catch-all deny. here it is not necessary: if no policy
 //!      // matches, a default deny applies
 //!      deny if true;
-//!   "#);
+//!   "#)
+//!   .add_token(&biscuit2)
+//!   .build()?;
 //!
 //!   let mut v2 = authorizer!(r#"
 //!      resource("/a/file1.txt");
 //!      operation("write");
 //!      allow if right("/a/file1.txt", "write");
-//!   "#);
-//!   
+//!   "#)
+//!   .add_token(&biscuit2)
+//!   .build()?;
+//!
 //!   let mut v3 = authorizer!(r#"
 //!      resource("/a/file2.txt");
 //!      operation("read");
 //!      allow if right("/a/file2.txt", "read");
-//!   "#);
+//!   "#)
+//!   .add_token(&biscuit2)
+//!   .build()?;
 //!
 //!   // the token restricts to read operations:
-//!   assert!(biscuit2.authorize(&v1).is_ok());
+//!   assert!(v1.authorize().is_ok());
 //!   // the second verifier requested a read operation
-//!   assert!(biscuit2.authorize(&v2).is_err());
+//!   assert!(v2.authorize().is_err());
 //!   // the third verifier requests /a/file2.txt
-//!   assert!(biscuit2.authorize(&v3).is_err());
+//!   assert!(v3.authorize().is_err());
 //!
 //!   Ok(())
 //! }

--- a/biscuit-auth/src/lib.rs
+++ b/biscuit-auth/src/lib.rs
@@ -102,7 +102,7 @@
 //!      // matches, a default deny applies
 //!      deny if true;
 //!   "#)
-//!   .add_token(&biscuit2)
+//!   .token(&biscuit2)
 //!   .build()?;
 //!
 //!   let mut v2 = authorizer!(r#"
@@ -110,7 +110,7 @@
 //!      operation("write");
 //!      allow if right("/a/file1.txt", "write");
 //!   "#)
-//!   .add_token(&biscuit2)
+//!   .token(&biscuit2)
 //!   .build()?;
 //!
 //!   let mut v3 = authorizer!(r#"
@@ -118,7 +118,7 @@
 //!      operation("read");
 //!      allow if right("/a/file2.txt", "read");
 //!   "#)
-//!   .add_token(&biscuit2)
+//!   .token(&biscuit2)
 //!   .build()?;
 //!
 //!   // the token restricts to read operations:

--- a/biscuit-auth/src/lib.rs
+++ b/biscuit-auth/src/lib.rs
@@ -102,24 +102,21 @@
 //!      // matches, a default deny applies
 //!      deny if true;
 //!   "#)
-//!   .token(&biscuit2)
-//!   .build()?;
+//!   .build(&biscuit2)?;
 //!
 //!   let mut v2 = authorizer!(r#"
 //!      resource("/a/file1.txt");
 //!      operation("write");
 //!      allow if right("/a/file1.txt", "write");
 //!   "#)
-//!   .token(&biscuit2)
-//!   .build()?;
+//!   .build(&biscuit2)?;
 //!
 //!   let mut v3 = authorizer!(r#"
 //!      resource("/a/file2.txt");
 //!      operation("read");
 //!      allow if right("/a/file2.txt", "read");
 //!   "#)
-//!   .token(&biscuit2)
-//!   .build()?;
+//!   .build(&biscuit2)?;
 //!
 //!   // the token restricts to read operations:
 //!   assert!(v1.authorize().is_ok());

--- a/biscuit-auth/src/macros.rs
+++ b/biscuit-auth/src/macros.rs
@@ -26,7 +26,7 @@
 //!   expiration = SystemTime::now() + Duration::from_secs(86_400),
 //! )).expect("Failed to append block");
 //!
-//! new_biscuit.authorize(&authorizer!(
+//! authorizer!(
 //!   r#"
 //!      time({now});
 //!      operation({operation});
@@ -42,7 +42,12 @@
 //!   operation = "read",
 //!   resource = "file1",
 //!   user_id = "1234",
-//! )).expect("Failed to authorize biscuit");
+//! )
+//!   .add_token(&new_biscuit)
+//!   .build()
+//!   .expect("failed to build the authorizer")
+//!   .authorize()
+//!   .expect("Failed to authorize biscuit");
 //! ```
 
 /// Create an `Authorizer` from a datalog string and optional parameters.
@@ -78,8 +83,8 @@ pub use biscuit_quote::authorizer;
 ///   now = SystemTime::now()
 /// );
 ///
-/// authorizer_merge!(
-///   &mut b,
+/// b = authorizer_merge!(
+///   b,
 ///   r#"
 ///     allow if true;
 ///   "#
@@ -128,8 +133,8 @@ pub use biscuit_quote::biscuit;
 ///   user_id = "1234"
 /// );
 ///
-/// biscuit_merge!(
-///   &mut b,
+/// b = biscuit_merge!(
+///   b,
 ///   r#"
 ///     check if time($time), $time < {expiration}
 ///   "#,
@@ -173,8 +178,8 @@ pub use biscuit_quote::block;
 ///   user_id = "1234"
 /// );
 ///
-/// block_merge!(
-///   &mut b,
+/// b = block_merge!(
+///   b,
 ///   r#"
 ///     check if user($id);
 ///   "#

--- a/biscuit-auth/src/macros.rs
+++ b/biscuit-auth/src/macros.rs
@@ -43,8 +43,7 @@
 //!   resource = "file1",
 //!   user_id = "1234",
 //! )
-//!   .token(&new_biscuit)
-//!   .build()
+//!   .build(&new_biscuit)
 //!   .expect("failed to build the authorizer")
 //!   .authorize()
 //!   .expect("Failed to authorize biscuit");

--- a/biscuit-auth/src/macros.rs
+++ b/biscuit-auth/src/macros.rs
@@ -43,7 +43,7 @@
 //!   resource = "file1",
 //!   user_id = "1234",
 //! )
-//!   .add_token(&new_biscuit)
+//!   .token(&new_biscuit)
 //!   .build()
 //!   .expect("failed to build the authorizer")
 //!   .authorize()

--- a/biscuit-auth/src/token/authorizer.rs
+++ b/biscuit-auth/src/token/authorizer.rs
@@ -623,6 +623,9 @@ impl Authorizer {
     pub fn dump_code(&self) -> String {
         let (facts, rules, checks, policies) = self.dump();
         let mut f = String::new();
+
+        let mut facts = facts.into_iter().map(|f| f.to_string()).collect::<Vec<_>>();
+        facts.sort();
         for fact in &facts {
             let _ = writeln!(f, "{fact};");
         }

--- a/biscuit-auth/src/token/authorizer.rs
+++ b/biscuit-auth/src/token/authorizer.rs
@@ -320,7 +320,6 @@ impl Authorizer {
         self.authorize_with_limits(limits)
     }
 
-    /// TODO: consume the input to prevent further direct use
     /// verifies the checks and policies
     ///
     /// on error, this can return a list of all the failed checks or deny policy
@@ -670,24 +669,6 @@ impl std::fmt::Display for Authorizer {
             all_facts.insert(origin, facts);
         }
 
-        let builder_facts = self
-            .authorizer_block_builder
-            .facts
-            .iter()
-            .map(|f| f.to_string())
-            .collect::<HashSet<_>>();
-        has_facts = has_facts || !builder_facts.is_empty();
-        let mut authorizer_origin = Origin::default();
-        authorizer_origin.insert(usize::MAX);
-        match all_facts.get_mut(&authorizer_origin) {
-            Some(e) => {
-                e.extend(builder_facts);
-            }
-            None => {
-                all_facts.insert(&authorizer_origin, builder_facts);
-            }
-        }
-
         if has_facts {
             writeln!(f, "// Facts:")?;
         }
@@ -720,19 +701,6 @@ impl std::fmt::Display for Authorizer {
                     .insert(self.symbols.print_rule(rule));
             }
         }
-
-        let builder_rules = self
-            .authorizer_block_builder
-            .rules
-            .iter()
-            .map(|rule| rule.to_string())
-            .collect::<HashSet<_>>();
-        has_rules = has_rules || !builder_rules.is_empty();
-
-        rules_map
-            .entry(usize::MAX)
-            .or_default()
-            .extend(builder_rules);
 
         if has_rules {
             writeln!(f, "// Rules:")?;

--- a/biscuit-auth/src/token/authorizer.rs
+++ b/biscuit-auth/src/token/authorizer.rs
@@ -165,7 +165,7 @@ impl Authorizer {
     fn query_inner<T: TryFrom<Fact, Error = E>, E: Into<error::Token>>(
         &mut self,
         rule: datalog::Rule,
-        limits: AuthorizerLimits,
+        _limits: AuthorizerLimits,
     ) -> Result<Vec<T>, error::Token> {
         let rule_trusted_origins = TrustedOrigins::from_scopes(
             &rule.scopes,
@@ -259,7 +259,7 @@ impl Authorizer {
     fn query_all_inner<T: TryFrom<Fact, Error = E>, E: Into<error::Token>>(
         &mut self,
         rule: datalog::Rule,
-        limits: AuthorizerLimits,
+        _limits: AuthorizerLimits,
     ) -> Result<Vec<T>, error::Token> {
         let rule_trusted_origins = if rule.scopes.is_empty() {
             self.token_origins.clone()
@@ -336,10 +336,9 @@ impl Authorizer {
         result
     }
 
-    fn authorize_inner(&mut self, mut limits: AuthorizerLimits) -> Result<usize, error::Token> {
+    fn authorize_inner(&mut self, limits: AuthorizerLimits) -> Result<usize, error::Token> {
         let start = Instant::now();
         let time_limit = start + limits.max_time;
-        let mut current_iterations = self.world.iterations;
 
         let mut errors = vec![];
         let mut policy_result: Option<Result<usize, usize>> = None;

--- a/biscuit-auth/src/token/authorizer.rs
+++ b/biscuit-auth/src/token/authorizer.rs
@@ -1,17 +1,11 @@
 //! Authorizer structure and associated functions
-use super::builder::{
-    constrained_rule, date, fact, pred, rule, string, var, AuthorizerBuilder, Binary, BlockBuilder,
-    Check, Expression, Fact, Op, Policy, PolicyKind, Rule, Scope, Term,
-};
-use super::builder_ext::{AuthorizerExt, BuilderExt};
+use super::builder::{AuthorizerBuilder, BlockBuilder, Check, Fact, Policy, PolicyKind, Rule};
 use super::{Biscuit, Block};
-use crate::builder::{self, CheckKind, Convert};
-use crate::crypto::PublicKey;
-use crate::datalog::{self, ExternFunc, Origin, RunLimits, SymbolTable, TrustedOrigins};
+use crate::builder::{CheckKind, Convert};
+use crate::datalog::{self, ExternFunc, Origin, RunLimits, TrustedOrigins};
 use crate::error;
 use crate::time::Instant;
 use crate::token;
-use biscuit_parser::parser::parse_source;
 use prost::Message;
 use std::collections::{BTreeMap, HashSet};
 use std::time::Duration;
@@ -20,7 +14,6 @@ use std::{
     convert::{TryFrom, TryInto},
     default::Default,
     fmt::Write,
-    time::SystemTime,
 };
 
 mod snapshot;
@@ -940,10 +933,11 @@ pub type AuthorizerLimits = RunLimits;
 mod tests {
     use std::time::Duration;
 
-    use builder::load_and_translate_block;
-    use datalog::World;
+    use datalog::{SymbolTable, World};
+    use token::builder::{self, load_and_translate_block, var};
     use token::{public_keys::PublicKeys, DATALOG_3_1};
 
+    use crate::PublicKey;
     use crate::{
         builder::{Algorithm, BiscuitBuilder, BlockBuilder},
         KeyPair,

--- a/biscuit-auth/src/token/authorizer.rs
+++ b/biscuit-auth/src/token/authorizer.rs
@@ -940,6 +940,8 @@ pub type AuthorizerLimits = RunLimits;
 mod tests {
     use std::time::Duration;
 
+    use builder::load_and_translate_block;
+    use datalog::World;
     use token::{public_keys::PublicKeys, DATALOG_3_1};
 
     use crate::{
@@ -1409,10 +1411,19 @@ allow if true;
             scopes: vec![],
         };
 
+        // FIXME
         assert_eq!(
-            authorizer
-                .load_and_translate_block(&mut block, 0, &syms)
-                .unwrap_err(),
+            /*builder
+            .load_and_translate_block(&mut block, 0, &syms)*/
+            load_and_translate_block(
+                &mut block,
+                0,
+                &syms,
+                &mut SymbolTable::new(),
+                &mut HashMap::new(),
+                &mut World::new(),
+            )
+            .unwrap_err(),
             error::Token::FailedLogic(error::Logic::InvalidBlockRule(
                 0,
                 "test($unbound) <- pred($any)".to_string()

--- a/biscuit-auth/src/token/authorizer.rs
+++ b/biscuit-auth/src/token/authorizer.rs
@@ -110,10 +110,11 @@ impl Authorizer {
     /// # use biscuit_auth::Biscuit;
     /// # use biscuit_auth::builder::Algorithm;
     /// let keypair = KeyPair::new(Algorithm::Ed25519);
-    /// let mut builder = Biscuit::builder();
-    /// builder.add_fact("user(\"John Doe\", 42)");
-    ///
-    /// let biscuit = builder.build(&keypair).unwrap();
+    /// let biscuit = Biscuit::builder()
+    ///     .add_fact("user(\"John Doe\", 42)")
+    ///     .expect("parse error")
+    ///     .build(&keypair)
+    ///     .unwrap();
     ///
     /// let mut authorizer = biscuit.authorizer().unwrap();
     /// let res: Vec<(String, i64)> = authorizer.query("data($name, $id) <- user($name, $id)").unwrap();
@@ -200,10 +201,11 @@ impl Authorizer {
     /// # use biscuit_auth::Biscuit;
     /// # use biscuit_auth::builder::Algorithm;
     /// let keypair = KeyPair::new(Algorithm::Ed25519,);
-    /// let mut builder = Biscuit::builder();
-    /// builder.add_fact("user(\"John Doe\", 42)");
-    ///
-    /// let biscuit = builder.build(&keypair).unwrap();
+    /// let biscuit = Biscuit::builder()
+    ///     .add_fact("user(\"John Doe\", 42)")
+    ///     .expect("parse error")
+    ///     .build(&keypair)
+    ///     .unwrap();
     ///
     /// let mut authorizer = biscuit.authorizer().unwrap();
     /// let res: Vec<(String, i64)> = authorizer.query_all("data($name, $id) <- user($name, $id)").unwrap();

--- a/biscuit-auth/src/token/authorizer.rs
+++ b/biscuit-auth/src/token/authorizer.rs
@@ -987,7 +987,7 @@ impl Authorizer {
             .map(|f| Fact::convert_from(f.1, &self.symbols))
             .collect::<Result<Vec<_>, error::Format>>()
             .unwrap();
-        facts.extend(self.authorizer_block_builder.facts.clone());
+        //facts.extend(self.authorizer_block_builder.facts.clone());
 
         let mut rules = self
             .world
@@ -996,7 +996,7 @@ impl Authorizer {
             .map(|r| Rule::convert_from(r.1, &self.symbols))
             .collect::<Result<Vec<_>, error::Format>>()
             .unwrap();
-        rules.extend(self.authorizer_block_builder.rules.clone());
+        //rules.extend(self.authorizer_block_builder.rules.clone());
 
         (facts, rules, checks, self.policies.clone())
     }

--- a/biscuit-auth/src/token/authorizer.rs
+++ b/biscuit-auth/src/token/authorizer.rs
@@ -622,17 +622,6 @@ impl Authorizer {
         Ok(())
     }
 
-    /// todo remove, it's covered in BuilderExt
-    /// adds a `allow if true` policy
-    pub fn allow(&mut self) -> Result<(), error::Token> {
-        self.add_policy("allow if true")
-    }
-
-    /// adds a `deny if true` policy
-    pub fn deny(&mut self) -> Result<(), error::Token> {
-        self.add_policy("deny if true")
-    }
-
     /// returns the elapsed execution time
     pub fn execution_time(&self) -> Duration {
         self.execution_time

--- a/biscuit-auth/src/token/authorizer.rs
+++ b/biscuit-auth/src/token/authorizer.rs
@@ -36,7 +36,7 @@ pub struct Authorizer {
 
 impl Authorizer {
     pub(crate) fn from_token(token: &Biscuit) -> Result<Self, error::Token> {
-        AuthorizerBuilder::new().token(token).build()
+        AuthorizerBuilder::new().build(token)
     }
 
     /// creates a new empty authorizer
@@ -872,7 +872,7 @@ mod tests {
         let mut authorizer = AuthorizerBuilder::new()
             .policy("allow if true")
             .unwrap()
-            .build()
+            .build_unauthenticated()
             .unwrap();
         assert_eq!(
             authorizer.authorize_with_limits(AuthorizerLimits {
@@ -911,7 +911,7 @@ mod tests {
                 scope_params,
             )
             .unwrap()
-            .build()
+            .build_unauthenticated()
             .unwrap();
     }
 
@@ -1092,12 +1092,11 @@ mod tests {
                 scope_params,
             )
             .unwrap()
-            .token(&biscuit2)
             .limits(AuthorizerLimits {
                 max_time: Duration::from_millis(10), //Set 10 milliseconds as the maximum time allowed for the authorization due to "cheap" worker on GitHub Actions
                 ..Default::default()
             })
-            .build()
+            .build(&biscuit2)
             .unwrap();
 
         println!("token:\n{}", biscuit2);
@@ -1229,7 +1228,6 @@ mod tests {
             .unwrap();
 
         let mut authorizer = AuthorizerBuilder::new()
-            .token(&token)
             .code(
                 r#"
           authorizer_fact(true);
@@ -1239,7 +1237,7 @@ mod tests {
         "#,
             )
             .unwrap()
-            .build()
+            .build(&token)
             .unwrap();
         let output_before_authorization = authorizer.to_string();
 
@@ -1345,7 +1343,7 @@ allow if true;
                 &[builder::pred("pred", &[builder::var("any")])],
             ))
             .unwrap()
-            .build()
+            .build_unauthenticated()
             .unwrap();
         let res: Vec<(String,)> = authorizer
             .query(builder::rule(

--- a/biscuit-auth/src/token/authorizer.rs
+++ b/biscuit-auth/src/token/authorizer.rs
@@ -30,15 +30,15 @@ mod snapshot;
 /// can be created from [Biscuit::authorizer] or [Authorizer::new]
 #[derive(Clone)]
 pub struct Authorizer {
-    authorizer_block_builder: BlockBuilder,
-    world: datalog::World,
+    pub(crate) authorizer_block_builder: BlockBuilder,
+    pub(crate) world: datalog::World,
     pub(crate) symbols: datalog::SymbolTable,
-    token_origins: TrustedOrigins,
-    policies: Vec<Policy>,
-    blocks: Option<Vec<Block>>,
-    public_key_to_block_id: HashMap<usize, Vec<usize>>,
-    limits: AuthorizerLimits,
-    execution_time: Duration,
+    pub(crate) token_origins: TrustedOrigins,
+    pub(crate) policies: Vec<Policy>,
+    pub(crate) blocks: Option<Vec<Block>>,
+    pub(crate) public_key_to_block_id: HashMap<usize, Vec<usize>>,
+    pub(crate) limits: AuthorizerLimits,
+    pub(crate) execution_time: Duration,
 }
 
 impl Authorizer {

--- a/biscuit-auth/src/token/authorizer/snapshot.rs
+++ b/biscuit-auth/src/token/authorizer/snapshot.rs
@@ -231,7 +231,7 @@ impl super::Authorizer {
     }
 }
 
-fn authorizer_origin_to_proto_origin(origin: &Origin) -> Vec<schema::Origin> {
+pub(crate) fn authorizer_origin_to_proto_origin(origin: &Origin) -> Vec<schema::Origin> {
     origin
         .inner
         .iter()
@@ -249,7 +249,9 @@ fn authorizer_origin_to_proto_origin(origin: &Origin) -> Vec<schema::Origin> {
         .collect()
 }
 
-fn proto_origin_to_authorizer_origin(origins: &[schema::Origin]) -> Result<Origin, error::Format> {
+pub(crate) fn proto_origin_to_authorizer_origin(
+    origins: &[schema::Origin],
+) -> Result<Origin, error::Format> {
     let mut new_origin = Origin::default();
 
     for origin in origins {

--- a/biscuit-auth/src/token/authorizer/snapshot.rs
+++ b/biscuit-auth/src/token/authorizer/snapshot.rs
@@ -2,7 +2,7 @@ use prost::Message;
 use std::{collections::HashMap, time::Duration};
 
 use crate::{
-    builder::{BlockBuilder, Convert, Policy},
+    builder::{load_and_translate_block, BlockBuilder, Convert, Policy},
     datalog::{Origin, RunLimits, TrustedOrigins},
     error,
     format::{
@@ -91,7 +91,14 @@ impl super::Authorizer {
                     .push(i);
             }
 
-            authorizer.load_and_translate_block(&mut block, i, &token_symbols)?;
+            load_and_translate_block(
+                &mut block,
+                i,
+                &token_symbols,
+                &mut authorizer.symbols,
+                &mut public_key_to_block_id,
+                &mut authorizer.world,
+            )?;
             blocks.push(block);
         }
 

--- a/biscuit-auth/src/token/builder.rs
+++ b/biscuit-auth/src/token/builder.rs
@@ -252,7 +252,7 @@ mod tests {
         let mut scope_params = HashMap::new();
         scope_params.insert("pk".to_string(), pubkey);
         builder = builder
-            .add_code_with_params(
+            .code_with_params(
                 r#"fact({p1}, "value");
              rule($head_var) <- f1($head_var), {p2} > 0 trusting {pk};
              check if {p3} trusting {pk};
@@ -276,7 +276,7 @@ check if true trusting ed25519/6e9e6d5a75cf0c0e87ec1256b4dfed0ca3ba452912d213fcc
 
         let mut fact = Fact::try_from("fact({p1}, {p4})").unwrap();
         fact.set("p1", "hello").unwrap();
-        let res = builder.clone().add_fact(fact);
+        let res = builder.clone().fact(fact);
         assert_eq!(
             res.unwrap_err(),
             error::Token::Language(biscuit_parser::error::LanguageError::Parameters {
@@ -289,7 +289,7 @@ check if true trusting ed25519/6e9e6d5a75cf0c0e87ec1256b4dfed0ca3ba452912d213fcc
         )
         .unwrap();
         rule.set("p2", "hello").unwrap();
-        let res = builder.clone().add_rule(rule);
+        let res = builder.clone().rule(rule);
         assert_eq!(
             res.unwrap_err(),
             error::Token::Language(biscuit_parser::error::LanguageError::Parameters {
@@ -299,7 +299,7 @@ check if true trusting ed25519/6e9e6d5a75cf0c0e87ec1256b4dfed0ca3ba452912d213fcc
         );
         let mut check = Check::try_from("check if {p4}, {p3}").unwrap();
         check.set("p3", true).unwrap();
-        let res = builder.clone().add_check(check);
+        let res = builder.clone().check(check);
         assert_eq!(
             res.unwrap_err(),
             error::Token::Language(biscuit_parser::error::LanguageError::Parameters {
@@ -316,7 +316,7 @@ check if true trusting ed25519/6e9e6d5a75cf0c0e87ec1256b4dfed0ca3ba452912d213fcc
         params.insert("p1".to_string(), "hello".into());
         params.insert("p2".to_string(), 1i64.into());
         params.insert("p4".to_string(), "this will be ignored".into());
-        let res = builder.add_code_with_params(
+        let res = builder.code_with_params(
             r#"fact({p1}, "value");
              rule($head_var) <- f1($head_var), {p2} > 0;
              check if {p3};

--- a/biscuit-auth/src/token/builder.rs
+++ b/biscuit-auth/src/token/builder.rs
@@ -16,6 +16,7 @@ pub use crate::datalog::{
 use crate::error;
 
 mod algorithm;
+mod authorizer;
 mod biscuit;
 mod block;
 mod check;
@@ -28,6 +29,7 @@ mod scope;
 mod term;
 
 pub use algorithm::*;
+pub use authorizer::*;
 pub use biscuit::*;
 pub use block::*;
 pub use check::*;

--- a/biscuit-auth/src/token/builder/authorizer.rs
+++ b/biscuit-auth/src/token/builder/authorizer.rs
@@ -380,7 +380,7 @@ impl<'a> AuthorizerBuilder<'a> {
 }
 
 /// we need to modify the block loaded from the token, because the authorizer's and the token's symbol table can differ
-fn load_and_translate_block(
+pub(crate) fn load_and_translate_block(
     block: &mut Block,
     i: usize,
     token_symbols: &SymbolTable,

--- a/biscuit-auth/src/token/builder/authorizer.rs
+++ b/biscuit-auth/src/token/builder/authorizer.rs
@@ -32,27 +32,27 @@ impl<'a> AuthorizerBuilder<'a> {
         AuthorizerBuilder::default()
     }
 
-    pub fn add_fact<F: TryInto<Fact>>(mut self, fact: F) -> Result<Self, error::Token>
+    pub fn fact<F: TryInto<Fact>>(mut self, fact: F) -> Result<Self, error::Token>
     where
         error::Token: From<<F as TryInto<Fact>>::Error>,
     {
-        self.authorizer_block_builder = self.authorizer_block_builder.add_fact(fact)?;
+        self.authorizer_block_builder = self.authorizer_block_builder.fact(fact)?;
         Ok(self)
     }
 
-    pub fn add_rule<R: TryInto<Rule>>(mut self, rule: R) -> Result<Self, error::Token>
+    pub fn rule<R: TryInto<Rule>>(mut self, rule: R) -> Result<Self, error::Token>
     where
         error::Token: From<<R as TryInto<Rule>>::Error>,
     {
-        self.authorizer_block_builder = self.authorizer_block_builder.add_rule(rule)?;
+        self.authorizer_block_builder = self.authorizer_block_builder.rule(rule)?;
         Ok(self)
     }
 
-    pub fn add_check<C: TryInto<Check>>(mut self, check: C) -> Result<Self, error::Token>
+    pub fn check<C: TryInto<Check>>(mut self, check: C) -> Result<Self, error::Token>
     where
         error::Token: From<<C as TryInto<Check>>::Error>,
     {
-        self.authorizer_block_builder = self.authorizer_block_builder.add_check(check)?;
+        self.authorizer_block_builder = self.authorizer_block_builder.check(check)?;
         Ok(self)
     }
 
@@ -64,7 +64,7 @@ impl<'a> AuthorizerBuilder<'a> {
     /// use biscuit::builder::AuthorizerBuilder;
     ///
     /// let mut authorizer = AuthorizerBuilder::new()
-    ///     .add_code(r#"
+    ///     .code(r#"
     ///       resource("/file1.txt");
     ///
     ///       check if user(1234);
@@ -75,13 +75,13 @@ impl<'a> AuthorizerBuilder<'a> {
     ///     .expect("should parse correctly")
     ///     .build();
     /// ```
-    pub fn add_code<T: AsRef<str>>(self, source: T) -> Result<Self, error::Token> {
-        self.add_code_with_params(source, HashMap::new(), HashMap::new())
+    pub fn code<T: AsRef<str>>(self, source: T) -> Result<Self, error::Token> {
+        self.code_with_params(source, HashMap::new(), HashMap::new())
     }
 
     /// Add datalog code to the builder, performing parameter subsitution as required
     /// Unknown parameters are ignored
-    pub fn add_code_with_params<T: AsRef<str>>(
+    pub fn code_with_params<T: AsRef<str>>(
         mut self,
         source: T,
         params: HashMap<String, Term>,
@@ -204,13 +204,13 @@ impl<'a> AuthorizerBuilder<'a> {
         Ok(self)
     }
 
-    pub fn add_scope(mut self, scope: Scope) -> Self {
-        self.authorizer_block_builder = self.authorizer_block_builder.add_scope(scope);
+    pub fn scope(mut self, scope: Scope) -> Self {
+        self.authorizer_block_builder = self.authorizer_block_builder.scope(scope);
         self
     }
 
     /// add a policy to the authorizer
-    pub fn add_policy<P: TryInto<Policy>>(mut self, policy: P) -> Result<Self, error::Token>
+    pub fn policy<P: TryInto<Policy>>(mut self, policy: P) -> Result<Self, error::Token>
     where
         error::Token: From<<P as TryInto<Policy>>::Error>,
     {
@@ -221,16 +221,16 @@ impl<'a> AuthorizerBuilder<'a> {
     }
 
     /// adds a fact with the current time
-    pub fn set_time(mut self) -> Self {
+    pub fn time(mut self) -> Self {
         let fact = fact("time", &[date(&SystemTime::now())]);
-        self.authorizer_block_builder = self.authorizer_block_builder.add_fact(fact).unwrap();
+        self.authorizer_block_builder = self.authorizer_block_builder.fact(fact).unwrap();
         self
     }
 
     /// Sets the runtime limits of the authorizer
     ///
     /// Those limits cover all the executions under the `authorize`, `query` and `query_all` methods
-    pub fn set_limits(mut self, limits: AuthorizerLimits) -> Self {
+    pub fn limits(mut self, limits: AuthorizerLimits) -> Self {
         self.limits = limits;
         self
     }
@@ -253,7 +253,7 @@ impl<'a> AuthorizerBuilder<'a> {
         self
     }
 
-    pub fn add_token(mut self, token: &'a Biscuit) -> Self {
+    pub fn token(mut self, token: &'a Biscuit) -> Self {
         self.token = Some(token);
         self
     }
@@ -451,16 +451,16 @@ pub(crate) fn load_and_translate_block(
 }
 
 impl<'a> BuilderExt for AuthorizerBuilder<'a> {
-    fn add_resource(mut self, name: &str) -> Self {
-        self.authorizer_block_builder = self.authorizer_block_builder.add_resource(name);
+    fn resource(mut self, name: &str) -> Self {
+        self.authorizer_block_builder = self.authorizer_block_builder.resource(name);
         self
     }
     fn check_resource(mut self, name: &str) -> Self {
         self.authorizer_block_builder = self.authorizer_block_builder.check_resource(name);
         self
     }
-    fn add_operation(mut self, name: &str) -> Self {
-        self.authorizer_block_builder = self.authorizer_block_builder.add_operation(name);
+    fn operation(mut self, name: &str) -> Self {
+        self.authorizer_block_builder = self.authorizer_block_builder.operation(name);
         self
     }
     fn check_operation(mut self, name: &str) -> Self {
@@ -484,10 +484,10 @@ impl<'a> BuilderExt for AuthorizerBuilder<'a> {
 }
 
 impl<'a> AuthorizerExt for AuthorizerBuilder<'a> {
-    fn add_allow_all(self) -> Self {
-        self.add_policy("allow if true").unwrap()
+    fn allow_all(self) -> Self {
+        self.policy("allow if true").unwrap()
     }
-    fn add_deny_all(self) -> Self {
-        self.add_policy("deny if true").unwrap()
+    fn deny_all(self) -> Self {
+        self.policy("deny if true").unwrap()
     }
 }

--- a/biscuit-auth/src/token/builder/authorizer.rs
+++ b/biscuit-auth/src/token/builder/authorizer.rs
@@ -36,7 +36,7 @@ impl<'a> AuthorizerBuilder<'a> {
     where
         error::Token: From<<F as TryInto<Fact>>::Error>,
     {
-        self.authorizer_block_builder.add_fact(fact)?;
+        self.authorizer_block_builder = self.authorizer_block_builder.add_fact(fact)?;
         Ok(self)
     }
 
@@ -44,7 +44,7 @@ impl<'a> AuthorizerBuilder<'a> {
     where
         error::Token: From<<R as TryInto<Rule>>::Error>,
     {
-        self.authorizer_block_builder.add_rule(rule)?;
+        self.authorizer_block_builder = self.authorizer_block_builder.add_rule(rule)?;
         Ok(self)
     }
 
@@ -52,7 +52,7 @@ impl<'a> AuthorizerBuilder<'a> {
     where
         error::Token: From<<C as TryInto<Check>>::Error>,
     {
-        self.authorizer_block_builder.add_check(check)?;
+        self.authorizer_block_builder = self.authorizer_block_builder.add_check(check)?;
         Ok(self)
     }
 
@@ -74,7 +74,7 @@ impl<'a> AuthorizerBuilder<'a> {
     ///   allow if true;
     /// "#).expect("should parse correctly");
     /// ```
-    pub fn add_code<T: AsRef<str>>(mut self, source: T) -> Result<Self, error::Token> {
+    pub fn add_code<T: AsRef<str>>(self, source: T) -> Result<Self, error::Token> {
         self.add_code_with_params(source, HashMap::new(), HashMap::new())
     }
 
@@ -204,7 +204,7 @@ impl<'a> AuthorizerBuilder<'a> {
     }
 
     pub fn add_scope(mut self, scope: Scope) -> Self {
-        self.authorizer_block_builder.add_scope(scope);
+        self.authorizer_block_builder = self.authorizer_block_builder.add_scope(scope);
         self
     }
 
@@ -222,7 +222,7 @@ impl<'a> AuthorizerBuilder<'a> {
     /// adds a fact with the current time
     pub fn set_time(mut self) -> Self {
         let fact = fact("time", &[date(&SystemTime::now())]);
-        self.authorizer_block_builder.add_fact(fact).unwrap();
+        self.authorizer_block_builder = self.authorizer_block_builder.add_fact(fact).unwrap();
         self
     }
 
@@ -450,36 +450,43 @@ pub(crate) fn load_and_translate_block(
 }
 
 impl<'a> BuilderExt for AuthorizerBuilder<'a> {
-    fn add_resource(&mut self, name: &str) {
-        self.authorizer_block_builder.add_resource(name);
+    fn add_resource(mut self, name: &str) -> Self {
+        self.authorizer_block_builder = self.authorizer_block_builder.add_resource(name);
+        self
     }
-    fn check_resource(&mut self, name: &str) {
-        self.authorizer_block_builder.check_resource(name);
+    fn check_resource(mut self, name: &str) -> Self {
+        self.authorizer_block_builder = self.authorizer_block_builder.check_resource(name);
+        self
     }
-    fn add_operation(&mut self, name: &str) {
-        self.authorizer_block_builder.add_operation(name);
+    fn add_operation(mut self, name: &str) -> Self {
+        self.authorizer_block_builder = self.authorizer_block_builder.add_operation(name);
+        self
     }
-    fn check_operation(&mut self, name: &str) {
-        self.authorizer_block_builder.check_operation(name);
+    fn check_operation(mut self, name: &str) -> Self {
+        self.authorizer_block_builder = self.authorizer_block_builder.check_operation(name);
+        self
     }
-    fn check_resource_prefix(&mut self, prefix: &str) {
-        self.authorizer_block_builder.check_resource_prefix(prefix);
+    fn check_resource_prefix(mut self, prefix: &str) -> Self {
+        self.authorizer_block_builder = self.authorizer_block_builder.check_resource_prefix(prefix);
+        self
     }
 
-    fn check_resource_suffix(&mut self, suffix: &str) {
-        self.authorizer_block_builder.check_resource_suffix(suffix);
+    fn check_resource_suffix(mut self, suffix: &str) -> Self {
+        self.authorizer_block_builder = self.authorizer_block_builder.check_resource_suffix(suffix);
+        self
     }
 
-    fn check_expiration_date(&mut self, exp: SystemTime) {
-        self.authorizer_block_builder.check_expiration_date(exp);
+    fn check_expiration_date(mut self, exp: SystemTime) -> Self {
+        self.authorizer_block_builder = self.authorizer_block_builder.check_expiration_date(exp);
+        self
     }
 }
 
 impl<'a> AuthorizerExt for AuthorizerBuilder<'a> {
-    fn add_allow_all(&mut self) {
-        self.add_policy("allow if true").unwrap();
+    fn add_allow_all(self) -> Self {
+        self.add_policy("allow if true").unwrap()
     }
-    fn add_deny_all(&mut self) {
-        self.add_policy("deny if true").unwrap();
+    fn add_deny_all(self) -> Self {
+        self.add_policy("deny if true").unwrap()
     }
 }

--- a/biscuit-auth/src/token/builder/authorizer.rs
+++ b/biscuit-auth/src/token/builder/authorizer.rs
@@ -61,18 +61,19 @@ impl<'a> AuthorizerBuilder<'a> {
     /// ```rust
     /// extern crate biscuit_auth as biscuit;
     ///
-    /// use biscuit::Authorizer;
+    /// use biscuit::builder::AuthorizerBuilder;
     ///
-    /// let mut authorizer = Authorizer::new();
+    /// let mut authorizer = AuthorizerBuilder::new()
+    ///     .add_code(r#"
+    ///       resource("/file1.txt");
     ///
-    /// authorizer.add_code(r#"
-    ///   resource("/file1.txt");
+    ///       check if user(1234);
     ///
-    ///   check if user(1234);
-    ///
-    ///   // default allow
-    ///   allow if true;
-    /// "#).expect("should parse correctly");
+    ///       // default allow
+    ///       allow if true;
+    ///     "#)
+    ///     .expect("should parse correctly")
+    ///     .build();
     /// ```
     pub fn add_code<T: AsRef<str>>(self, source: T) -> Result<Self, error::Token> {
         self.add_code_with_params(source, HashMap::new(), HashMap::new())

--- a/biscuit-auth/src/token/builder/authorizer.rs
+++ b/biscuit-auth/src/token/builder/authorizer.rs
@@ -53,6 +53,24 @@ impl<'a> AuthorizerBuilder<'a> {
         self.authorizer_block_builder.add_check(check)
     }
 
+    /// adds some datalog code to the authorizer
+    ///
+    /// ```rust
+    /// extern crate biscuit_auth as biscuit;
+    ///
+    /// use biscuit::Authorizer;
+    ///
+    /// let mut authorizer = Authorizer::new();
+    ///
+    /// authorizer.add_code(r#"
+    ///   resource("/file1.txt");
+    ///
+    ///   check if user(1234);
+    ///
+    ///   // default allow
+    ///   allow if true;
+    /// "#).expect("should parse correctly");
+    /// ```
     pub fn add_code<T: AsRef<str>>(&mut self, source: T) -> Result<(), error::Token> {
         self.add_code_with_params(source, HashMap::new(), HashMap::new())
     }

--- a/biscuit-auth/src/token/builder/authorizer.rs
+++ b/biscuit-auth/src/token/builder/authorizer.rs
@@ -430,7 +430,7 @@ pub(crate) fn load_and_translate_block(
         &block.scopes,
         &TrustedOrigins::default(),
         i,
-        &public_key_to_block_id,
+        public_key_to_block_id,
     );
 
     for fact in block.facts.iter_mut() {
@@ -448,7 +448,7 @@ pub(crate) fn load_and_translate_block(
             &rule.scopes,
             &block_trusted_origins,
             i,
-            &public_key_to_block_id,
+            public_key_to_block_id,
         );
 
         world.rules.insert(i, &rule_trusted_origins, rule.clone());

--- a/biscuit-auth/src/token/builder/authorizer.rs
+++ b/biscuit-auth/src/token/builder/authorizer.rs
@@ -1,0 +1,117 @@
+use std::{collections::HashMap, convert::TryInto, time::SystemTime};
+
+use crate::{
+    builder_ext::{AuthorizerExt, BuilderExt},
+    error, Authorizer, Biscuit, PublicKey,
+};
+
+use super::{BlockBuilder, Check, Fact, Policy, Rule, Scope, Term};
+
+#[derive(Clone, Debug, Default)]
+pub struct AuthorizerBuilder<'a> {
+    block: BlockBuilder,
+    policies: Vec<Policy>,
+    token: Option<&'a Biscuit>,
+}
+
+impl<'a> AuthorizerBuilder<'a> {
+    pub fn new() -> AuthorizerBuilder<'a> {
+        AuthorizerBuilder::default()
+    }
+
+    pub fn add_fact<F: TryInto<Fact>>(&mut self, fact: F) -> Result<(), error::Token>
+    where
+        error::Token: From<<F as TryInto<Fact>>::Error>,
+    {
+        self.block.add_fact(fact)
+    }
+
+    pub fn add_rule<R: TryInto<Rule>>(&mut self, rule: R) -> Result<(), error::Token>
+    where
+        error::Token: From<<R as TryInto<Rule>>::Error>,
+    {
+        self.block.add_rule(rule)
+    }
+
+    pub fn add_check<C: TryInto<Check>>(&mut self, check: C) -> Result<(), error::Token>
+    where
+        error::Token: From<<C as TryInto<Check>>::Error>,
+    {
+        self.block.add_check(check)
+    }
+
+    pub fn add_code<T: AsRef<str>>(&mut self, source: T) -> Result<(), error::Token> {
+        self.add_code_with_params(source, HashMap::new(), HashMap::new())
+    }
+
+    /// Add datalog code to the builder, performing parameter subsitution as required
+    /// Unknown parameters are ignored
+    pub fn add_code_with_params<T: AsRef<str>>(
+        &mut self,
+        source: T,
+        params: HashMap<String, Term>,
+        scope_params: HashMap<String, PublicKey>,
+    ) -> Result<(), error::Token> {
+        self.block
+            .add_code_with_params(source, params, scope_params)
+    }
+
+    pub fn add_scope(&mut self, scope: Scope) {
+        self.block.add_scope(scope);
+    }
+
+    /// add a policy to the authorizer
+    pub fn add_policy<P: TryInto<Policy>>(&mut self, policy: P) -> Result<(), error::Token>
+    where
+        error::Token: From<<P as TryInto<Policy>>::Error>,
+    {
+        let policy = policy.try_into()?;
+        policy.validate_parameters()?;
+        self.policies.push(policy);
+        Ok(())
+    }
+
+    pub fn add_token(&mut self, token: &'a Biscuit) {
+        self.token = Some(token);
+    }
+
+    pub fn build(self) -> Result<Authorizer, error::Token> {
+        let authorizer = Authorizer::new();
+        Ok(authorizer)
+    }
+}
+
+impl<'a> BuilderExt for AuthorizerBuilder<'a> {
+    fn add_resource(&mut self, name: &str) {
+        self.block.add_resource(name);
+    }
+    fn check_resource(&mut self, name: &str) {
+        self.block.check_resource(name);
+    }
+    fn add_operation(&mut self, name: &str) {
+        self.block.add_operation(name);
+    }
+    fn check_operation(&mut self, name: &str) {
+        self.block.check_operation(name);
+    }
+    fn check_resource_prefix(&mut self, prefix: &str) {
+        self.block.check_resource_prefix(prefix);
+    }
+
+    fn check_resource_suffix(&mut self, suffix: &str) {
+        self.block.check_resource_suffix(suffix);
+    }
+
+    fn check_expiration_date(&mut self, exp: SystemTime) {
+        self.block.check_expiration_date(exp);
+    }
+}
+
+impl<'a> AuthorizerExt for AuthorizerBuilder<'a> {
+    fn add_allow_all(&mut self) {
+        self.add_policy("allow if true").unwrap();
+    }
+    fn add_deny_all(&mut self) {
+        self.add_policy("deny if true").unwrap();
+    }
+}

--- a/biscuit-auth/src/token/builder/authorizer.rs
+++ b/biscuit-auth/src/token/builder/authorizer.rs
@@ -1,16 +1,26 @@
-use std::{collections::HashMap, convert::TryInto, time::SystemTime};
+use std::{
+    collections::HashMap,
+    convert::TryInto,
+    time::{Instant, SystemTime},
+};
 
 use crate::{
+    builder::Convert,
     builder_ext::{AuthorizerExt, BuilderExt},
-    error, Authorizer, Biscuit, PublicKey,
+    datalog::{ExternFunc, Origin, SymbolTable, TrustedOrigins, World},
+    error,
+    token::{self, Block},
+    Authorizer, AuthorizerLimits, Biscuit, PublicKey,
 };
 
 use super::{BlockBuilder, Check, Fact, Policy, Rule, Scope, Term};
 
 #[derive(Clone, Debug, Default)]
 pub struct AuthorizerBuilder<'a> {
-    block: BlockBuilder,
+    authorizer_block_builder: BlockBuilder,
     policies: Vec<Policy>,
+    extern_funcs: HashMap<String, ExternFunc>,
+    limits: AuthorizerLimits,
     token: Option<&'a Biscuit>,
 }
 
@@ -23,21 +33,21 @@ impl<'a> AuthorizerBuilder<'a> {
     where
         error::Token: From<<F as TryInto<Fact>>::Error>,
     {
-        self.block.add_fact(fact)
+        self.authorizer_block_builder.add_fact(fact)
     }
 
     pub fn add_rule<R: TryInto<Rule>>(&mut self, rule: R) -> Result<(), error::Token>
     where
         error::Token: From<<R as TryInto<Rule>>::Error>,
     {
-        self.block.add_rule(rule)
+        self.authorizer_block_builder.add_rule(rule)
     }
 
     pub fn add_check<C: TryInto<Check>>(&mut self, check: C) -> Result<(), error::Token>
     where
         error::Token: From<<C as TryInto<Check>>::Error>,
     {
-        self.block.add_check(check)
+        self.authorizer_block_builder.add_check(check)
     }
 
     pub fn add_code<T: AsRef<str>>(&mut self, source: T) -> Result<(), error::Token> {
@@ -52,12 +62,12 @@ impl<'a> AuthorizerBuilder<'a> {
         params: HashMap<String, Term>,
         scope_params: HashMap<String, PublicKey>,
     ) -> Result<(), error::Token> {
-        self.block
+        self.authorizer_block_builder
             .add_code_with_params(source, params, scope_params)
     }
 
     pub fn add_scope(&mut self, scope: Scope) {
-        self.block.add_scope(scope);
+        self.authorizer_block_builder.add_scope(scope);
     }
 
     /// add a policy to the authorizer
@@ -71,39 +81,218 @@ impl<'a> AuthorizerBuilder<'a> {
         Ok(())
     }
 
+    /// Sets the runtime limits of the authorizer
+    ///
+    /// Those limits cover all the executions under the `authorize`, `query` and `query_all` methods
+    pub fn set_limits(&mut self, limits: AuthorizerLimits) {
+        self.limits = limits;
+    }
+
+    /// Replaces the registered external functions
+    pub fn set_extern_funcs(&mut self, extern_funcs: HashMap<String, ExternFunc>) {
+        self.extern_funcs = extern_funcs;
+    }
+
+    /// Registers the provided external functions (possibly replacing already registered functions)
+    pub fn register_extern_funcs(&mut self, extern_funcs: HashMap<String, ExternFunc>) {
+        self.extern_funcs.extend(extern_funcs);
+    }
+
+    /// Registers the provided external function (possibly replacing an already registered function)
+    pub fn register_extern_func(&mut self, name: String, func: ExternFunc) {
+        self.extern_funcs.insert(name, func);
+    }
+
     pub fn add_token(&mut self, token: &'a Biscuit) {
         self.token = Some(token);
     }
 
     pub fn build(self) -> Result<Authorizer, error::Token> {
-        let authorizer = Authorizer::new();
-        Ok(authorizer)
+        let mut world = World::new();
+        world.extern_funcs = self.extern_funcs;
+
+        let mut symbols = SymbolTable::new();
+        let mut public_key_to_block_id: HashMap<usize, Vec<usize>> = HashMap::new();
+        let mut token_origins = TrustedOrigins::default();
+        let mut blocks: Option<Vec<Block>> = None;
+
+        // load the token if present
+        if let Some(token) = self.token {
+            for (i, block) in token.container.blocks.iter().enumerate() {
+                if let Some(sig) = block.external_signature.as_ref() {
+                    let new_key_id = symbols.public_keys.insert(&sig.public_key);
+
+                    public_key_to_block_id
+                        .entry(new_key_id as usize)
+                        .or_default()
+                        .push(i + 1);
+                }
+            }
+
+            blocks = Some(
+                token
+                    .blocks()
+                    .enumerate()
+                    .map(|(i, block)| {
+                        block.and_then(|mut b| {
+                            load_and_translate_block(
+                                &mut b,
+                                i,
+                                &token.symbols,
+                                &mut symbols,
+                                &mut public_key_to_block_id,
+                                &mut world,
+                            )?;
+                            Ok(b)
+                        })
+                    })
+                    .collect::<Result<Vec<_>, _>>()?,
+            );
+
+            token_origins = TrustedOrigins::from_scopes(
+                &[token::Scope::Previous],
+                &TrustedOrigins::default(),
+                token.block_count(),
+                &public_key_to_block_id,
+            );
+        }
+        let mut authorizer_origin = Origin::default();
+        authorizer_origin.insert(usize::MAX);
+
+        let authorizer_scopes: Vec<token::Scope> = self
+            .authorizer_block_builder
+            .scopes
+            .clone()
+            .iter()
+            .map(|s| s.convert(&mut symbols))
+            .collect();
+
+        let authorizer_trusted_origins = TrustedOrigins::from_scopes(
+            &authorizer_scopes,
+            &TrustedOrigins::default(),
+            usize::MAX,
+            &public_key_to_block_id,
+        );
+        for fact in &self.authorizer_block_builder.facts {
+            world
+                .facts
+                .insert(&authorizer_origin, fact.convert(&mut symbols));
+        }
+
+        for rule in &self.authorizer_block_builder.rules {
+            let rule = rule.convert(&mut symbols);
+
+            let rule_trusted_origins = TrustedOrigins::from_scopes(
+                &rule.scopes,
+                &authorizer_trusted_origins,
+                usize::MAX,
+                &public_key_to_block_id,
+            );
+
+            world.rules.insert(usize::MAX, &rule_trusted_origins, rule);
+        }
+
+        let start = Instant::now();
+        world.run_with_limits(&symbols, self.limits.clone())?;
+        let execution_time = start.elapsed();
+
+        Ok(Authorizer {
+            authorizer_block_builder: self.authorizer_block_builder,
+            world,
+            symbols,
+            token_origins,
+            policies: self.policies,
+            blocks,
+            public_key_to_block_id,
+            limits: self.limits,
+            execution_time,
+        })
     }
+}
+
+/// we need to modify the block loaded from the token, because the authorizer's and the token's symbol table can differ
+fn load_and_translate_block(
+    block: &mut Block,
+    i: usize,
+    token_symbols: &SymbolTable,
+    authorizer_symbols: &mut SymbolTable,
+    public_key_to_block_id: &mut HashMap<usize, Vec<usize>>,
+    world: &mut World,
+) -> Result<(), error::Token> {
+    // if it is a 3rd party block, it should not affect the main symbol table
+    let block_symbols = if i == 0 || block.external_key.is_none() {
+        token_symbols.clone()
+    } else {
+        block.symbols.clone()
+    };
+
+    let mut block_origin = Origin::default();
+    block_origin.insert(i);
+
+    for scope in block.scopes.iter_mut() {
+        *scope = crate::token::builder::Scope::convert_from(scope, &block_symbols)
+            .map(|s| s.convert(authorizer_symbols))?;
+    }
+
+    let block_trusted_origins = TrustedOrigins::from_scopes(
+        &block.scopes,
+        &TrustedOrigins::default(),
+        i,
+        &public_key_to_block_id,
+    );
+
+    for fact in block.facts.iter_mut() {
+        *fact = Fact::convert_from(fact, &block_symbols)?.convert(authorizer_symbols);
+        world.facts.insert(&block_origin, fact.clone());
+    }
+
+    for rule in block.rules.iter_mut() {
+        if let Err(_message) = rule.validate_variables(&block_symbols) {
+            return Err(error::Logic::InvalidBlockRule(0, block_symbols.print_rule(rule)).into());
+        }
+        *rule = rule.translate(&block_symbols, authorizer_symbols)?;
+
+        let rule_trusted_origins = TrustedOrigins::from_scopes(
+            &rule.scopes,
+            &block_trusted_origins,
+            i,
+            &public_key_to_block_id,
+        );
+
+        world.rules.insert(i, &rule_trusted_origins, rule.clone());
+    }
+
+    for check in block.checks.iter_mut() {
+        let c = Check::convert_from(check, &block_symbols)?;
+        *check = c.convert(authorizer_symbols);
+    }
+
+    Ok(())
 }
 
 impl<'a> BuilderExt for AuthorizerBuilder<'a> {
     fn add_resource(&mut self, name: &str) {
-        self.block.add_resource(name);
+        self.authorizer_block_builder.add_resource(name);
     }
     fn check_resource(&mut self, name: &str) {
-        self.block.check_resource(name);
+        self.authorizer_block_builder.check_resource(name);
     }
     fn add_operation(&mut self, name: &str) {
-        self.block.add_operation(name);
+        self.authorizer_block_builder.add_operation(name);
     }
     fn check_operation(&mut self, name: &str) {
-        self.block.check_operation(name);
+        self.authorizer_block_builder.check_operation(name);
     }
     fn check_resource_prefix(&mut self, prefix: &str) {
-        self.block.check_resource_prefix(prefix);
+        self.authorizer_block_builder.check_resource_prefix(prefix);
     }
 
     fn check_resource_suffix(&mut self, suffix: &str) {
-        self.block.check_resource_suffix(suffix);
+        self.authorizer_block_builder.check_resource_suffix(suffix);
     }
 
     fn check_expiration_date(&mut self, exp: SystemTime) {
-        self.block.check_expiration_date(exp);
+        self.authorizer_block_builder.check_expiration_date(exp);
     }
 }
 

--- a/biscuit-auth/src/token/builder/authorizer.rs
+++ b/biscuit-auth/src/token/builder/authorizer.rs
@@ -80,7 +80,7 @@ impl AuthorizerBuilder {
     ///       allow if true;
     ///     "#)
     ///     .expect("should parse correctly")
-    ///     .build();
+    ///     .build_unauthenticated();
     /// ```
     pub fn code<T: AsRef<str>>(self, source: T) -> Result<Self, error::Token> {
         self.code_with_params(source, HashMap::new(), HashMap::new())

--- a/biscuit-auth/src/token/builder/biscuit.rs
+++ b/biscuit-auth/src/token/builder/biscuit.rs
@@ -30,70 +30,68 @@ impl BiscuitBuilder {
         self
     }
 
-    pub fn add_fact<F: TryInto<Fact>>(mut self, fact: F) -> Result<Self, error::Token>
+    pub fn fact<F: TryInto<Fact>>(mut self, fact: F) -> Result<Self, error::Token>
     where
         error::Token: From<<F as TryInto<Fact>>::Error>,
     {
-        self.inner = self.inner.add_fact(fact)?;
+        self.inner = self.inner.fact(fact)?;
         Ok(self)
     }
 
-    pub fn add_rule<Ru: TryInto<Rule>>(mut self, rule: Ru) -> Result<Self, error::Token>
+    pub fn rule<Ru: TryInto<Rule>>(mut self, rule: Ru) -> Result<Self, error::Token>
     where
         error::Token: From<<Ru as TryInto<Rule>>::Error>,
     {
-        self.inner = self.inner.add_rule(rule)?;
+        self.inner = self.inner.rule(rule)?;
         Ok(self)
     }
 
-    pub fn add_check<C: TryInto<Check>>(mut self, check: C) -> Result<Self, error::Token>
+    pub fn check<C: TryInto<Check>>(mut self, check: C) -> Result<Self, error::Token>
     where
         error::Token: From<<C as TryInto<Check>>::Error>,
     {
-        self.inner = self.inner.add_check(check)?;
+        self.inner = self.inner.check(check)?;
         Ok(self)
     }
 
-    pub fn add_code<T: AsRef<str>>(mut self, source: T) -> Result<Self, error::Token> {
+    pub fn code<T: AsRef<str>>(mut self, source: T) -> Result<Self, error::Token> {
         self.inner = self
             .inner
-            .add_code_with_params(source, HashMap::new(), HashMap::new())?;
+            .code_with_params(source, HashMap::new(), HashMap::new())?;
         Ok(self)
     }
 
-    pub fn add_code_with_params<T: AsRef<str>>(
+    pub fn code_with_params<T: AsRef<str>>(
         mut self,
         source: T,
         params: HashMap<String, Term>,
         scope_params: HashMap<String, PublicKey>,
     ) -> Result<Self, error::Token> {
-        self.inner = self
-            .inner
-            .add_code_with_params(source, params, scope_params)?;
+        self.inner = self.inner.code_with_params(source, params, scope_params)?;
         Ok(self)
     }
 
-    pub fn add_scope(mut self, scope: Scope) -> Self {
-        self.inner = self.inner.add_scope(scope);
+    pub fn scope(mut self, scope: Scope) -> Self {
+        self.inner = self.inner.scope(scope);
         self
     }
 
     #[cfg(test)]
-    pub(crate) fn add_right(self, resource: &str, right: &str) -> Self {
+    pub(crate) fn right(self, resource: &str, right: &str) -> Self {
         use crate::builder::fact;
 
         use super::string;
 
-        self.add_fact(fact("right", &[string(resource), string(right)]))
+        self.fact(fact("right", &[string(resource), string(right)]))
             .unwrap()
     }
 
-    pub fn set_context(mut self, context: String) -> Self {
-        self.inner = self.inner.set_context(context);
+    pub fn context(mut self, context: String) -> Self {
+        self.inner = self.inner.context(context);
         self
     }
 
-    pub fn set_root_key_id(mut self, root_key_id: u32) -> Self {
+    pub fn root_key_id(mut self, root_key_id: u32) -> Self {
         self.root_key_id = Some(root_key_id);
         self
     }
@@ -166,8 +164,8 @@ impl fmt::Display for BiscuitBuilder {
 }
 
 impl BuilderExt for BiscuitBuilder {
-    fn add_resource(mut self, name: &str) -> Self {
-        self.inner = self.inner.add_resource(name);
+    fn resource(mut self, name: &str) -> Self {
+        self.inner = self.inner.resource(name);
         self
     }
     fn check_resource(mut self, name: &str) -> Self {
@@ -182,8 +180,8 @@ impl BuilderExt for BiscuitBuilder {
         self.inner = self.inner.check_resource_suffix(suffix);
         self
     }
-    fn add_operation(mut self, name: &str) -> Self {
-        self.inner = self.inner.add_operation(name);
+    fn operation(mut self, name: &str) -> Self {
+        self.inner = self.inner.operation(name);
         self
     }
     fn check_operation(mut self, name: &str) -> Self {

--- a/biscuit-auth/src/token/builder/block.rs
+++ b/biscuit-auth/src/token/builder/block.rs
@@ -37,7 +37,7 @@ impl BlockBuilder {
         self
     }
 
-    pub fn add_fact<F: TryInto<Fact>>(mut self, fact: F) -> Result<Self, error::Token>
+    pub fn fact<F: TryInto<Fact>>(mut self, fact: F) -> Result<Self, error::Token>
     where
         error::Token: From<<F as TryInto<Fact>>::Error>,
     {
@@ -48,7 +48,7 @@ impl BlockBuilder {
         Ok(self)
     }
 
-    pub fn add_rule<R: TryInto<Rule>>(mut self, rule: R) -> Result<Self, error::Token>
+    pub fn rule<R: TryInto<Rule>>(mut self, rule: R) -> Result<Self, error::Token>
     where
         error::Token: From<<R as TryInto<Rule>>::Error>,
     {
@@ -58,7 +58,7 @@ impl BlockBuilder {
         Ok(self)
     }
 
-    pub fn add_check<C: TryInto<Check>>(mut self, check: C) -> Result<Self, error::Token>
+    pub fn check<C: TryInto<Check>>(mut self, check: C) -> Result<Self, error::Token>
     where
         error::Token: From<<C as TryInto<Check>>::Error>,
     {
@@ -68,13 +68,13 @@ impl BlockBuilder {
         Ok(self)
     }
 
-    pub fn add_code<T: AsRef<str>>(self, source: T) -> Result<Self, error::Token> {
-        self.add_code_with_params(source, HashMap::new(), HashMap::new())
+    pub fn code<T: AsRef<str>>(self, source: T) -> Result<Self, error::Token> {
+        self.code_with_params(source, HashMap::new(), HashMap::new())
     }
 
     /// Add datalog code to the builder, performing parameter subsitution as required
     /// Unknown parameters are ignored
-    pub fn add_code_with_params<T: AsRef<str>>(
+    pub fn code_with_params<T: AsRef<str>>(
         mut self,
         source: T,
         params: HashMap<String, Term>,
@@ -168,12 +168,12 @@ impl BlockBuilder {
         Ok(self)
     }
 
-    pub fn add_scope(mut self, scope: Scope) -> Self {
+    pub fn scope(mut self, scope: Scope) -> Self {
         self.scopes.push(scope);
         self
     }
 
-    pub fn set_context(mut self, context: String) -> Self {
+    pub fn context(mut self, context: String) -> Self {
         self.context = Some(context);
         self
     }
@@ -266,7 +266,7 @@ impl BlockBuilder {
             ],
         );
 
-        self.add_check(check)
+        self.check(check)
     }
 }
 
@@ -289,7 +289,7 @@ impl fmt::Display for BlockBuilder {
 }
 
 impl BuilderExt for BlockBuilder {
-    fn add_resource(mut self, name: &str) -> Self {
+    fn resource(mut self, name: &str) -> Self {
         self.facts.push(fact("resource", &[string(name)]));
         self
     }
@@ -304,7 +304,7 @@ impl BuilderExt for BlockBuilder {
         });
         self
     }
-    fn add_operation(mut self, name: &str) -> Self {
+    fn operation(mut self, name: &str) -> Self {
         self.facts.push(fact("operation", &[string(name)]));
         self
     }

--- a/biscuit-auth/src/token/builder/term.rs
+++ b/biscuit-auth/src/token/builder/term.rs
@@ -374,9 +374,9 @@ impl fmt::Display for Term {
                 let terms = m
                     .iter()
                     .map(|(key, term)| match key {
-                        MapKey::Integer(i) => format!("{i}: {}", term.to_string()),
-                        MapKey::Str(s) => format!("\"{s}\": {}", term.to_string()),
-                        MapKey::Parameter(s) => format!("{{{s}}}: {}", term.to_string()),
+                        MapKey::Integer(i) => format!("{i}: {}", term),
+                        MapKey::Str(s) => format!("\"{s}\": {}", term),
+                        MapKey::Parameter(s) => format!("{{{s}}}: {}", term),
                     })
                     .collect::<Vec<_>>();
                 write!(f, "{{{}}}", terms.join(", "))

--- a/biscuit-auth/src/token/builder_ext.rs
+++ b/biscuit-auth/src/token/builder_ext.rs
@@ -11,6 +11,6 @@ pub trait BuilderExt {
 }
 
 pub trait AuthorizerExt {
-    fn add_allow_all(&mut self);
-    fn add_deny_all(&mut self);
+    fn add_allow_all(self) -> Self;
+    fn add_deny_all(self) -> Self;
 }

--- a/biscuit-auth/src/token/builder_ext.rs
+++ b/biscuit-auth/src/token/builder_ext.rs
@@ -1,16 +1,16 @@
 use std::time::SystemTime;
 
 pub trait BuilderExt {
-    fn add_resource(self, name: &str) -> Self;
+    fn resource(self, name: &str) -> Self;
     fn check_resource(self, name: &str) -> Self;
     fn check_resource_prefix(self, prefix: &str) -> Self;
     fn check_resource_suffix(self, suffix: &str) -> Self;
-    fn add_operation(self, name: &str) -> Self;
+    fn operation(self, name: &str) -> Self;
     fn check_operation(self, name: &str) -> Self;
     fn check_expiration_date(self, date: SystemTime) -> Self;
 }
 
 pub trait AuthorizerExt {
-    fn add_allow_all(self) -> Self;
-    fn add_deny_all(self) -> Self;
+    fn allow_all(self) -> Self;
+    fn deny_all(self) -> Self;
 }

--- a/biscuit-auth/src/token/mod.rs
+++ b/biscuit-auth/src/token/mod.rs
@@ -847,7 +847,7 @@ mod tests {
         let final_token = Biscuit::from(&serialized3, root.public()).unwrap();
         println!("final token:\n{}", final_token);
         {
-            let mut builder = AuthorizerBuilder::new().token(&final_token);
+            let mut builder = AuthorizerBuilder::new();
 
             let mut facts = vec![
                 fact("resource", &[string("file1")]),
@@ -860,7 +860,7 @@ mod tests {
 
             //println!("final token: {:#?}", final_token);
 
-            let mut authorizer = builder.allow_all().build().unwrap();
+            let mut authorizer = builder.allow_all().build(&final_token).unwrap();
 
             let res = authorizer.authorize();
             println!("res1: {:?}", res);
@@ -868,7 +868,7 @@ mod tests {
         }
 
         {
-            let mut builder = AuthorizerBuilder::new().token(&final_token);
+            let mut builder = AuthorizerBuilder::new();
 
             let mut facts = vec![
                 fact("resource", &[string("file2")]),
@@ -880,7 +880,7 @@ mod tests {
             }
             builder = builder.allow_all();
 
-            let mut authorizer = builder.build().unwrap();
+            let mut authorizer = builder.build(&final_token).unwrap();
 
             let res = authorizer.authorize_with_limits(AuthorizerLimits {
                 max_time: Duration::from_secs(10),
@@ -924,13 +924,12 @@ mod tests {
 
         {
             let mut authorizer = AuthorizerBuilder::new()
-                .token(&biscuit2)
                 .fact("resource(\"/folder1/file1\")")
                 .unwrap()
                 .fact("operation(\"read\")")
                 .unwrap()
                 .allow_all()
-                .build()
+                .build(&biscuit2)
                 .unwrap();
 
             let res = authorizer.authorize_with_limits(AuthorizerLimits {
@@ -944,13 +943,12 @@ mod tests {
 
         {
             let mut authorizer = AuthorizerBuilder::new()
-                .token(&biscuit2)
                 .fact("resource(\"/folder2/file3\")")
                 .unwrap()
                 .fact("operation(\"read\")")
                 .unwrap()
                 .allow_all()
-                .build()
+                .build(&biscuit2)
                 .unwrap();
 
             let res = authorizer.authorize_with_limits(AuthorizerLimits {
@@ -975,12 +973,11 @@ mod tests {
 
         {
             let mut authorizer = AuthorizerBuilder::new()
-                .token(&biscuit2)
                 .fact("resource(\"/folder2/file1\")")
                 .unwrap()
                 .fact("operation(\"write\")")
                 .unwrap()
-                .build()
+                .build(&biscuit2)
                 .unwrap();
 
             let res = authorizer.authorize();
@@ -1017,14 +1014,13 @@ mod tests {
 
         {
             let mut authorizer = AuthorizerBuilder::new()
-                .token(&biscuit2)
                 .fact("resource(\"file1\")")
                 .unwrap()
                 .fact("operation(\"read\")")
                 .unwrap()
                 .time()
                 .allow_all()
-                .build()
+                .build(&biscuit2)
                 .unwrap();
 
             let res = authorizer.authorize_with_limits(AuthorizerLimits {
@@ -1038,14 +1034,13 @@ mod tests {
         {
             println!("biscuit2: {}", biscuit2);
             let mut authorizer = AuthorizerBuilder::new()
-                .token(&biscuit2)
                 .fact("resource(\"file1\")")
                 .unwrap()
                 .fact("operation(\"read\")")
                 .unwrap()
                 .time()
                 .allow_all()
-                .build()
+                .build(&biscuit2)
                 .unwrap();
 
             let res = authorizer.authorize_with_limits(AuthorizerLimits {
@@ -1087,13 +1082,12 @@ mod tests {
         //panic!();
         {
             let mut authorizer = AuthorizerBuilder::new()
-                .token(&biscuit2)
                 .fact("resource(\"/folder1/file1\")")
                 .unwrap()
                 .fact("operation(\"read\")")
                 .unwrap()
                 .allow_all()
-                .build()
+                .build(&biscuit2)
                 .unwrap();
 
             let res = authorizer.authorize_with_limits(AuthorizerLimits {
@@ -1114,13 +1108,12 @@ mod tests {
 
         {
             let mut authorizer = AuthorizerBuilder::new()
-                .token(&biscuit3)
                 .fact("resource(\"/folder1/file1\")")
                 .unwrap()
                 .fact("operation(\"read\")")
                 .unwrap()
                 .allow_all()
-                .build()
+                .build(&biscuit3)
                 .unwrap();
 
             let res = authorizer.authorize();
@@ -1148,14 +1141,13 @@ mod tests {
         println!("{}", biscuit1);
 
         let mut authorizer = AuthorizerBuilder::new()
-            .token(&biscuit1)
             .check(rule(
                 "right",
                 &[string("right")],
                 &[pred("right", &[string("file2"), string("write")])],
             ))
             .unwrap()
-            .build()
+            .build(&biscuit1)
             .unwrap();
 
         //assert!(v.verify().is_err());
@@ -1209,13 +1201,12 @@ mod tests {
             println!("biscuit3: {}", biscuit3);
 
             let mut authorizer = AuthorizerBuilder::new()
-                .token(&biscuit3)
                 .fact("resource(\"file1\")")
                 .unwrap()
                 .fact("operation(\"read\")")
                 .unwrap()
                 .time()
-                .build()
+                .build(&biscuit3)
                 .unwrap();
 
             // test that cloning correctly embeds the first block's facts
@@ -1295,13 +1286,12 @@ mod tests {
         //println!("generated biscuit token 2: {} bytes\n{}", serialized2.len(), serialized2.to_hex(16));
         {
             let mut authorizer = AuthorizerBuilder::new()
-                .token(&biscuit2)
                 .fact("resource(\"file1\")")
                 .unwrap()
                 .fact("operation(\"read\")")
                 .unwrap()
                 .time()
-                .build()
+                .build(&biscuit2)
                 .unwrap();
 
             println!("world:\n{}", authorizer.print_world());
@@ -1391,11 +1381,10 @@ mod tests {
         let biscuit2 = biscuit1.append_with_keypair(&keypair2, block2).unwrap();
 
         let mut authorizer = AuthorizerBuilder::new()
-            .token(&biscuit2)
             .check("check if bytes($0), { hex:00000000, hex:0102AB }.contains($0)")
             .unwrap()
             .allow_all()
-            .build()
+            .build(&biscuit2)
             .unwrap();
 
         let res = authorizer.authorize_with_limits(AuthorizerLimits {
@@ -1480,7 +1469,6 @@ mod tests {
         println!("final token:\n{}", final_token);
 
         let mut authorizer = AuthorizerBuilder::new()
-            .token(&final_token)
             .fact("resource(\"/folder2/file1\")")
             .unwrap()
             .fact("operation(\"write\")")
@@ -1488,7 +1476,7 @@ mod tests {
             .policy("allow if resource($file), operation($op), right($file, $op)")
             .unwrap()
             .deny_all()
-            .build()
+            .build(&final_token)
             .unwrap();
 
         let res = authorizer.authorize_with_limits(crate::token::authorizer::AuthorizerLimits {
@@ -1524,14 +1512,13 @@ mod tests {
 
         {
             let mut authorizer = AuthorizerBuilder::new()
-                .token(&biscuit1)
                 .fact("fact(0)")
                 .unwrap()
                 .fact("fact(1)")
                 .unwrap()
                 //println!("final token: {:#?}", final_token);
                 .allow_all()
-                .build()
+                .build(&biscuit1)
                 .unwrap();
 
             let res = authorizer.authorize_with_limits(AuthorizerLimits {
@@ -1544,14 +1531,13 @@ mod tests {
 
         {
             let mut authorizer = AuthorizerBuilder::new()
-                .token(&biscuit2)
                 .fact("fact(0)")
                 .unwrap()
                 .fact("fact(1)")
                 .unwrap()
                 //println!("final token: {:#?}", final_token);
                 .allow_all()
-                .build()
+                .build(&biscuit2)
                 .unwrap();
 
             let res = authorizer.authorize_with_limits(AuthorizerLimits {

--- a/biscuit-auth/src/token/mod.rs
+++ b/biscuit-auth/src/token/mod.rs
@@ -884,10 +884,9 @@ mod tests {
             for fact in facts.drain(..) {
                 builder.add_fact(fact).unwrap();
             }
+            builder.add_allow_all();
 
             let mut authorizer = builder.build().unwrap();
-
-            authorizer.add_allow_all();
 
             let res = authorizer.authorize_with_limits(AuthorizerLimits {
                 max_time: Duration::from_secs(10),

--- a/biscuit-auth/src/token/mod.rs
+++ b/biscuit-auth/src/token/mod.rs
@@ -846,8 +846,7 @@ mod tests {
         let final_token = Biscuit::from(&serialized3, root.public()).unwrap();
         println!("final token:\n{}", final_token);
         {
-            let mut builder = AuthorizerBuilder::new();
-            builder.add_token(&final_token);
+            let mut builder = AuthorizerBuilder::new().add_token(&final_token);
 
             let mut facts = vec![
                 fact("resource", &[string("file1")]),
@@ -855,13 +854,12 @@ mod tests {
             ];
 
             for fact in facts.drain(..) {
-                builder.add_fact(fact).unwrap();
+                builder = builder.add_fact(fact).unwrap();
             }
 
             //println!("final token: {:#?}", final_token);
-            builder.add_allow_all();
 
-            let mut authorizer = builder.build().unwrap();
+            let mut authorizer = builder.add_allow_all().build().unwrap();
 
             let res = authorizer.authorize();
             println!("res1: {:?}", res);
@@ -869,8 +867,7 @@ mod tests {
         }
 
         {
-            let mut builder = AuthorizerBuilder::new();
-            builder.add_token(&final_token);
+            let mut builder = AuthorizerBuilder::new().add_token(&final_token);
 
             let mut facts = vec![
                 fact("resource", &[string("file2")]),
@@ -878,9 +875,9 @@ mod tests {
             ];
 
             for fact in facts.drain(..) {
-                builder.add_fact(fact).unwrap();
+                builder = builder.add_fact(fact).unwrap();
             }
-            builder.add_allow_all();
+            builder = builder.add_allow_all();
 
             let mut authorizer = builder.build().unwrap();
 
@@ -925,13 +922,15 @@ mod tests {
         let biscuit2 = biscuit1.append_with_keypair(&keypair2, block2).unwrap();
 
         {
-            let mut builder = AuthorizerBuilder::new();
-            builder.add_token(&biscuit2);
-            builder.add_fact("resource(\"/folder1/file1\")").unwrap();
-            builder.add_fact("operation(\"read\")").unwrap();
-            builder.add_allow_all();
-
-            let mut authorizer = builder.build().unwrap();
+            let mut authorizer = AuthorizerBuilder::new()
+                .add_token(&biscuit2)
+                .add_fact("resource(\"/folder1/file1\")")
+                .unwrap()
+                .add_fact("operation(\"read\")")
+                .unwrap()
+                .add_allow_all()
+                .build()
+                .unwrap();
 
             let res = authorizer.authorize_with_limits(AuthorizerLimits {
                 max_time: Duration::from_secs(10),
@@ -943,13 +942,15 @@ mod tests {
         }
 
         {
-            let mut builder = AuthorizerBuilder::new();
-            builder.add_token(&biscuit2);
-            builder.add_fact("resource(\"/folder2/file3\")").unwrap();
-            builder.add_fact("operation(\"read\")").unwrap();
-            builder.add_allow_all();
-
-            let mut authorizer = builder.build().unwrap();
+            let mut authorizer = AuthorizerBuilder::new()
+                .add_token(&biscuit2)
+                .add_fact("resource(\"/folder2/file3\")")
+                .unwrap()
+                .add_fact("operation(\"read\")")
+                .unwrap()
+                .add_allow_all()
+                .build()
+                .unwrap();
 
             let res = authorizer.authorize_with_limits(AuthorizerLimits {
                 max_time: Duration::from_secs(10),
@@ -972,12 +973,14 @@ mod tests {
         }
 
         {
-            let mut builder = AuthorizerBuilder::new();
-            builder.add_token(&biscuit2);
-            builder.add_fact("resource(\"/folder2/file1\")").unwrap();
-            builder.add_fact("operation(\"write\")").unwrap();
-
-            let mut authorizer = builder.build().unwrap();
+            let mut authorizer = AuthorizerBuilder::new()
+                .add_token(&biscuit2)
+                .add_fact("resource(\"/folder2/file1\")")
+                .unwrap()
+                .add_fact("operation(\"write\")")
+                .unwrap()
+                .build()
+                .unwrap();
 
             let res = authorizer.authorize();
             println!("res3: {:?}", res);
@@ -1012,14 +1015,16 @@ mod tests {
         let biscuit2 = biscuit1.append_with_keypair(&keypair2, block2).unwrap();
 
         {
-            let mut builder = AuthorizerBuilder::new();
-            builder.add_token(&biscuit2);
-            builder.add_fact("resource(\"file1\")").unwrap();
-            builder.add_fact("operation(\"read\")").unwrap();
-            builder.set_time();
-            builder.add_allow_all();
-
-            let mut authorizer = builder.build().unwrap();
+            let mut authorizer = AuthorizerBuilder::new()
+                .add_token(&biscuit2)
+                .add_fact("resource(\"file1\")")
+                .unwrap()
+                .add_fact("operation(\"read\")")
+                .unwrap()
+                .set_time()
+                .add_allow_all()
+                .build()
+                .unwrap();
 
             let res = authorizer.authorize_with_limits(AuthorizerLimits {
                 max_time: Duration::from_secs(10),
@@ -1031,14 +1036,16 @@ mod tests {
 
         {
             println!("biscuit2: {}", biscuit2);
-            let mut builder = AuthorizerBuilder::new();
-            builder.add_token(&biscuit2);
-            builder.add_fact("resource(\"file1\")").unwrap();
-            builder.add_fact("operation(\"read\")").unwrap();
-            builder.set_time();
-            builder.add_allow_all();
-
-            let mut authorizer = builder.build().unwrap();
+            let mut authorizer = AuthorizerBuilder::new()
+                .add_token(&biscuit2)
+                .add_fact("resource(\"file1\")")
+                .unwrap()
+                .add_fact("operation(\"read\")")
+                .unwrap()
+                .set_time()
+                .add_allow_all()
+                .build()
+                .unwrap();
 
             let res = authorizer.authorize_with_limits(AuthorizerLimits {
                 max_time: Duration::from_secs(10),
@@ -1078,13 +1085,15 @@ mod tests {
         //println!("biscuit2:\n{:#?}", biscuit2);
         //panic!();
         {
-            let mut builder = AuthorizerBuilder::new();
-            builder.add_token(&biscuit2);
-            builder.add_fact("resource(\"/folder1/file1\")").unwrap();
-            builder.add_fact("operation(\"read\")").unwrap();
-            builder.add_allow_all();
-
-            let mut authorizer = builder.build().unwrap();
+            let mut authorizer = AuthorizerBuilder::new()
+                .add_token(&biscuit2)
+                .add_fact("resource(\"/folder1/file1\")")
+                .unwrap()
+                .add_fact("operation(\"read\")")
+                .unwrap()
+                .add_allow_all()
+                .build()
+                .unwrap();
 
             let res = authorizer.authorize_with_limits(AuthorizerLimits {
                 max_time: Duration::from_secs(10),
@@ -1103,13 +1112,15 @@ mod tests {
         let biscuit3 = Biscuit::from(sealed, root.public()).unwrap();
 
         {
-            let mut builder = AuthorizerBuilder::new();
-            builder.add_token(&biscuit3);
-            builder.add_fact("resource(\"/folder1/file1\")").unwrap();
-            builder.add_fact("operation(\"read\")").unwrap();
-            builder.add_allow_all();
-
-            let mut authorizer = builder.build().unwrap();
+            let mut authorizer = AuthorizerBuilder::new()
+                .add_token(&biscuit3)
+                .add_fact("resource(\"/folder1/file1\")")
+                .unwrap()
+                .add_fact("operation(\"read\")")
+                .unwrap()
+                .add_allow_all()
+                .build()
+                .unwrap();
 
             let res = authorizer.authorize();
             println!("res1: {:?}", res);
@@ -1135,17 +1146,16 @@ mod tests {
             .unwrap();
         println!("{}", biscuit1);
 
-        let mut builder = AuthorizerBuilder::new();
-        builder.add_token(&biscuit1);
-
-        builder
+        let mut authorizer = AuthorizerBuilder::new()
+            .add_token(&biscuit1)
             .add_check(rule(
                 "right",
                 &[string("right")],
                 &[pred("right", &[string("file2"), string("write")])],
             ))
+            .unwrap()
+            .build()
             .unwrap();
-        let mut authorizer = builder.build().unwrap();
 
         //assert!(v.verify().is_err());
         let res = authorizer.authorize_with_limits(AuthorizerLimits {
@@ -1197,12 +1207,15 @@ mod tests {
         {
             println!("biscuit3: {}", biscuit3);
 
-            let mut builder = AuthorizerBuilder::new();
-            builder.add_token(&biscuit3);
-            builder.add_fact("resource(\"file1\")").unwrap();
-            builder.add_fact("operation(\"read\")").unwrap();
-            builder.set_time();
-            let mut authorizer = builder.build().unwrap();
+            let mut authorizer = AuthorizerBuilder::new()
+                .add_token(&biscuit3)
+                .add_fact("resource(\"file1\")")
+                .unwrap()
+                .add_fact("operation(\"read\")")
+                .unwrap()
+                .set_time()
+                .build()
+                .unwrap();
 
             // test that cloning correctly embeds the first block's facts
             let mut other_authorizer = authorizer.clone();
@@ -1280,12 +1293,15 @@ mod tests {
 
         //println!("generated biscuit token 2: {} bytes\n{}", serialized2.len(), serialized2.to_hex(16));
         {
-            let mut builder = AuthorizerBuilder::new();
-            builder.add_token(&biscuit2);
-            builder.add_fact("resource(\"file1\")").unwrap();
-            builder.add_fact("operation(\"read\")").unwrap();
-            builder.set_time();
-            let mut authorizer = builder.build().unwrap();
+            let mut authorizer = AuthorizerBuilder::new()
+                .add_token(&biscuit2)
+                .add_fact("resource(\"file1\")")
+                .unwrap()
+                .add_fact("operation(\"read\")")
+                .unwrap()
+                .set_time()
+                .build()
+                .unwrap();
 
             println!("world:\n{}", authorizer.print_world());
             println!("symbols: {:?}", authorizer.symbols);
@@ -1373,13 +1389,13 @@ mod tests {
         let keypair2 = KeyPair::new_with_rng(builder::Algorithm::Ed25519, &mut rng);
         let biscuit2 = biscuit1.append_with_keypair(&keypair2, block2).unwrap();
 
-        let mut builder = AuthorizerBuilder::new();
-        builder.add_token(&biscuit2);
-        builder
+        let mut authorizer = AuthorizerBuilder::new()
+            .add_token(&biscuit2)
             .add_check("check if bytes($0), { hex:00000000, hex:0102AB }.contains($0)")
+            .unwrap()
+            .add_allow_all()
+            .build()
             .unwrap();
-        builder.add_allow_all();
-        let mut authorizer = builder.build().unwrap();
 
         let res = authorizer.authorize_with_limits(AuthorizerLimits {
             max_time: Duration::from_secs(10),
@@ -1462,15 +1478,17 @@ mod tests {
         let final_token = Biscuit::from(&serialized2, root.public()).unwrap();
         println!("final token:\n{}", final_token);
 
-        let mut builder = AuthorizerBuilder::new();
-        builder.add_token(&final_token);
-        builder.add_fact("resource(\"/folder2/file1\")").unwrap();
-        builder.add_fact("operation(\"write\")").unwrap();
-        builder
+        let mut authorizer = AuthorizerBuilder::new()
+            .add_token(&final_token)
+            .add_fact("resource(\"/folder2/file1\")")
+            .unwrap()
+            .add_fact("operation(\"write\")")
+            .unwrap()
             .add_policy("allow if resource($file), operation($op), right($file, $op)")
+            .unwrap()
+            .add_deny_all()
+            .build()
             .unwrap();
-        builder.add_deny_all();
-        let mut authorizer = builder.build().unwrap();
 
         let res = authorizer.authorize_with_limits(crate::token::authorizer::AuthorizerLimits {
             max_time: Duration::from_secs(1),
@@ -1504,15 +1522,16 @@ mod tests {
         println!("biscuit2 (authority): {}", biscuit2);
 
         {
-            let mut builder = AuthorizerBuilder::new();
-            builder.add_token(&biscuit1);
-            builder.add_fact("fact(0)").unwrap();
-            builder.add_fact("fact(1)").unwrap();
-
-            //println!("final token: {:#?}", final_token);
-            builder.add_allow_all();
-
-            let mut authorizer = builder.build().unwrap();
+            let mut authorizer = AuthorizerBuilder::new()
+                .add_token(&biscuit1)
+                .add_fact("fact(0)")
+                .unwrap()
+                .add_fact("fact(1)")
+                .unwrap()
+                //println!("final token: {:#?}", final_token);
+                .add_allow_all()
+                .build()
+                .unwrap();
 
             let res = authorizer.authorize_with_limits(AuthorizerLimits {
                 max_time: Duration::from_secs(10),
@@ -1523,15 +1542,16 @@ mod tests {
         }
 
         {
-            let mut builder = AuthorizerBuilder::new();
-            builder.add_token(&biscuit2);
-            builder.add_fact("fact(0)").unwrap();
-            builder.add_fact("fact(1)").unwrap();
-
-            //println!("final token: {:#?}", final_token);
-            builder.add_allow_all();
-
-            let mut authorizer = builder.build().unwrap();
+            let mut authorizer = AuthorizerBuilder::new()
+                .add_token(&biscuit2)
+                .add_fact("fact(0)")
+                .unwrap()
+                .add_fact("fact(1)")
+                .unwrap()
+                //println!("final token: {:#?}", final_token);
+                .add_allow_all()
+                .build()
+                .unwrap();
 
             let res = authorizer.authorize_with_limits(AuthorizerLimits {
                 max_time: Duration::from_secs(10),

--- a/biscuit-auth/src/token/mod.rs
+++ b/biscuit-auth/src/token/mod.rs
@@ -54,25 +54,26 @@ pub fn default_symbol_table() -> SymbolTable {
 ///
 /// use biscuit::{KeyPair, Biscuit, builder::*, builder_ext::*};
 ///
-/// fn main() {
+/// fn main() -> Result<(), biscuit::error::Token> {
 ///   let root = KeyPair::new(Algorithm::Ed25519);
 ///
 ///   // first we define the authority block for global data,
 ///   // like access rights
 ///   // data from the authority block cannot be created in any other block
-///   let mut builder = Biscuit::builder();
-///   builder.add_fact(fact("right", &[string("/a/file1.txt"), string("read")]));
+///   let token1 = Biscuit::builder()
+///       .add_fact(fact("right", &[string("/a/file1.txt"), string("read")]))?
 ///
-///   // facts and rules can also be parsed from a string
-///   builder.add_fact("right(\"/a/file1.txt\", \"read\")").expect("parse error");
-///
-///   let token1 = builder.build(&root).unwrap();
+///       // facts and rules can also be parsed from a string
+///       .add_fact("right(\"/a/file1.txt\", \"read\")")?
+///       .build(&root)?;
 ///
 ///   // we can create a new block builder from that token
-///   let mut builder2 = BlockBuilder::new();
-///   builder2.check_operation("read");
+///   let builder2 = BlockBuilder::new()
+///       .check_operation("read");
 ///
-///   let token2 = token1.append(builder2).unwrap();
+///   let token2 = token1.append(builder2)?;
+///
+///   Ok(())
 /// }
 /// ```
 #[derive(Clone, Debug)]

--- a/biscuit-auth/src/token/mod.rs
+++ b/biscuit-auth/src/token/mod.rs
@@ -61,10 +61,10 @@ pub fn default_symbol_table() -> SymbolTable {
 ///   // like access rights
 ///   // data from the authority block cannot be created in any other block
 ///   let token1 = Biscuit::builder()
-///       .add_fact(fact("right", &[string("/a/file1.txt"), string("read")]))?
+///       .fact(fact("right", &[string("/a/file1.txt"), string("read")]))?
 ///
 ///       // facts and rules can also be parsed from a string
-///       .add_fact("right(\"/a/file1.txt\", \"read\")")?
+///       .fact("right(\"/a/file1.txt\", \"read\")")?
 ///       .build(&root)?;
 ///
 ///   // we can create a new block builder from that token
@@ -744,11 +744,11 @@ mod tests {
 
         let serialized1 = {
             let biscuit1 = Biscuit::builder()
-                .add_fact("right(\"file1\", \"read\")")
+                .fact("right(\"file1\", \"read\")")
                 .unwrap()
-                .add_fact("right(\"file2\", \"read\")")
+                .fact("right(\"file2\", \"read\")")
                 .unwrap()
-                .add_fact("right(\"file1\", \"write\")")
+                .fact("right(\"file1\", \"write\")")
                 .unwrap()
                 .build_with_rng(&root, default_symbol_table(), &mut rng)
                 .unwrap();
@@ -796,7 +796,7 @@ mod tests {
 
             // new check: can only have read access1
             let block2 = BlockBuilder::new()
-                .add_check(rule(
+                .check(rule(
                     "check1",
                     &[var("resource")],
                     &[
@@ -825,7 +825,7 @@ mod tests {
 
             // new check: can only access file1
             let block3 = BlockBuilder::new()
-                .add_check(rule(
+                .check(rule(
                     "check2",
                     &[string("file1")],
                     &[pred("resource", &[string("file1")])],
@@ -847,7 +847,7 @@ mod tests {
         let final_token = Biscuit::from(&serialized3, root.public()).unwrap();
         println!("final token:\n{}", final_token);
         {
-            let mut builder = AuthorizerBuilder::new().add_token(&final_token);
+            let mut builder = AuthorizerBuilder::new().token(&final_token);
 
             let mut facts = vec![
                 fact("resource", &[string("file1")]),
@@ -855,12 +855,12 @@ mod tests {
             ];
 
             for fact in facts.drain(..) {
-                builder = builder.add_fact(fact).unwrap();
+                builder = builder.fact(fact).unwrap();
             }
 
             //println!("final token: {:#?}", final_token);
 
-            let mut authorizer = builder.add_allow_all().build().unwrap();
+            let mut authorizer = builder.allow_all().build().unwrap();
 
             let res = authorizer.authorize();
             println!("res1: {:?}", res);
@@ -868,7 +868,7 @@ mod tests {
         }
 
         {
-            let mut builder = AuthorizerBuilder::new().add_token(&final_token);
+            let mut builder = AuthorizerBuilder::new().token(&final_token);
 
             let mut facts = vec![
                 fact("resource", &[string("file2")]),
@@ -876,9 +876,9 @@ mod tests {
             ];
 
             for fact in facts.drain(..) {
-                builder = builder.add_fact(fact).unwrap();
+                builder = builder.fact(fact).unwrap();
             }
-            builder = builder.add_allow_all();
+            builder = builder.allow_all();
 
             let mut authorizer = builder.build().unwrap();
 
@@ -904,11 +904,11 @@ mod tests {
         let root = KeyPair::new_with_rng(builder::Algorithm::Ed25519, &mut rng);
 
         let biscuit1 = Biscuit::builder()
-            .add_right("/folder1/file1", "read")
-            .add_right("/folder1/file1", "write")
-            .add_right("/folder1/file2", "read")
-            .add_right("/folder1/file2", "write")
-            .add_right("/folder2/file3", "read")
+            .right("/folder1/file1", "read")
+            .right("/folder1/file1", "write")
+            .right("/folder1/file2", "read")
+            .right("/folder1/file2", "write")
+            .right("/folder2/file3", "read")
             .build_with_rng(&root, default_symbol_table(), &mut rng)
             .unwrap();
 
@@ -924,12 +924,12 @@ mod tests {
 
         {
             let mut authorizer = AuthorizerBuilder::new()
-                .add_token(&biscuit2)
-                .add_fact("resource(\"/folder1/file1\")")
+                .token(&biscuit2)
+                .fact("resource(\"/folder1/file1\")")
                 .unwrap()
-                .add_fact("operation(\"read\")")
+                .fact("operation(\"read\")")
                 .unwrap()
-                .add_allow_all()
+                .allow_all()
                 .build()
                 .unwrap();
 
@@ -944,12 +944,12 @@ mod tests {
 
         {
             let mut authorizer = AuthorizerBuilder::new()
-                .add_token(&biscuit2)
-                .add_fact("resource(\"/folder2/file3\")")
+                .token(&biscuit2)
+                .fact("resource(\"/folder2/file3\")")
                 .unwrap()
-                .add_fact("operation(\"read\")")
+                .fact("operation(\"read\")")
                 .unwrap()
-                .add_allow_all()
+                .allow_all()
                 .build()
                 .unwrap();
 
@@ -975,10 +975,10 @@ mod tests {
 
         {
             let mut authorizer = AuthorizerBuilder::new()
-                .add_token(&biscuit2)
-                .add_fact("resource(\"/folder2/file1\")")
+                .token(&biscuit2)
+                .fact("resource(\"/folder2/file1\")")
                 .unwrap()
-                .add_fact("operation(\"write\")")
+                .fact("operation(\"write\")")
                 .unwrap()
                 .build()
                 .unwrap();
@@ -1000,8 +1000,8 @@ mod tests {
         let root = KeyPair::new_with_rng(builder::Algorithm::Ed25519, &mut rng);
 
         let biscuit1 = Biscuit::builder()
-            .add_right("file1", "read")
-            .add_right("file2", "read")
+            .right("file1", "read")
+            .right("file2", "read")
             .build_with_rng(&root, default_symbol_table(), &mut rng)
             .unwrap();
 
@@ -1009,7 +1009,7 @@ mod tests {
 
         let block2 = BlockBuilder::new()
             .check_expiration_date(SystemTime::now() + Duration::from_secs(30))
-            .add_fact("key(1234)")
+            .fact("key(1234)")
             .unwrap();
 
         let keypair2 = KeyPair::new_with_rng(builder::Algorithm::Ed25519, &mut rng);
@@ -1017,13 +1017,13 @@ mod tests {
 
         {
             let mut authorizer = AuthorizerBuilder::new()
-                .add_token(&biscuit2)
-                .add_fact("resource(\"file1\")")
+                .token(&biscuit2)
+                .fact("resource(\"file1\")")
                 .unwrap()
-                .add_fact("operation(\"read\")")
+                .fact("operation(\"read\")")
                 .unwrap()
-                .set_time()
-                .add_allow_all()
+                .time()
+                .allow_all()
                 .build()
                 .unwrap();
 
@@ -1038,13 +1038,13 @@ mod tests {
         {
             println!("biscuit2: {}", biscuit2);
             let mut authorizer = AuthorizerBuilder::new()
-                .add_token(&biscuit2)
-                .add_fact("resource(\"file1\")")
+                .token(&biscuit2)
+                .fact("resource(\"file1\")")
                 .unwrap()
-                .add_fact("operation(\"read\")")
+                .fact("operation(\"read\")")
                 .unwrap()
-                .set_time()
-                .add_allow_all()
+                .time()
+                .allow_all()
                 .build()
                 .unwrap();
 
@@ -1065,11 +1065,11 @@ mod tests {
         let mut rng: StdRng = SeedableRng::seed_from_u64(0);
         let root = KeyPair::new_with_rng(builder::Algorithm::Ed25519, &mut rng);
         let biscuit1 = Biscuit::builder()
-            .add_right("/folder1/file1", "read")
-            .add_right("/folder1/file1", "write")
-            .add_right("/folder1/file2", "read")
-            .add_right("/folder1/file2", "write")
-            .add_right("/folder2/file3", "read")
+            .right("/folder1/file1", "read")
+            .right("/folder1/file1", "write")
+            .right("/folder1/file2", "read")
+            .right("/folder1/file2", "write")
+            .right("/folder2/file3", "read")
             .build_with_rng(&root, default_symbol_table(), &mut rng)
             .unwrap();
 
@@ -1087,12 +1087,12 @@ mod tests {
         //panic!();
         {
             let mut authorizer = AuthorizerBuilder::new()
-                .add_token(&biscuit2)
-                .add_fact("resource(\"/folder1/file1\")")
+                .token(&biscuit2)
+                .fact("resource(\"/folder1/file1\")")
                 .unwrap()
-                .add_fact("operation(\"read\")")
+                .fact("operation(\"read\")")
                 .unwrap()
-                .add_allow_all()
+                .allow_all()
                 .build()
                 .unwrap();
 
@@ -1114,12 +1114,12 @@ mod tests {
 
         {
             let mut authorizer = AuthorizerBuilder::new()
-                .add_token(&biscuit3)
-                .add_fact("resource(\"/folder1/file1\")")
+                .token(&biscuit3)
+                .fact("resource(\"/folder1/file1\")")
                 .unwrap()
-                .add_fact("operation(\"read\")")
+                .fact("operation(\"read\")")
                 .unwrap()
-                .add_allow_all()
+                .allow_all()
                 .build()
                 .unwrap();
 
@@ -1137,19 +1137,19 @@ mod tests {
         let root = KeyPair::new_with_rng(builder::Algorithm::Ed25519, &mut rng);
 
         let biscuit1 = Biscuit::builder()
-            .add_fact(fact("right", &[string("file1"), string("read")]))
+            .fact(fact("right", &[string("file1"), string("read")]))
             .unwrap()
-            .add_fact(fact("right", &[string("file2"), string("read")]))
+            .fact(fact("right", &[string("file2"), string("read")]))
             .unwrap()
-            .add_fact(fact("right", &[string("file1"), string("write")]))
+            .fact(fact("right", &[string("file1"), string("write")]))
             .unwrap()
             .build_with_rng(&root, default_symbol_table(), &mut rng)
             .unwrap();
         println!("{}", biscuit1);
 
         let mut authorizer = AuthorizerBuilder::new()
-            .add_token(&biscuit1)
-            .add_check(rule(
+            .token(&biscuit1)
+            .check(rule(
                 "right",
                 &[string("right")],
                 &[pred("right", &[string("file2"), string("write")])],
@@ -1181,9 +1181,9 @@ mod tests {
         let root = KeyPair::new_with_rng(builder::Algorithm::Ed25519, &mut rng);
 
         let biscuit1 = Biscuit::builder()
-            .add_right("file1", "read")
-            .add_right("file2", "read")
-            .add_fact("key(0000)")
+            .right("file1", "read")
+            .right("file2", "read")
+            .fact("key(0000)")
             .unwrap()
             .build_with_rng(&root, default_symbol_table(), &mut rng)
             .unwrap();
@@ -1192,7 +1192,7 @@ mod tests {
 
         let block2 = BlockBuilder::new()
             .check_expiration_date(SystemTime::now() + Duration::from_secs(30))
-            .add_fact("key(1234)")
+            .fact("key(1234)")
             .unwrap();
 
         let keypair2 = KeyPair::new_with_rng(builder::Algorithm::Ed25519, &mut rng);
@@ -1200,7 +1200,7 @@ mod tests {
 
         let block3 = BlockBuilder::new()
             .check_expiration_date(SystemTime::now() + Duration::from_secs(10))
-            .add_fact("key(5678)")
+            .fact("key(5678)")
             .unwrap();
 
         let keypair3 = KeyPair::new_with_rng(builder::Algorithm::Ed25519, &mut rng);
@@ -1209,12 +1209,12 @@ mod tests {
             println!("biscuit3: {}", biscuit3);
 
             let mut authorizer = AuthorizerBuilder::new()
-                .add_token(&biscuit3)
-                .add_fact("resource(\"file1\")")
+                .token(&biscuit3)
+                .fact("resource(\"file1\")")
                 .unwrap()
-                .add_fact("operation(\"read\")")
+                .fact("operation(\"read\")")
                 .unwrap()
-                .set_time()
+                .time()
                 .build()
                 .unwrap();
 
@@ -1272,7 +1272,7 @@ mod tests {
         let root = KeyPair::new_with_rng(builder::Algorithm::Ed25519, &mut rng);
 
         let biscuit1 = Biscuit::builder()
-            .add_check(check(
+            .check(check(
                 &[pred("resource", &[string("hello")])],
                 CheckKind::One,
             ))
@@ -1284,7 +1284,7 @@ mod tests {
 
         // new check: can only have read access1
         let block2 = BlockBuilder::new()
-            .add_fact(fact("check1", &[string("test")]))
+            .fact(fact("check1", &[string("test")]))
             .unwrap();
 
         let keypair2 = KeyPair::new_with_rng(builder::Algorithm::Ed25519, &mut rng);
@@ -1295,12 +1295,12 @@ mod tests {
         //println!("generated biscuit token 2: {} bytes\n{}", serialized2.len(), serialized2.to_hex(16));
         {
             let mut authorizer = AuthorizerBuilder::new()
-                .add_token(&biscuit2)
-                .add_fact("resource(\"file1\")")
+                .token(&biscuit2)
+                .fact("resource(\"file1\")")
                 .unwrap()
-                .add_fact("operation(\"read\")")
+                .fact("operation(\"read\")")
                 .unwrap()
-                .set_time()
+                .time()
                 .build()
                 .unwrap();
 
@@ -1377,7 +1377,7 @@ mod tests {
         let root = KeyPair::new_with_rng(builder::Algorithm::Ed25519, &mut rng);
 
         let biscuit1 = Biscuit::builder()
-            .add_fact("bytes(hex:0102AB)")
+            .fact("bytes(hex:0102AB)")
             .unwrap()
             .build_with_rng(&root, default_symbol_table(), &mut rng)
             .unwrap();
@@ -1385,16 +1385,16 @@ mod tests {
         println!("biscuit1 (authority): {}", biscuit1);
 
         let block2 = BlockBuilder::new()
-            .add_rule("has_bytes($0) <- bytes($0), { hex:00000000, hex:0102AB }.contains($0)")
+            .rule("has_bytes($0) <- bytes($0), { hex:00000000, hex:0102AB }.contains($0)")
             .unwrap();
         let keypair2 = KeyPair::new_with_rng(builder::Algorithm::Ed25519, &mut rng);
         let biscuit2 = biscuit1.append_with_keypair(&keypair2, block2).unwrap();
 
         let mut authorizer = AuthorizerBuilder::new()
-            .add_token(&biscuit2)
-            .add_check("check if bytes($0), { hex:00000000, hex:0102AB }.contains($0)")
+            .token(&biscuit2)
+            .check("check if bytes($0), { hex:00000000, hex:0102AB }.contains($0)")
             .unwrap()
-            .add_allow_all()
+            .allow_all()
             .build()
             .unwrap();
 
@@ -1425,13 +1425,13 @@ mod tests {
 
         let serialized1 = {
             let biscuit1 = Biscuit::builder()
-                .add_fact("right(\"/folder1/file1\", \"read\")")
+                .fact("right(\"/folder1/file1\", \"read\")")
                 .unwrap()
-                .add_fact("right(\"/folder1/file1\", \"write\")")
+                .fact("right(\"/folder1/file1\", \"write\")")
                 .unwrap()
-                .add_fact("right(\"/folder2/file1\", \"read\")")
+                .fact("right(\"/folder2/file1\", \"read\")")
                 .unwrap()
-                .add_check("check if operation(\"read\")")
+                .check("check if operation(\"read\")")
                 .unwrap()
                 .build_with_rng(&root, default_symbol_table(), &mut rng)
                 .unwrap();
@@ -1452,15 +1452,15 @@ mod tests {
             let  block2 = BlockBuilder::new()
 
             // Bypass `check if operation("read")` from authority block
-                .add_rule("operation(\"read\") <- operation($any)")
+                .rule("operation(\"read\") <- operation($any)")
                 .unwrap()
 
             // Bypass `check if resource($file), $file.starts_with("/folder1/")` from block #1
-                .add_rule("resource(\"/folder1/\") <- resource($any)")
+                .rule("resource(\"/folder1/\") <- resource($any)")
                 .unwrap()
 
             // Add missing rights
-          .add_rule("right($file, $right) <- right($any1, $any2), resource($file), operation($right)")
+          .rule("right($file, $right) <- right($any1, $any2), resource($file), operation($right)")
                 .unwrap();
 
             let keypair2 = KeyPair::new_with_rng(builder::Algorithm::Ed25519, &mut rng);
@@ -1480,14 +1480,14 @@ mod tests {
         println!("final token:\n{}", final_token);
 
         let mut authorizer = AuthorizerBuilder::new()
-            .add_token(&final_token)
-            .add_fact("resource(\"/folder2/file1\")")
+            .token(&final_token)
+            .fact("resource(\"/folder2/file1\")")
             .unwrap()
-            .add_fact("operation(\"write\")")
+            .fact("operation(\"write\")")
             .unwrap()
-            .add_policy("allow if resource($file), operation($op), right($file, $op)")
+            .policy("allow if resource($file), operation($op), right($file, $op)")
             .unwrap()
-            .add_deny_all()
+            .deny_all()
             .build()
             .unwrap();
 
@@ -1507,7 +1507,7 @@ mod tests {
         let root = KeyPair::new_with_rng(builder::Algorithm::Ed25519, &mut rng);
 
         let biscuit1 = Biscuit::builder()
-            .add_check("check if fact($v), $v < 1")
+            .check("check if fact($v), $v < 1")
             .unwrap()
             .build_with_rng(&root, default_symbol_table(), &mut rng)
             .unwrap();
@@ -1515,7 +1515,7 @@ mod tests {
         println!("biscuit1 (authority): {}", biscuit1);
 
         let biscuit2 = Biscuit::builder()
-            .add_check("check all fact($v), $v < 1")
+            .check("check all fact($v), $v < 1")
             .unwrap()
             .build_with_rng(&root, default_symbol_table(), &mut rng)
             .unwrap();
@@ -1524,13 +1524,13 @@ mod tests {
 
         {
             let mut authorizer = AuthorizerBuilder::new()
-                .add_token(&biscuit1)
-                .add_fact("fact(0)")
+                .token(&biscuit1)
+                .fact("fact(0)")
                 .unwrap()
-                .add_fact("fact(1)")
+                .fact("fact(1)")
                 .unwrap()
                 //println!("final token: {:#?}", final_token);
-                .add_allow_all()
+                .allow_all()
                 .build()
                 .unwrap();
 
@@ -1544,13 +1544,13 @@ mod tests {
 
         {
             let mut authorizer = AuthorizerBuilder::new()
-                .add_token(&biscuit2)
-                .add_fact("fact(0)")
+                .token(&biscuit2)
+                .fact("fact(0)")
                 .unwrap()
-                .add_fact("fact(1)")
+                .fact("fact(1)")
                 .unwrap()
                 //println!("final token: {:#?}", final_token);
-                .add_allow_all()
+                .allow_all()
                 .build()
                 .unwrap();
 
@@ -1632,11 +1632,11 @@ mod tests {
         let mut rng: StdRng = SeedableRng::seed_from_u64(0);
         let root = KeyPair::new_with_rng(builder::Algorithm::Ed25519, &mut rng);
         let biscuit1 = Biscuit::builder()
-            .add_fact("right(\"file1\", \"read\")")
+            .fact("right(\"file1\", \"read\")")
             .unwrap()
-            .add_fact("right(\"file2\", \"read\")")
+            .fact("right(\"file2\", \"read\")")
             .unwrap()
-            .add_fact("right(\"file1\", \"write\")")
+            .fact("right(\"file1\", \"write\")")
             .unwrap()
             .build_with_rng(&root, default_symbol_table(), &mut rng)
             .unwrap();

--- a/biscuit-auth/src/token/third_party.rs
+++ b/biscuit-auth/src/token/third_party.rs
@@ -160,11 +160,11 @@ mod tests {
         let mut rng: rand::rngs::StdRng = rand::SeedableRng::seed_from_u64(0);
         let root = KeyPair::new_with_rng(crate::builder::Algorithm::Ed25519, &mut rng);
         let biscuit1 = crate::Biscuit::builder()
-            .add_fact("right(\"file1\", \"read\")")
+            .fact("right(\"file1\", \"read\")")
             .unwrap()
-            .add_fact("right(\"file2\", \"read\")")
+            .fact("right(\"file2\", \"read\")")
             .unwrap()
-            .add_fact("right(\"file1\", \"write\")")
+            .fact("right(\"file1\", \"write\")")
             .unwrap()
             .build_with_rng(&root, crate::token::default_symbol_table(), &mut rng)
             .unwrap();

--- a/biscuit-auth/tests/macros.rs
+++ b/biscuit-auth/tests/macros.rs
@@ -75,9 +75,11 @@ fn authorizer_macro() {
       "#
     );
 
+    let authorizer = b.build().unwrap();
     assert_eq!(
-        b.dump_code(),
+        authorizer.dump_code(),
         r#"fact("test", hex:aabbcc, [true], "my_value");
+rule("test", true);
 appended(true);
 
 rule($0, true) <- fact($0, $1, $2, "my_value");
@@ -92,7 +94,9 @@ allow if true;
 
 #[test]
 fn authorizer_macro_trailing_comma() {
-    let a = authorizer!(r#"fact("test", {my_key});"#, my_key = "my_value",);
+    let a = authorizer!(r#"fact("test", {my_key});"#, my_key = "my_value",)
+        .build()
+        .unwrap();
     assert_eq!(
         a.dump_code(),
         r#"fact("test", "my_value");

--- a/biscuit-auth/tests/macros.rs
+++ b/biscuit-auth/tests/macros.rs
@@ -68,8 +68,8 @@ fn authorizer_macro() {
     );
 
     let is_true = true;
-    authorizer_merge!(
-        &mut b,
+    b = authorizer_merge!(
+        b,
         r#"appended({is_true});
         allow if true;
       "#
@@ -123,8 +123,7 @@ fn biscuit_macro() {
         check if true trusting ed25519/6e9e6d5a75cf0c0e87ec1256b4dfed0ca3ba452912d213fcc70f8516583db9db;
         "#,
         my_key_bytes = s.into_bytes(),
-    );
-    b.set_root_key_id(2);
+    ).set_root_key_id(2);
 
     let is_true = true;
     b = biscuit_merge!(
@@ -253,7 +252,7 @@ fn json() {
     );
     let json_value: biscuit_auth::builder::Term = value.try_into().unwrap();
 
-    let mut builder = authorizer!(
+    let mut authorizer = authorizer!(
         r#"
         user_roles({json_value});
         allow if
@@ -261,10 +260,10 @@ fn json() {
           user_roles($value),
           $value.get("id") == $id,
           $value.get("roles").contains("admin");"#
-    );
-
-    builder.add_token(&biscuit);
-    let mut authorizer = builder.build().unwrap();
+    )
+    .add_token(&biscuit)
+    .build()
+    .unwrap();
     assert_eq!(
         authorizer
             .authorize_with_limits(RunLimits {

--- a/biscuit-auth/tests/macros.rs
+++ b/biscuit-auth/tests/macros.rs
@@ -249,7 +249,7 @@ fn json() {
     );
     let json_value: biscuit_auth::builder::Term = value.try_into().unwrap();
 
-    let mut authorizer = authorizer!(
+    let mut builder = authorizer!(
         r#"
         user_roles({json_value});
         allow if
@@ -259,7 +259,8 @@ fn json() {
           $value.get("roles").contains("admin");"#
     );
 
-    authorizer.add_token(&biscuit).unwrap();
+    builder.add_token(&biscuit);
+    let mut authorizer = builder.build().unwrap();
     assert_eq!(
         authorizer
             .authorize_with_limits(RunLimits {

--- a/biscuit-auth/tests/macros.rs
+++ b/biscuit-auth/tests/macros.rs
@@ -123,7 +123,7 @@ fn biscuit_macro() {
         check if true trusting ed25519/6e9e6d5a75cf0c0e87ec1256b4dfed0ca3ba452912d213fcc70f8516583db9db;
         "#,
         my_key_bytes = s.into_bytes(),
-    ).set_root_key_id(2);
+    ).root_key_id(2);
 
     let is_true = true;
     b = biscuit_merge!(
@@ -261,7 +261,7 @@ fn json() {
           $value.get("id") == $id,
           $value.get("roles").contains("admin");"#
     )
-    .add_token(&biscuit)
+    .token(&biscuit)
     .build()
     .unwrap();
     assert_eq!(

--- a/biscuit-auth/tests/macros.rs
+++ b/biscuit-auth/tests/macros.rs
@@ -78,9 +78,9 @@ fn authorizer_macro() {
     let authorizer = b.build().unwrap();
     assert_eq!(
         authorizer.dump_code(),
-        r#"fact("test", hex:aabbcc, [true], "my_value");
+        r#"appended(true);
+fact("test", hex:aabbcc, [true], "my_value");
 rule("test", true);
-appended(true);
 
 rule($0, true) <- fact($0, $1, $2, "my_value");
 

--- a/biscuit-auth/tests/macros.rs
+++ b/biscuit-auth/tests/macros.rs
@@ -75,7 +75,7 @@ fn authorizer_macro() {
       "#
     );
 
-    let authorizer = b.build().unwrap();
+    let authorizer = b.build_unauthenticated().unwrap();
     assert_eq!(
         authorizer.dump_code(),
         r#"appended(true);
@@ -95,7 +95,7 @@ allow if true;
 #[test]
 fn authorizer_macro_trailing_comma() {
     let a = authorizer!(r#"fact("test", {my_key});"#, my_key = "my_value",)
-        .build()
+        .build_unauthenticated()
         .unwrap();
     assert_eq!(
         a.dump_code(),
@@ -261,8 +261,7 @@ fn json() {
           $value.get("id") == $id,
           $value.get("roles").contains("admin");"#
     )
-    .token(&biscuit)
-    .build()
+    .build(&biscuit)
     .unwrap();
     assert_eq!(
         authorizer

--- a/biscuit-auth/tests/rights.rs
+++ b/biscuit-auth/tests/rights.rs
@@ -12,17 +12,17 @@ fn main() {
     let root = KeyPair::new_with_rng(builder::Algorithm::Ed25519, &mut rng);
 
     let biscuit1 = Biscuit::builder()
-        .add_fact(fact(
+        .fact(fact(
             "right",
             &[string("authority"), string("file1"), string("read")],
         ))
         .unwrap()
-        .add_fact(fact(
+        .fact(fact(
             "right",
             &[string("authority"), string("file2"), string("read")],
         ))
         .unwrap()
-        .add_fact(fact(
+        .fact(fact(
             "right",
             &[string("authority"), string("file1"), string("write")],
         ))
@@ -32,8 +32,8 @@ fn main() {
     println!("{}", biscuit1);
 
     let mut v = AuthorizerBuilder::new()
-        .add_token(&biscuit1)
-        .add_check(rule(
+        .token(&biscuit1)
+        .check(rule(
             "right",
             &[string("right")],
             &[pred(

--- a/biscuit-auth/tests/rights.rs
+++ b/biscuit-auth/tests/rights.rs
@@ -32,7 +32,6 @@ fn main() {
     println!("{}", biscuit1);
 
     let mut v = AuthorizerBuilder::new()
-        .token(&biscuit1)
         .check(rule(
             "right",
             &[string("right")],
@@ -42,7 +41,7 @@ fn main() {
             )],
         ))
         .unwrap()
-        .build()
+        .build(&biscuit1)
         .unwrap();
     //v.add_resource("file2");
     //v.add_operation("read");

--- a/biscuit-auth/tests/rights.rs
+++ b/biscuit-auth/tests/rights.rs
@@ -31,17 +31,19 @@ fn main() {
         .unwrap();
     println!("{}", biscuit1);
 
-    let mut builder = AuthorizerBuilder::new();
-    builder.add_token(&biscuit1);
-    builder.add_check(rule(
-        "right",
-        &[string("right")],
-        &[pred(
+    let mut v = AuthorizerBuilder::new()
+        .add_token(&biscuit1)
+        .add_check(rule(
             "right",
-            &[string("authority"), string("file2"), string("write")],
-        )],
-    ));
-    let mut v = builder.build().expect("omg verifier");
+            &[string("right")],
+            &[pred(
+                "right",
+                &[string("authority"), string("file2"), string("write")],
+            )],
+        ))
+        .unwrap()
+        .build()
+        .unwrap();
     //v.add_resource("file2");
     //v.add_operation("read");
     //v.add_operation("write");

--- a/biscuit-auth/tests/rights.rs
+++ b/biscuit-auth/tests/rights.rs
@@ -31,12 +31,9 @@ fn main() {
         .unwrap();
     println!("{}", biscuit1);
 
-    let mut v = biscuit1.authorizer().expect("omg verifier");
-    //v.add_resource("file2");
-    //v.add_operation("read");
-    //v.add_operation("write");
-
-    v.add_check(rule(
+    let mut builder = AuthorizerBuilder::new();
+    builder.add_token(&biscuit1);
+    builder.add_check(rule(
         "right",
         &[string("right")],
         &[pred(
@@ -44,6 +41,10 @@ fn main() {
             &[string("authority"), string("file2"), string("write")],
         )],
     ));
+    let mut v = builder.build().expect("omg verifier");
+    //v.add_resource("file2");
+    //v.add_operation("read");
+    //v.add_operation("write");
 
     let res = v.authorize();
     println!("{:#?}", res);

--- a/biscuit-capi/src/lib.rs
+++ b/biscuit-capi/src/lib.rs
@@ -581,7 +581,9 @@ pub unsafe extern "C" fn biscuit_builder_add_check(
         })
         .is_ok()
 }
-
+/// Build a biscuit token from a builder
+///
+/// The builder will be freed automatically when the biscuit is returned
 #[no_mangle]
 pub unsafe extern "C" fn biscuit_builder_build(
     builder: Option<&BiscuitBuilder>,
@@ -1120,9 +1122,12 @@ pub unsafe extern "C" fn authorizer_builder_add_policy(
         .is_ok()
 }
 
+/// Build an authorizer
+///
+/// The builder will be freed automatically when the authorizer is returned
 #[no_mangle]
 pub unsafe extern "C" fn authorizer_builder_build(
-    builder: Option<AuthorizerBuilder>,
+    builder: Option<Box<AuthorizerBuilder>>,
 ) -> Option<Box<Authorizer>> {
     if builder.is_none() {
         update_last_error(Error::InvalidArgument);

--- a/biscuit-capi/src/lib.rs
+++ b/biscuit-capi/src/lib.rs
@@ -426,33 +426,33 @@ pub unsafe extern "C" fn public_key_free(_kp: Option<Box<PublicKey>>) {}
 impl BiscuitBuilder {
     fn set_context(&mut self, context: &str) {
         let mut inner = self.0.take().unwrap();
-        inner = inner.set_context(context.to_string());
+        inner = inner.context(context.to_string());
         self.0 = Some(inner);
     }
 
     fn set_root_key_id(&mut self, root_key_id: u32) {
         let mut inner = self.0.take().unwrap();
-        inner = inner.set_root_key_id(root_key_id);
+        inner = inner.root_key_id(root_key_id);
         self.0 = Some(inner);
     }
 
     fn add_fact(&mut self, fact: &str) -> Result<(), biscuit_auth::error::Token> {
         let mut inner = self.0.take().unwrap();
-        inner = inner.add_fact(fact)?;
+        inner = inner.fact(fact)?;
         self.0 = Some(inner);
         Ok(())
     }
 
     fn add_rule(&mut self, rule: &str) -> Result<(), biscuit_auth::error::Token> {
         let mut inner = self.0.take().unwrap();
-        inner = inner.add_rule(rule)?;
+        inner = inner.rule(rule)?;
         self.0 = Some(inner);
         Ok(())
     }
 
     fn add_check(&mut self, check: &str) -> Result<(), biscuit_auth::error::Token> {
         let mut inner = self.0.take().unwrap();
-        inner = inner.add_check(check)?;
+        inner = inner.check(check)?;
         self.0 = Some(inner);
         Ok(())
     }
@@ -802,27 +802,27 @@ pub unsafe extern "C" fn biscuit_block_context(
 impl BlockBuilder {
     fn set_context(&mut self, context: &str) {
         let mut inner = self.0.take().unwrap();
-        inner = inner.set_context(context.to_string());
+        inner = inner.context(context.to_string());
         self.0 = Some(inner);
     }
 
     fn add_fact(&mut self, fact: &str) -> Result<(), biscuit_auth::error::Token> {
         let mut inner = self.0.take().unwrap();
-        inner = inner.add_fact(fact)?;
+        inner = inner.fact(fact)?;
         self.0 = Some(inner);
         Ok(())
     }
 
     fn add_rule(&mut self, rule: &str) -> Result<(), biscuit_auth::error::Token> {
         let mut inner = self.0.take().unwrap();
-        inner = inner.add_rule(rule)?;
+        inner = inner.rule(rule)?;
         self.0 = Some(inner);
         Ok(())
     }
 
     fn add_check(&mut self, check: &str) -> Result<(), biscuit_auth::error::Token> {
         let mut inner = self.0.take().unwrap();
-        inner = inner.add_check(check)?;
+        inner = inner.check(check)?;
         self.0 = Some(inner);
         Ok(())
     }
@@ -992,28 +992,28 @@ pub unsafe extern "C" fn block_builder_free(_builder: Option<Box<BlockBuilder>>)
 impl<'a> AuthorizerBuilder<'a> {
     fn add_fact(&mut self, fact: &str) -> Result<(), biscuit_auth::error::Token> {
         let mut inner = self.0.take().unwrap();
-        inner = inner.add_fact(fact)?;
+        inner = inner.fact(fact)?;
         self.0 = Some(inner);
         Ok(())
     }
 
     fn add_rule(&mut self, rule: &str) -> Result<(), biscuit_auth::error::Token> {
         let mut inner = self.0.take().unwrap();
-        inner = inner.add_rule(rule)?;
+        inner = inner.rule(rule)?;
         self.0 = Some(inner);
         Ok(())
     }
 
     fn add_check(&mut self, check: &str) -> Result<(), biscuit_auth::error::Token> {
         let mut inner = self.0.take().unwrap();
-        inner = inner.add_check(check)?;
+        inner = inner.check(check)?;
         self.0 = Some(inner);
         Ok(())
     }
 
     fn add_policy(&mut self, policy: &str) -> Result<(), biscuit_auth::error::Token> {
         let mut inner = self.0.take().unwrap();
-        inner = inner.add_policy(policy)?;
+        inner = inner.policy(policy)?;
         self.0 = Some(inner);
         Ok(())
     }

--- a/biscuit-capi/tests/capi.rs
+++ b/biscuit-capi/tests/capi.rs
@@ -39,13 +39,17 @@ mod capi {
                 Biscuit* b2 = biscuit_append_block(biscuit, bb, kp2);
                 printf("biscuit append error? %s\n", error_message());
 
-                Authorizer * authorizer = biscuit_authorizer(b2);
-                printf("authorizer creation error? %s\n", error_message());
-                authorizer_add_check(authorizer, "check if right(\"efgh\")");
+                AuthorizerBuilder * ab = authorizer_builder();
+                printf("authorizer builder creation error? %s\n", error_message());
+
+                authorizer_builder_add_check(authorizer, "check if right(\"efgh\")");
                 printf("authorizer add check error? %s\n", error_message());
 
-                authorizer_add_policy(authorizer, "allow if true");
+                authorizer_builder_add_policy(authorizer, "allow if true");
                 printf("authorizer add policy error? %s\n", error_message());
+
+                Authorizer * authorizer = authorizer_builder_build(b2);
+                printf("authorizer creation error? %s\n", error_message());
 
                 if(!authorizer_authorize(authorizer)) {
                     printf("authorizer error(code = %d): %s\n", error_kind(), error_message());

--- a/biscuit-capi/tests/capi.rs
+++ b/biscuit-capi/tests/capi.rs
@@ -42,13 +42,13 @@ mod capi {
                 AuthorizerBuilder * ab = authorizer_builder();
                 printf("authorizer builder creation error? %s\n", error_message());
 
-                authorizer_builder_add_check(authorizer, "check if right(\"efgh\")");
-                printf("authorizer add check error? %s\n", error_message());
+                authorizer_builder_add_check(ab, "check if right(\"efgh\")");
+                printf("authorizer builder add check error? %s\n", error_message());
 
-                authorizer_builder_add_policy(authorizer, "allow if true");
-                printf("authorizer add policy error? %s\n", error_message());
+                authorizer_builder_add_policy(ab, "allow if true");
+                printf("authorizer builder add policy error? %s\n", error_message());
 
-                Authorizer * authorizer = authorizer_builder_build(b2);
+                Authorizer * authorizer = authorizer_builder_build(ab, b2);
                 printf("authorizer creation error? %s\n", error_message());
 
                 if(!authorizer_authorize(authorizer)) {
@@ -115,9 +115,10 @@ builder add authority error? (null)
 biscuit creation error? (null)
 builder add check error? (null)
 biscuit append error? (null)
+authorizer builder creation error? (null)
+authorizer builder add check error? (null)
+authorizer builder add policy error? (null)
 authorizer creation error? (null)
-authorizer add check error? (null)
-authorizer add policy error? (null)
 authorizer error(code = 21): authorization failed: an allow policy matched (policy index: 0), and the following checks failed: Check n°0 in authorizer: check if right("efgh"), Check n°0 in block n°1: check if operation("read")
 failed checks (2):
   Authorizer check 0: check if right("efgh")

--- a/biscuit-quote/src/lib.rs
+++ b/biscuit-quote/src/lib.rs
@@ -129,7 +129,7 @@ pub fn authorizer(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
         parameters,
     } = syn::parse_macro_input!(input as ParsedCreateNew);
 
-    let ty = syn::parse_quote!(::biscuit_auth::Authorizer);
+    let ty = syn::parse_quote!(::biscuit_auth::builder::AuthorizerBuilder);
     let builder = Builder::source(ty, None, datalog, parameters)
         .unwrap_or_else(|e| abort_call_site!(e.to_string()));
 
@@ -148,7 +148,7 @@ pub fn authorizer_merge(input: proc_macro::TokenStream) -> proc_macro::TokenStre
         parameters,
     } = syn::parse_macro_input!(input as ParsedMerge);
 
-    let ty = syn::parse_quote!(::biscuit_auth::Authorizer);
+    let ty = syn::parse_quote!(::biscuit_auth::builder::AuthorizerBuilder);
     let builder = Builder::source(ty, Some(target), datalog, parameters)
         .unwrap_or_else(|e| abort_call_site!(e.to_string()));
 

--- a/biscuit-quote/src/lib.rs
+++ b/biscuit-quote/src/lib.rs
@@ -349,7 +349,7 @@ impl Item {
             },
             middle: TokenStream::new(),
             end: quote! {
-                __biscuit_auth_builder = __biscuit_auth_builder.add_fact(__biscuit_auth_item).unwrap();
+                __biscuit_auth_builder = __biscuit_auth_builder.fact(__biscuit_auth_item).unwrap();
             },
         }
     }
@@ -361,7 +361,7 @@ impl Item {
             },
             middle: TokenStream::new(),
             end: quote! {
-                __biscuit_auth_builder = __biscuit_auth_builder.add_rule(__biscuit_auth_item).unwrap();
+                __biscuit_auth_builder = __biscuit_auth_builder.rule(__biscuit_auth_item).unwrap();
             },
         }
     }
@@ -374,7 +374,7 @@ impl Item {
             },
             middle: TokenStream::new(),
             end: quote! {
-                __biscuit_auth_builder =__biscuit_auth_builder.add_check(__biscuit_auth_item).unwrap();
+                __biscuit_auth_builder =__biscuit_auth_builder.check(__biscuit_auth_item).unwrap();
             },
         }
     }
@@ -387,7 +387,7 @@ impl Item {
             },
             middle: TokenStream::new(),
             end: quote! {
-                __biscuit_auth_builder = __biscuit_auth_builder.add_policy(__biscuit_auth_item).unwrap();
+                __biscuit_auth_builder = __biscuit_auth_builder.policy(__biscuit_auth_item).unwrap();
             },
         }
     }


### PR DESCRIPTION
Fix https://github.com/biscuit-auth/biscuit-rust/issues/194, https://github.com/biscuit-auth/biscuit-rust/issues/193, https://github.com/biscuit-auth/biscuit-rust/issues/192

This adds an `AuthorizerBuilder` struct that is used to create an `Authorizer`. All of the mutable behaviour, like adding facts or executing Datalog rules is moved into the builder, while the authorizer is limited to read-only queries (still requiring self mutability to track execution time). The `AuthorizerBuilder` is compatible with snapshots, to store and reuse checks and policies. It has a `build` method taking a token as argument, and a `build_unauthenticated` for authorization without token.

The builder APIs are alo changing. Before, we had the following:

```rust
 let mut builder = Biscuit::builder();	
builder.add_fact(r"right("file1", "read")"#)?;
builder.add_fact(r"right("file2", "read")"#)?;
let token = builder.build()?;
```

Builders are now constructed like this:

```rust
let token = Biscuit::builder()
    .fact(r"right("file1", "read")"#)?
    .fact(r"right("file2", "read")"#)?
    .build()?;
````