### PR TITLE
API improvements

### DIFF
--- a/biscuit-auth/src/bwk.rs
+++ b/biscuit-auth/src/bwk.rs
@@ -62,7 +62,7 @@ mod tests {
 
     #[test]
     fn roundtrips() {
-        let keypair = KeyPair::new(Algorithm::Ed25519);
+        let keypair = KeyPair::new();
         let bwk = BiscuitWebKey {
             public_key: keypair.public(),
             key_id: 12,
@@ -74,7 +74,7 @@ mod tests {
         let parsed: BiscuitWebKey = serde_json::from_str(&serialized).unwrap();
         assert_eq!(parsed, bwk);
 
-        let keypair = KeyPair::new(Algorithm::Secp256r1);
+        let keypair = KeyPair::new_with_algorithm(Algorithm::Secp256r1);
         let bwk = BiscuitWebKey {
             public_key: keypair.public(),
             key_id: 0,
@@ -86,7 +86,7 @@ mod tests {
         let parsed: BiscuitWebKey = serde_json::from_str(&serialized).unwrap();
         assert_eq!(parsed, bwk);
 
-        let keypair = KeyPair::new(Algorithm::Ed25519);
+        let keypair = KeyPair::new();
         let bwk = BiscuitWebKey {
             public_key: keypair.public(),
             key_id: 0,

--- a/biscuit-auth/src/crypto/mod.rs
+++ b/biscuit-auth/src/crypto/mod.rs
@@ -29,7 +29,13 @@ pub enum KeyPair {
 }
 
 impl KeyPair {
-    pub fn new(algorithm: Algorithm) -> Self {
+    /// Create a new ed25519 keypair with the default OS RNG
+    pub fn new() -> Self {
+        Self::new_with_rng(Algorithm::Ed25519, &mut rand::rngs::OsRng)
+    }
+
+    /// Create a new keypair with a chosen algorithm and the default OS RNG
+    pub fn new_with_algorithm(algorithm: Algorithm) -> Self {
         Self::new_with_rng(algorithm, &mut rand::rngs::OsRng)
     }
 
@@ -107,7 +113,7 @@ impl KeyPair {
 
 impl std::default::Default for KeyPair {
     fn default() -> Self {
-        Self::new(Algorithm::Ed25519)
+        Self::new()
     }
 }
 

--- a/biscuit-auth/src/format/mod.rs
+++ b/biscuit-auth/src/format/mod.rs
@@ -618,8 +618,8 @@ mod tests {
     fn test_block_signature_version() {
         assert_eq!(
             block_signature_version(
-                &KeyPair::new(Algorithm::Ed25519),
-                &KeyPair::new(Algorithm::Ed25519),
+                &KeyPair::new(),
+                &KeyPair::new(),
                 &None,
                 &Some(DATALOG_3_1),
                 std::iter::empty()
@@ -629,8 +629,8 @@ mod tests {
         );
         assert_eq!(
             block_signature_version(
-                &KeyPair::new(Algorithm::Secp256r1),
-                &KeyPair::new(Algorithm::Ed25519),
+                &KeyPair::new_with_algorithm(Algorithm::Secp256r1),
+                &KeyPair::new_with_algorithm(Algorithm::Ed25519),
                 &None,
                 &Some(DATALOG_3_1),
                 std::iter::empty()
@@ -640,8 +640,8 @@ mod tests {
         );
         assert_eq!(
             block_signature_version(
-                &KeyPair::new(Algorithm::Ed25519),
-                &KeyPair::new(Algorithm::Secp256r1),
+                &KeyPair::new_with_algorithm(Algorithm::Ed25519),
+                &KeyPair::new_with_algorithm(Algorithm::Secp256r1),
                 &None,
                 &Some(DATALOG_3_1),
                 std::iter::empty()
@@ -651,8 +651,8 @@ mod tests {
         );
         assert_eq!(
             block_signature_version(
-                &KeyPair::new(Algorithm::Secp256r1),
-                &KeyPair::new(Algorithm::Secp256r1),
+                &KeyPair::new_with_algorithm(Algorithm::Secp256r1),
+                &KeyPair::new_with_algorithm(Algorithm::Secp256r1),
                 &None,
                 &Some(DATALOG_3_1),
                 std::iter::empty()
@@ -662,10 +662,10 @@ mod tests {
         );
         assert_eq!(
             block_signature_version(
-                &KeyPair::new(Algorithm::Ed25519),
-                &KeyPair::new(Algorithm::Ed25519),
+                &KeyPair::new(),
+                &KeyPair::new(),
                 &Some(ExternalSignature {
-                    public_key: KeyPair::new(Algorithm::Ed25519).public(),
+                    public_key: KeyPair::new().public(),
                     signature: Signature::from_vec(Vec::new())
                 }),
                 &Some(DATALOG_3_1),
@@ -676,8 +676,8 @@ mod tests {
         );
         assert_eq!(
             block_signature_version(
-                &KeyPair::new(Algorithm::Ed25519),
-                &KeyPair::new(Algorithm::Ed25519),
+                &KeyPair::new(),
+                &KeyPair::new(),
                 &None,
                 &Some(DATALOG_3_3),
                 std::iter::empty()
@@ -687,8 +687,8 @@ mod tests {
         );
         assert_eq!(
             block_signature_version(
-                &KeyPair::new(Algorithm::Ed25519),
-                &KeyPair::new(Algorithm::Ed25519),
+                &KeyPair::new(),
+                &KeyPair::new(),
                 &None,
                 &Some(DATALOG_3_1),
                 std::iter::once(1)

--- a/biscuit-auth/src/lib.rs
+++ b/biscuit-auth/src/lib.rs
@@ -32,7 +32,7 @@
 //! fn main() -> Result<(), error::Token> {
 //!   // let's generate the root key pair. The root public key will be necessary
 //!   // to verify the token
-//!   let root = KeyPair::new(Algorithm::Ed25519);
+//!   let root = KeyPair::new();
 //!   let public_key = root.public();
 //!
 //!   // creating a first token

--- a/biscuit-auth/src/lib.rs
+++ b/biscuit-auth/src/lib.rs
@@ -232,6 +232,7 @@ mod token;
 pub use crypto::{KeyPair, PrivateKey, PublicKey};
 pub use token::authorizer::{Authorizer, AuthorizerLimits};
 pub use token::builder;
+pub use token::builder::{Algorithm, AuthorizerBuilder, BiscuitBuilder, BlockBuilder};
 pub use token::builder_ext;
 pub use token::unverified::UnverifiedBiscuit;
 pub use token::Biscuit;

--- a/biscuit-auth/src/macros.rs
+++ b/biscuit-auth/src/macros.rs
@@ -2,11 +2,10 @@
 //!
 //! ```rust
 //! use biscuit_auth::KeyPair;
-//! use biscuit_auth::builder::Algorithm;
 //! use biscuit_auth::macros::{authorizer, biscuit, block};
 //! use std::time::{Duration, SystemTime};
 //!
-//! let root = KeyPair::new(Algorithm::Ed25519);
+//! let root = KeyPair::new();
 //!
 //! let user_id = "1234";
 //! let biscuit = biscuit!(
@@ -97,11 +96,10 @@ pub use biscuit_quote::authorizer_merge;
 ///
 /// ```rust
 /// use biscuit_auth::{Biscuit, KeyPair};
-/// use biscuit_auth::builder::Algorithm;
 /// use biscuit_auth::macros::biscuit;
 /// use std::time::{SystemTime, Duration};
 ///
-/// let root = KeyPair::new(Algorithm::Ed25519);
+/// let root = KeyPair::new();
 /// let biscuit = biscuit!(
 ///   r#"
 ///     user({user_id});
@@ -119,11 +117,10 @@ pub use biscuit_quote::biscuit;
 ///
 /// ```rust
 /// use biscuit_auth::{Biscuit, KeyPair};
-/// use biscuit_auth::builder::Algorithm;
 /// use biscuit_auth::macros::{biscuit, biscuit_merge};
 /// use std::time::{SystemTime, Duration};
 ///
-/// let root = KeyPair::new(Algorithm::Ed25519);
+/// let root = KeyPair::new();
 ///
 /// let mut b = biscuit!(
 ///   r#"

--- a/biscuit-auth/src/token/authorizer.rs
+++ b/biscuit-auth/src/token/authorizer.rs
@@ -108,8 +108,7 @@ impl Authorizer {
     /// ```rust
     /// # use biscuit_auth::KeyPair;
     /// # use biscuit_auth::Biscuit;
-    /// # use biscuit_auth::builder::Algorithm;
-    /// let keypair = KeyPair::new(Algorithm::Ed25519);
+    /// let keypair = KeyPair::new();
     /// let biscuit = Biscuit::builder()
     ///     .fact("user(\"John Doe\", 42)")
     ///     .expect("parse error")
@@ -199,8 +198,7 @@ impl Authorizer {
     /// ```rust
     /// # use biscuit_auth::KeyPair;
     /// # use biscuit_auth::Biscuit;
-    /// # use biscuit_auth::builder::Algorithm;
-    /// let keypair = KeyPair::new(Algorithm::Ed25519,);
+    /// let keypair = KeyPair::new();
     /// let biscuit = Biscuit::builder()
     ///     .fact("user(\"John Doe\", 42)")
     ///     .expect("parse error")
@@ -861,7 +859,7 @@ mod tests {
 
     use crate::PublicKey;
     use crate::{
-        builder::{Algorithm, BiscuitBuilder, BlockBuilder},
+        builder::{BiscuitBuilder, BlockBuilder},
         KeyPair,
     };
 
@@ -995,7 +993,7 @@ mod tests {
     fn query_authorizer_from_token_tuple() {
         use crate::Biscuit;
         use crate::KeyPair;
-        let keypair = KeyPair::new(Algorithm::Ed25519);
+        let keypair = KeyPair::new();
         let biscuit = Biscuit::builder()
             .fact("user(\"John Doe\", 42)")
             .unwrap()
@@ -1016,7 +1014,7 @@ mod tests {
     fn query_authorizer_from_token_string() {
         use crate::Biscuit;
         use crate::KeyPair;
-        let keypair = KeyPair::new(Algorithm::Ed25519);
+        let keypair = KeyPair::new();
         let biscuit = Biscuit::builder()
             .fact("user(\"John Doe\")")
             .unwrap()
@@ -1032,8 +1030,8 @@ mod tests {
 
     #[test]
     fn authorizer_with_scopes() {
-        let root = KeyPair::new(Algorithm::Ed25519);
-        let external = KeyPair::new(Algorithm::Ed25519);
+        let root = KeyPair::new();
+        let external = KeyPair::new();
 
         let mut scope_params = HashMap::new();
         scope_params.insert("external_pub".to_string(), external.public());
@@ -1065,7 +1063,7 @@ mod tests {
         let biscuit2 = Biscuit::from(serialized, root.public()).unwrap();
 
         let builder = AuthorizerBuilder::new();
-        let external2 = KeyPair::new(Algorithm::Ed25519);
+        let external2 = KeyPair::new();
 
         let mut scope_params = HashMap::new();
         scope_params.insert("external".to_string(), external.public());
@@ -1213,7 +1211,7 @@ mod tests {
 
     #[test]
     fn authorizer_display_before_and_after_authorization() {
-        let root = KeyPair::new(Algorithm::Ed25519);
+        let root = KeyPair::new();
 
         let token = BiscuitBuilder::new()
             .code(

--- a/biscuit-auth/src/token/mod.rs
+++ b/biscuit-auth/src/token/mod.rs
@@ -55,7 +55,7 @@ pub fn default_symbol_table() -> SymbolTable {
 /// use biscuit::{KeyPair, Biscuit, builder::*, builder_ext::*};
 ///
 /// fn main() -> Result<(), biscuit::error::Token> {
-///   let root = KeyPair::new(Algorithm::Ed25519);
+///   let root = KeyPair::new();
 ///
 ///   // first we define the authority block for global data,
 ///   // like access rights

--- a/biscuit-auth/tests/macros.rs
+++ b/biscuit-auth/tests/macros.rs
@@ -251,7 +251,7 @@ fn policy_macro() {
 
 #[test]
 fn json() {
-    let key_pair = KeyPair::new(biscuit_auth::builder::Algorithm::Ed25519);
+    let key_pair = KeyPair::new();
     let biscuit = biscuit!(r#"user(123)"#).build(&key_pair).unwrap();
 
     let value: serde_json::Value = json!(


### PR DESCRIPTION
- top-level exports for Algorithm, *Builder
- restore `KeyPair::new()`, introduce `KeyPair::new_with_algorithm()`

see commit messages for the rationale