### PR TITLE
fix snapshot de-serializing

### DIFF
--- a/biscuit-auth/src/datalog/mod.rs
+++ b/biscuit-auth/src/datalog/mod.rs
@@ -733,7 +733,7 @@ impl World {
 }
 
 /// runtime limits for the Datalog engine
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RunLimits {
     /// maximum number of Datalog facts (memory usage)
     pub max_facts: u64,

--- a/biscuit-auth/src/token/builder/authorizer.rs
+++ b/biscuit-auth/src/token/builder/authorizer.rs
@@ -31,7 +31,7 @@ pub struct AuthorizerBuilder {
     authorizer_block_builder: BlockBuilder,
     policies: Vec<Policy>,
     extern_funcs: HashMap<String, ExternFunc>,
-    limits: AuthorizerLimits,
+    pub(crate) limits: AuthorizerLimits,
 }
 
 impl AuthorizerBuilder {


### PR DESCRIPTION
Facts and rules from the authorizer block were not added to the `datalog::World` when creating an authorizer from a snapshot