### PR TITLE
crypto: serialize keys with alg-prefixed hex strings

### DIFF
--- a/biscuit-auth/src/crypto/mod.rs
+++ b/biscuit-auth/src/crypto/mod.rs
@@ -314,19 +314,19 @@ impl Signature {
 }
 
 impl FromStr for PublicKey {
-    type Err = error::Token;
+    type Err = error::Format;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let (_, public_key) = biscuit_parser::parser::public_key(s)
             .finish()
-            .map_err(biscuit_parser::error::LanguageError::from)?;
-        Ok(PublicKey::from_bytes(
+            .map_err(|e| error::Format::InvalidKey(e.to_string()))?;
+        PublicKey::from_bytes(
             &public_key.key,
             match public_key.algorithm {
                 biscuit_parser::builder::Algorithm::Ed25519 => Algorithm::Ed25519,
                 biscuit_parser::builder::Algorithm::Secp256r1 => Algorithm::Secp256r1,
             },
-        )?)
+        )
     }
 }
 


### PR DESCRIPTION
add `from_bytes_string()` and `to_bytes_string()` on `PublicKey` and `PrivateKey`, which look like the datalog syntax (`ed25519/<hex bytes>`), so that the key algorithm is explicit.

This will avoid confusions at program boundaries, when the keys must be read from strings (eg in biscuit-cli or when reading keys from environment variables).

I chose to implement it only on the top level structures (ie not in `ed25519` and `p256` modules), and in new methods to avoid breaking existing code.