### PR TITLE
`UnverifiedBiscuit.external_public_keys()` now returns `PublicKey`s

### DIFF
--- a/biscuit-auth/CHANGELOG.md
+++ b/biscuit-auth/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Support for P256 signatures (#108)
 - `query_exactly_once()` (#260) (Baran Yildirim)
 - include algorithm prefix in public/private key strings (#261)
+- `UnverifiedBiscuit.external_public_keys()` now returns `PublicKey`s, not byte vecs (#263)
 
 # `5.0.0`
 

--- a/biscuit-auth/src/token/unverified.rs
+++ b/biscuit-auth/src/token/unverified.rs
@@ -216,16 +216,11 @@ impl UnverifiedBiscuit {
     /// Blocks carrying an external public key are _third-party blocks_
     /// and their contents can be trusted as coming from the holder of
     /// the corresponding private key
-    pub fn external_public_keys(&self) -> Vec<Option<Vec<u8>>> {
+    pub fn external_public_keys(&self) -> Vec<Option<PublicKey>> {
         let mut res = vec![None];
 
         for block in self.container.blocks.iter() {
-            res.push(
-                block
-                    .external_signature
-                    .as_ref()
-                    .map(|sig| sig.public_key.to_bytes().to_vec()),
-            );
+            res.push(block.external_signature.as_ref().map(|sig| sig.public_key));
         }
 
         res


### PR DESCRIPTION
Same as `Biscuit`. This was also necessary for proper support of ECDSA keys