### PR TITLE
Authorizer API improvements

### DIFF
--- a/biscuit-auth/src/token/authorizer.rs
+++ b/biscuit-auth/src/token/authorizer.rs
@@ -21,7 +21,7 @@ mod snapshot;
 /// used to check authorization policies on a token
 ///
 /// can be created from [Biscuit::authorizer] or [Authorizer::new]
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Authorizer {
     pub(crate) authorizer_block_builder: BlockBuilder,
     pub(crate) world: datalog::World,

--- a/biscuit-auth/src/token/authorizer/snapshot.rs
+++ b/biscuit-auth/src/token/authorizer/snapshot.rs
@@ -69,7 +69,8 @@ impl super::Authorizer {
         authorizer.authorizer_block_builder = authorizer_block_builder;
         authorizer.policies = policies;
         authorizer.limits = limits;
-        authorizer.execution_time = execution_time;
+        authorizer.execution_time =
+            Some(execution_time).filter(|_| execution_time > Duration::default());
 
         let mut public_key_to_block_id: HashMap<usize, Vec<usize>> = HashMap::new();
         let mut blocks = Vec::new();
@@ -207,7 +208,7 @@ impl super::Authorizer {
 
         Ok(schema::AuthorizerSnapshot {
             world,
-            execution_time: self.execution_time.as_nanos() as u64,
+            execution_time: self.execution_time.unwrap_or_default().as_nanos() as u64,
             limits: schema::RunLimits {
                 max_facts: self.limits.max_facts,
                 max_iterations: self.limits.max_iterations,

--- a/biscuit-auth/src/token/builder/authorizer.rs
+++ b/biscuit-auth/src/token/builder/authorizer.rs
@@ -2,7 +2,7 @@ use std::{
     collections::HashMap,
     convert::TryInto,
     fmt::Write,
-    time::{Duration, Instant, SystemTime},
+    time::{Duration, SystemTime},
 };
 
 use biscuit_parser::parser::parse_source;
@@ -384,9 +384,11 @@ impl AuthorizerBuilder {
             world.rules.insert(usize::MAX, &rule_trusted_origins, rule);
         }
 
+        /*
         let start = Instant::now();
         world.run_with_limits(&symbols, self.limits.clone())?;
         let execution_time = start.elapsed();
+        */
 
         Ok(Authorizer {
             authorizer_block_builder: self.authorizer_block_builder,
@@ -397,7 +399,7 @@ impl AuthorizerBuilder {
             blocks,
             public_key_to_block_id,
             limits: self.limits,
-            execution_time,
+            execution_time: None,
         })
     }
 }

--- a/biscuit-auth/tests/macros.rs
+++ b/biscuit-auth/tests/macros.rs
@@ -75,13 +75,14 @@ fn authorizer_macro() {
       "#
     );
 
-    let authorizer = b
+    let mut authorizer = b
         .limits(RunLimits {
             max_time: Duration::from_secs(10),
             ..Default::default()
         })
         .build_unauthenticated()
         .unwrap();
+    authorizer.run().unwrap();
     assert_eq!(
         authorizer.dump_code(),
         r#"appended(true);


### PR DESCRIPTION
Based on tests with a private project:

- `impl Debug for Authorizer`
- allow constructing an `Authorizer` even if datalog evaluation fails

the second part is the biggest change, it makes running evaluation actually lazy (authorize and query functions ensure that evaluation is run). This allows constructing an Authorizer even if datalog evaluation fails. This is especially useful to take snapshots of failed datalog evaluations.


## TODO

- consider keeping track of failed evaluations (eg by replacing `Option<Duration>` with `NotStarted | Success(Duration) | Failed(Duration)` ) => maybe in a next version, this would require further changes to the snapshot data structure
- have a look at snapshot roundtrips => i have found an issue with `Authorizer::from_snapshot()`, but this will require extra work, in a separate PR
